### PR TITLE
refactor: lineweight autocorrect

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -9563,6 +9563,18 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
         <source>inch</source>
         <translation>palec</translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation>Chyba souboru></translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation>Soubor se nepodařilo otevřít pro čtení.</translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation>Nepodařilo se otevřít soubor pro zápis.</translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12427,6 +12439,12 @@ SeamlyME jako obvykle.
     <message>
         <source>Validation error file %1</source>
         <translation>Soubor chyb ověření %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation>Nelze otevřít soubor se vzorem %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -9549,6 +9549,18 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <source>inch</source>
         <translation>zoll</translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation>Dateifehler</translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation>Die Datei konnte nicht zum Lesen geöffnet werden.</translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation>Die Datei konnte nicht zum Schreiben geöffnet werden.</translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12414,6 +12426,12 @@ wie gewohnt in SeamlyME laden können.
     <message>
         <source>Validation error file %1</source>
         <translation>Validierungsfehlerdatei %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation>Musterdatei kann nicht geöffnet werden %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -9567,6 +9567,18 @@ Press enter to temporarily add it to the list.</source>
         <source>inch</source>
         <translation>ίντσα</translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation>Σφάλμα στο αρχείο</translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation>Δεν ήταν δυνατό το άνοιγμα του αρχείου για ανάγνωση.</translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation>Δεν ήταν δυνατό το άνοιγμα του αρχείου για εγγραφή.</translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12431,6 +12443,12 @@ load in SeamlyME as usual.
     <message>
         <source>Validation error file %1</source>
         <translation>Αρχείο σφάλματος επικύρωσης %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation>Δεν είναι δυνατό το άνοιγμα του αρχείου μοτίβου %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Fix formula</translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9533,6 +9533,18 @@ Press enter to temporarily add it to the list.</source>
         <source>inch</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12390,6 +12402,11 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Validation error file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9533,6 +9533,18 @@ Press enter to temporarily add it to the list.</source>
         <source>inch</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12390,6 +12402,11 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Validation error file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Fix formula</translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9533,6 +9533,18 @@ Press enter to temporarily add it to the list.</source>
         <source>inch</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12390,6 +12402,11 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Validation error file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9533,6 +9533,18 @@ Press enter to temporarily add it to the list.</source>
         <source>inch</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12390,6 +12402,11 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Validation error file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -9604,6 +9604,18 @@ actualización:</translation>
         <source>inch</source>
         <translation>pulgada</translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation>Error en archivo</translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation>No se pudo abrir el archivo para leer.</translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation>No se pudo abrir el archivo para escribir.</translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12469,6 +12481,12 @@ load in SeamlyME as usual.
     <message>
         <source>Validation error file %1</source>
         <translation>Archivo de error de validación %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation>No se puede abrir el archivo de patrón %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -9565,6 +9565,18 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
         <source>inch</source>
         <translation>tuuma</translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation>Tiedostovirhe</translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation>Tiedostoa ei voitu avata lukemista varten.</translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation>Tiedostoa ei voitu avata kirjoittamista varten.</translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12429,6 +12441,12 @@ Haluatko tallentaa muutokset?</translation>
     <message>
         <source>Validation error file %1</source>
         <translation>Vahvistusvirhe tiedostossa %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation>Kuviotiedostoa ei voi avata %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -9591,6 +9591,18 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
         <source>inch</source>
         <translation>pouce</translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation>Erreur de fichier</translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation>Impossible d'ouvrir le fichier pour le lire.</translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation>Impossible d'ouvrir le fichier pour l'écriture.</translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12457,6 +12469,12 @@ charger dans SeamlyME comme d&apos;habitude.
     <message>
         <source>Validation error file %1</source>
         <translation>Fichier d&apos;erreur de validation %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation>Impossible d'ouvrir le fichier de modèles %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9529,6 +9529,18 @@ Press enter to temporarily add it to the list.</source>
         <source>inch</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12383,6 +12395,11 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Validation error file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -9565,6 +9565,18 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
         <source>inch</source>
         <translation>inci</translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation>Kesalahan berkas</translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation>Tidak dapat membuka berkas untuk dibaca.</translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation>Tidak dapat membuka berkas untuk ditulis.</translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12429,6 +12441,12 @@ unggah ke SeamlyME seperti biasa.
     <message>
         <source>Validation error file %1</source>
         <translation>File kesalahan validasi %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation>Tidak dapat membuka file pola %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -3070,7 +3070,7 @@ p, li { white-space: pre-wrap; }
         <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation>Seamly2D ha riscontrato un errore durante il calcolo di una formula.
-Prova ad annullare l'ultima operazione o a correggere la formula non funzionante.</translation>
+Prova ad annullare l&apos;ultima operazione o a correggere la formula non funzionante.</translation>
     </message>
 </context>
 <context>
@@ -9553,6 +9553,18 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
         <source>inch</source>
         <translation>pollice</translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation>Errore nel file</translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation>Impossibile aprire il file per la lettura.</translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation>Impossibile aprire il file per la scrittura.</translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12417,6 +12429,12 @@ caricare in SeamlyME come di consueto.
     <message>
         <source>Validation error file %1</source>
         <translation>Errore di convalida file %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation>Impossibile aprire il file pattern %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -9548,6 +9548,18 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
         <source>inch</source>
         <translation>inch</translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation>Bestandsfout</translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation>Het bestand kon niet worden geopend om te lezen.</translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation>Het bestand kon niet worden geopend om te schrijven.</translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12411,6 +12423,12 @@ load in SeamlyME as usual.
     <message>
         <source>Validation error file %1</source>
         <translation>Validatiefoutbestand %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation>Kan patroonbestand niet openen %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -9551,6 +9551,18 @@ Prima enter para o adicionar temporariamente à lista.</translation>
         <source>inch</source>
         <translation>polegada</translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation>Erro de arquivo</translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation>Não foi possível abrir o arquivo para leitura.</translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation>Não foi possível abrir o arquivo para gravação.</translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12415,6 +12427,12 @@ carregar no SeamlyME como de costume.
     <message>
         <source>Validation error file %1</source>
         <translation>Arquivo de erro de validação %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation>Não é possível abrir o arquivo de padrão %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -9567,6 +9567,18 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
         <source>inch</source>
         <translation>inch</translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation>Eroare de fișier</translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation>Nu s-a putut deschide fișierul pentru citire.</translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation>Nu s-a putut deschide fișierul pentru scriere.</translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12430,6 +12442,12 @@ load in SeamlyME as usual.
     <message>
         <source>Validation error file %1</source>
         <translation>Fișier de eroare de validare %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation>Nu se poate deschide fișierul cu modelul %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -9572,6 +9572,18 @@ Press enter to temporarily add it to the list.</source>
         <source>inch</source>
         <translation>дюйм</translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation>Ошибка файла</translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation>Не удалось открыть файл для чтения.</translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation>Не удалось открыть файл для записи.</translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12436,6 +12448,12 @@ load in SeamlyME as usual.
     <message>
         <source>Validation error file %1</source>
         <translation>Файл ошибки проверки %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation>Невозможно открыть файл шаблона %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -9565,6 +9565,18 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
         <source>inch</source>
         <translation>inç</translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation>Dosya hatası</translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation>Dosya okunmak üzere açılamadı.</translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation>Yazma işlemi için dosya açılamadı.</translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12428,6 +12440,12 @@ load in SeamlyME as usual.
     <message>
         <source>Validation error file %1</source>
         <translation>Doğrulama hatası dosyası %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation>Desen dosyası açılamıyor %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -9566,6 +9566,18 @@ Press enter to temporarily add it to the list.</source>
         <source>inch</source>
         <translation>дюйм</translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation>Помилка файла</translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation>Не вдалося відкрити файл для запису.</translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation>Не вдалося відкрити файл для читання.</translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12429,6 +12441,12 @@ load in SeamlyME as usual.
     <message>
         <source>Validation error file %1</source>
         <translation>Файл помилки перевірки %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation>Не вдається відкрити файл візерунка %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9529,6 +9529,18 @@ Press enter to temporarily add it to the list.</source>
         <source>inch</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>File Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open file for reading.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not open file for writing.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -12383,6 +12395,11 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Validation error file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -115,6 +115,7 @@
 #include <QFontComboBox>
 #include <QtCore5Compat/QTextCodec>
 #include <QDoubleSpinBox>
+#include <QFileDevice>
 #include <QFileDialog>
 #include <QFileSystemWatcher>
 #include <QFontComboBox>
@@ -152,7 +153,6 @@ const QString autosavePostfix = QStringLiteral(".autosave");
 // Strings for dynamically translating "Ctrl" in the status bar tool tips
 const QString strQShortcut = QStringLiteral("QShortcut");
 const QString strCtrl      = QStringLiteral("Ctrl");
-
 
 /// @brief Seamly2D MainWindow constructor.
 ///
@@ -5255,6 +5255,64 @@ void MainWindow::setCurrentFile(const QString &fileName)
     UpdateWindowTitle();
 }
 
+/// @brief replaceInFile Search and replace pattern file.
+///
+/// This method Replaces every occurrence of searchString with replaceString in the pattern file.
+///
+/// @param filename File path of xml pattern file.
+/// @param searchString Search string.
+/// @param replaceString Replacement String.
+void MainWindow::replaceInFile(const QString &filename, const QString &searchString, const QString &replaceString)
+{
+    QFile file(filename);
+
+    // Open the file in read-only mode. If in GUI mode post messagebox if file fails to open. 
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+    {
+        if (guiEnabled)
+        {
+            QMessageBox::warning(qApp->getMainWindow(), QObject::tr("File Error"),
+                                 QObject::tr("Could not open file for reading."),
+                                 QMessageBox::Ok, QMessageBox::Ok);
+        }
+        return;
+    }
+
+    // Read the entire file contents and retrieve last modified datestamp.
+    QString fileContent = QTextStream(&file).readAll();
+    QDateTime oldDateTime = file.fileTime(QFileDevice::FileModificationTime);
+    file.close();
+
+    if (fileContent.contains(searchString))
+    {
+        // Replace all occurrences of the search string
+        fileContent.replace(searchString, replaceString);
+
+        // Open the file in write-only mode to save changes. Truncate forces file to be cleared and pointer reset.
+        if (!file.open(QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate))
+        {
+            if (guiEnabled)
+            {
+                QMessageBox::warning(qApp->getMainWindow(), QObject::tr("File Error"),
+                                     QObject::tr("Could not open file for writing."),
+                                     QMessageBox::Ok, QMessageBox::Ok);
+            }
+            return;
+        }
+
+        // Write out updated file contents.
+        QTextStream out(&file);
+        out << fileContent;
+
+        // Restore datestamp and close file.
+        file.setFileTime(oldDateTime, QFileDevice::FileModificationTime);
+        file.close();
+
+        // Mark pattern as unsaved.
+        patternChangesWereSaved(false);
+    }
+}
+
 //---------------------------------------------------------------------------------------------------------------------
 /**
  * @brief ReadSettings read setting for app.
@@ -6467,6 +6525,9 @@ bool MainWindow::LoadPattern(const QString &fileName, const QString& customMeasu
         Clear();
         return false;
     }
+
+    replaceInFile(fileName, "lineWeight=\"1.00\"", "lineWeight=\"1\"");
+
 
     try
     {

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -383,7 +383,6 @@ private:
     void                              handleLayoutMenu();
     void                              handleImagesMenu();
 
-
     void                              CancelTool();
 
     void               setWidgetsEnabled(bool enable);
@@ -421,6 +420,7 @@ private:
     bool               SavePattern(const QString &fileName, QString &error);
     void               AutoSavePattern();
     void               setCurrentFile(const QString &fileName);
+    void               replaceInFile(const QString &filename, const QString &search, const QString &replace);
 
     void               ReadSettings();
     void               WriteSettings();

--- a/src/libs/ifc/xml/vdomdocument.cpp
+++ b/src/libs/ifc/xml/vdomdocument.cpp
@@ -665,31 +665,6 @@ void VDomDocument::ValidateXML(const QString &schema, const QString &fileName)
     QTextStream patternIn(&patternFile);
     std::string xmlString = patternIn.readAll().toStdString();
 
-    // Fix files with invalid lineweight. 
-    size_t startPos = 0;
-    std::string fromString = "lineWeight=\"1.00\"";
-    std::string toString = "lineWeight=\"1\"";
-    while((startPos = xmlString.find(fromString, startPos)) != std::string::npos)
-    {
-        xmlString.replace(startPos, fromString.length(), toString);
-        // Advance startPos past the newly inserted 'toString' to avoid infinite loops
-        // if 'fromString' is a substring of 'toString' (e.g., replacing "a" with "aa").
-        startPos += toString.length();
-    }
-    // If any replacements were made write the changes back to the pattern file.
-    if (startPos > 0)
-    {
-        patternFile.close();
-        if (patternFile.open(QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate) == false)
-        {
-            const QString errorMsg(tr("Can't open pattern file %1:\n%2.").arg(fileName).arg(patternFile.errorString()));
-            throw VException(errorMsg);
-        }
-
-        QTextStream patternOut(&patternFile);
-        patternOut << QString::fromStdString(xmlString);
-    }
-
     xercesc::MemBufInputSource inputBuffer((XMLByte*)xmlString.c_str(), xmlString.size(), "/input.xml");
 
     domParser->parse(inputBuffer);


### PR DESCRIPTION
This PR refactors the autocorrection of an invalid lineweight. It does the following:

- Only corrects a pattern file if it contains an invalid "1.00" lineweight.

- Maintains the existing datestamp when making corrections.

- Sets the pattern file to an unsaved state, so that if a user subsequently saves the pattern file, the datestamp will then be updated.  