### PR TITLE
feature: extend pattern piece bounding rect to cutline

### DIFF
--- a/src/libs/vtools/tools/pattern_piece_tool.cpp
+++ b/src/libs/vtools/tools/pattern_piece_tool.cpp
@@ -1560,6 +1560,7 @@ void PatternPieceTool::RefreshGeometry()
     {
         m_cutPath = piece.SeamAllowancePath(seamAllowancePoints);
         m_cutLine->setPath(m_cutPath);
+        m_pieceRect = m_cutLine->boundingRect();
 
         QPainterPath allowancePath = path;
         allowancePath.addPath(m_cutPath);
@@ -1575,11 +1576,10 @@ void PatternPieceTool::RefreshGeometry()
     {
         m_cutLine->setPath(QPainterPath());
         m_allowanceFill->setPath(QPainterPath());
+        m_pieceRect = path.boundingRect();
     }
 
     m_notches->setPath(piece.getNotchesPath(this->getData(), seamAllowancePoints));
-
-    m_pieceRect = path.boundingRect();
 
     updatePieceDetails();
 


### PR DESCRIPTION
The PR does the following:

- Extends the bounding rect of a pattern piece to the cutline path if a seam allawance exists, otherwise the bounding rect remain the main path of the piece.

- Allows selection of a pattern piece by including the seam allowance area as part of the selection target area.

- Allows the Grainline to extend into the seam allowance upto the cutline. 
<img width="448" height="188" alt="Screenshot 2025-10-22 083404" src="https://github.com/user-attachments/assets/663fcb22-8c32-48a3-b591-dd4f6938a44d" />

- Allows the text of labels to appear within the seam allowance.

<img width="730" height="197" alt="Screenshot 2025-10-22 084215" src="https://github.com/user-attachments/assets/d1a211dd-e048-4ce8-b046-663eb9ede35b" />

Closes issue #1418 

