### PR TITLE
fix: Main Window resizing issue

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -7940,8 +7940,8 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
         <translation>Počet:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
-        <translation>Vyberte objekty hlavní cesty ve směru hodinových ručiček. Pomocí klávesy &lt;b&gt;SHIFT&lt;/b&gt; obraťte směr křivky nebo klávesou &lt;b&gt;CTRL&lt;/b&gt; zachovejte směr křivky. Stisknutím klávesy &lt;b&gt;ENTER&lt;/b&gt; dokončete vytváření dílce </translation>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Vyberte objekty hlavní cesty ve směru hodinových ručiček. Pomocí klávesy &lt;b&gt;SHIFT&lt;/b&gt; obraťte směr křivky nebo klávesou &lt;b&gt;CTRL&lt;/b&gt; zachovejte směr křivky.</translation>
     </message>
     <message>
         <source>Press OK to create pattern piece</source>
@@ -8166,6 +8166,10 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
         <translation>Délka nesmí být menší než délka 2 šípů</translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation>Stisknutím klávesy &lt;b&gt;ENTER&lt;/b&gt; dokončete vytváření dílce.</translation>
     </message>
 </context>
 <context>
@@ -12427,6 +12431,11 @@ SeamlyME jako obvykle.
     <message>
         <source>Validation error file %1</source>
         <translation>Soubor chyb ověření %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -7925,8 +7925,8 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <translation>Zählen:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
-        <translation>Hauptpfad Objekte im Uhrzeigersinn auswählen, mit &lt;b&gt;SHIFT&lt;/b&gt; Kurvenrichtung umkehren,  oder &lt;b&gt;Strg&lt;/b&gt; um Kurvenrichtung beizubehalten. Mit &lt;b&gt;Enter&lt;/b&gt; Teilerstellung abschließen </translation>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Hauptpfad Objekte im Uhrzeigersinn auswählen, mit &lt;b&gt;SHIFT&lt;/b&gt; Kurvenrichtung umkehren,  oder &lt;b&gt;Strg&lt;/b&gt; um Kurvenrichtung beizubehalten.</translation>
     </message>
     <message>
         <source>Press OK to create pattern piece</source>
@@ -8151,6 +8151,10 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
         <translation>Die Länge darf nicht kürzer sein als die Länge von 2 Pfeilen</translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation>Mit &lt;b&gt;Enter&lt;/b&gt; Teilerstellung abschließen.</translation>
     </message>
 </context>
 <context>
@@ -12414,6 +12418,11 @@ wie gewohnt in SeamlyME laden können.
     <message>
         <source>Validation error file %1</source>
         <translation>Validierungsfehlerdatei %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -7944,8 +7944,8 @@ Press enter to temporarily add it to the list.</source>
         <translation>Αριθμός:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
-        <translation>Επιλέξτε αντικείμενα κύριας διαδρομής δεξιόστροφα, χρησιμοποιήστε το &lt;b&gt;SHIFT&lt;/b&gt; για να αντιστρέψετε την κατεύθυνση της καμπύλης ή το &lt;b&gt;CTRL&lt;/b&gt; για να διατηρήσετε την κατεύθυνση της καμπύλης. Πατήστε το &lt;b&gt;ENTER&lt;/b&gt; για να ολοκληρώσετε τη δημιουργία κομματιών </translation>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Επιλέξτε αντικείμενα κύριας διαδρομής δεξιόστροφα, χρησιμοποιήστε το &lt;b&gt;SHIFT&lt;/b&gt; για να αντιστρέψετε την κατεύθυνση της καμπύλης ή το &lt;b&gt;CTRL&lt;/b&gt; για να διατηρήσετε την κατεύθυνση της καμπύλης.</translation>
     </message>
     <message>
         <source>Press OK to create pattern piece</source>
@@ -8170,6 +8170,10 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
         <translation>Το μήκος δεν μπορεί να είναι μικρότερο από το μήκος 2 βελών</translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation>Πατήστε το &lt;b&gt;ENTER&lt;/b&gt; για να ολοκληρώσετε τη δημιουργία κομματιών.</translation>
     </message>
 </context>
 <context>
@@ -12431,6 +12435,11 @@ load in SeamlyME as usual.
     <message>
         <source>Validation error file %1</source>
         <translation>Αρχείο σφάλματος επικύρωσης %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Fix formula</translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7910,7 +7910,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8135,6 +8135,10 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12390,6 +12394,11 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Validation error file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7910,7 +7910,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8135,6 +8135,10 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12390,6 +12394,11 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Validation error file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Fix formula</translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7910,7 +7910,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8135,6 +8135,10 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12390,6 +12394,11 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Validation error file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7910,7 +7910,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8135,6 +8135,10 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12390,6 +12394,11 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Validation error file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -7978,8 +7978,8 @@ Press enter to temporarily add it to the list.</source>
         <translation>Contar:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
-        <translation>Seleccione los objetos de la ruta principal en el sentido de las agujas del reloj. Utilice tecla&lt;b&gt;MAYÚS&lt;/b&gt; para invertir la dirección de la curva o la tecla &lt;b&gt;CTRL&lt;/b&gt; para mantener la dirección de la curva. Presione la tecla &lt;b&gt;ENTER&lt;/b&gt; para finalizar la creación de la pieza </translation>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Seleccione los objetos de la ruta principal en el sentido de las agujas del reloj. Utilice tecla &lt;b&gt;MAYÚS&lt;/b&gt; para invertir la dirección de la curva o la tecla &lt;b&gt;CTRL&lt;/b&gt; para mantener la dirección de la curva.</translation>
     </message>
     <message>
         <source>Press OK to create pattern piece</source>
@@ -8204,6 +8204,10 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
         <translation>La longitud no puede ser menor que la longitud de 2 flechas</translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation>Presione la tecla &lt;b&gt;ENTER&lt;/b&gt; para finalizar la creación de la pieza.</translation>
     </message>
 </context>
 <context>
@@ -12469,6 +12473,11 @@ load in SeamlyME as usual.
     <message>
         <source>Validation error file %1</source>
         <translation>Archivo de error de validación %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -7942,8 +7942,8 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
         <translation>Lasku:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
-        <translation>Valitse pääpolun objektit myötäpäivään. Käytä &lt;b&gt;SHIFT&lt;/b&gt;-näppäintä kääntääksesi käyrän suunnan tai &lt;b&gt;CTRL&lt;/b&gt;-näppäintä säilyttääksesi käyrän suunnan. Paina &lt;b&gt;ENTER&lt;/b&gt;-näppäintä viimeistelläksesi osan luomisen </translation>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Valitse pääpolun objektit myötäpäivään. Käytä &lt;b&gt;SHIFT&lt;/b&gt;-näppäintä kääntääksesi käyrän suunnan tai &lt;b&gt;CTRL&lt;/b&gt;-näppäintä säilyttääksesi käyrän suunnan.</translation>
     </message>
     <message>
         <source>Press OK to create pattern piece</source>
@@ -8168,6 +8168,10 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
         <translation>Pituus ei voi olla pienempi kuin kahden nuolen pituus</translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation>Paina &lt;b&gt;ENTER&lt;/b&gt;-näppäintä viimeistelläksesi osan luomisen.</translation>
     </message>
 </context>
 <context>
@@ -12429,6 +12433,11 @@ Haluatko tallentaa muutokset?</translation>
     <message>
         <source>Validation error file %1</source>
         <translation>Vahvistusvirhe tiedostossa %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -7970,8 +7970,8 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
         <translation>Nombre :</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
-        <translation>Sélectionnez les objets du chemin principal dans le sens des aiguilles d&apos;une montre. Utilisez &lt;b&gt;MAJ&lt;/b&gt; pour inverser le sens de la courbe ou &lt;b&gt;CTRL&lt;/b&gt; pour conserver le sens de la courbe. Appuyez sur &lt;b&gt;ENTRÉE&lt;/b&gt; pour terminer la création de la pièce </translation>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Sélectionnez les objets du chemin principal dans le sens des aiguilles d&apos;une montre. Utilisez &lt;b&gt;MAJ&lt;/b&gt; pour inverser le sens de la courbe ou &lt;b&gt;CTRL&lt;/b&gt; pour conserver le sens de la courbe.</translation>
     </message>
     <message>
         <source>Press OK to create pattern piece</source>
@@ -8192,6 +8192,10 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
         <translation>La longueur ne peut pas être inférieure à la longueur de 2 flèches</translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation>Appuyez sur &lt;b&gt;ENTRÉE&lt;/b&gt; pour terminer la création de la pièce .</translation>
     </message>
 </context>
 <context>
@@ -12457,6 +12461,11 @@ charger dans SeamlyME comme d&apos;habitude.
     <message>
         <source>Validation error file %1</source>
         <translation>Fichier d&apos;erreur de validation %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7906,7 +7906,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8131,6 +8131,10 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12383,6 +12387,11 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Validation error file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -7942,8 +7942,8 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
         <translation>Hitung:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
-        <translation>Pilih objek jalur utama searah jarum jam, Gunakan &lt;b&gt;SHIFT&lt;/b&gt; untuk membalikkan arah lengkung, atau &lt;b&gt;CTRL&lt;/b&gt; untuk mempertahankan arah lengkung. Tekan &lt;b&gt;ENTER&lt;/b&gt; untuk menyelesaikan pembuatan bagian </translation>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Pilih objek jalur utama searah jarum jam, Gunakan &lt;b&gt;SHIFT&lt;/b&gt; untuk membalikkan arah lengkung, atau &lt;b&gt;CTRL&lt;/b&gt; untuk mempertahankan arah lengkung.</translation>
     </message>
     <message>
         <source>Press OK to create pattern piece</source>
@@ -8168,6 +8168,10 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
         <translation>Panjangnya tidak boleh kurang dari panjang 2 anak panah</translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation>Tekan &lt;b&gt;ENTER&lt;/b&gt; untuk menyelesaikan pembuatan bagian.</translation>
     </message>
 </context>
 <context>
@@ -12429,6 +12433,11 @@ unggah ke SeamlyME seperti biasa.
     <message>
         <source>Validation error file %1</source>
         <translation>File kesalahan validasi %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -3070,7 +3070,7 @@ p, li { white-space: pre-wrap; }
         <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation>Seamly2D ha riscontrato un errore durante il calcolo di una formula.
-Prova ad annullare l'ultima operazione o a correggere la formula non funzionante.</translation>
+Prova ad annullare l&apos;ultima operazione o a correggere la formula non funzionante.</translation>
     </message>
 </context>
 <context>
@@ -7930,8 +7930,8 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
         <translation>Contare:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
-        <translation>Selezionare gli oggetti del percorso principale in senso orario, Utilizzare &lt;b&gt;SHIFT&lt;/b&gt; per invertire la direzione della curva, oppure &lt;b&gt;CTRL&lt;/b&gt; per mantenere la direzione della curva. Premere &lt;b&gt;ENTER&lt;/b&gt; per terminare la creazione del pezzo </translation>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Selezionare gli oggetti del percorso principale in senso orario, Utilizzare &lt;b&gt;SHIFT&lt;/b&gt; per invertire la direzione della curva, oppure &lt;b&gt;CTRL&lt;/b&gt; per mantenere la direzione della curva.</translation>
     </message>
     <message>
         <source>Press OK to create pattern piece</source>
@@ -8156,6 +8156,10 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
         <translation>La lunghezza non può essere inferiore alla lunghezza di 2 frecce</translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation>Premere &lt;b&gt;ENTER&lt;/b&gt; per terminare la creazione del pezzo.</translation>
     </message>
 </context>
 <context>
@@ -12417,6 +12421,11 @@ caricare in SeamlyME come di consueto.
     <message>
         <source>Validation error file %1</source>
         <translation>Errore di convalida file %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -7925,8 +7925,8 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
         <translation>Aantal:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
-        <translation>Selecteer het pad van objecten met de klok mee, Gebruik &lt;b&gt;SHIFT&lt;/b&gt; om de richting van krommes om te draaien, of &lt;b&gt;Ctrl&lt;/b&gt; om de richting te bewaren. Druk &lt;b&gt;ENTER&lt;/b&gt; om het maken van het patroondeel te beëindigen </translation>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Selecteer het pad van objecten met de klok mee, Gebruik &lt;b&gt;SHIFT&lt;/b&gt; om de richting van krommes om te draaien, of &lt;b&gt;Ctrl&lt;/b&gt; om de richting te bewaren.</translation>
     </message>
     <message>
         <source>Press OK to create pattern piece</source>
@@ -8151,6 +8151,10 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
         <translation>Lengte mag niet kleiner zijn dan de lengte van 2 pijlen</translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation>Druk &lt;b&gt;ENTER&lt;/b&gt; om het maken van het patroondeel te beëindigen.</translation>
     </message>
 </context>
 <context>
@@ -12411,6 +12415,11 @@ load in SeamlyME as usual.
     <message>
         <source>Validation error file %1</source>
         <translation>Validatiefoutbestand %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -7928,8 +7928,8 @@ Prima enter para o adicionar temporariamente à lista.</translation>
         <translation>Contar:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
-        <translation>Selecionar os objectos da trajetória principal no sentido dos ponteiros do relógio, Utilizar &lt;b&gt;SHIFT&lt;/b&gt; para inverter a direção da curva, ou &lt;b&gt;CTRL&lt;/b&gt; para manter a direção da curva. Pressionar &lt;b&gt;ENTER&lt;/b&gt; para terminar a criação da peça </translation>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Selecionar os objectos da trajetória principal no sentido dos ponteiros do relógio, Utilizar &lt;b&gt;SHIFT&lt;/b&gt; para inverter a direção da curva, ou &lt;b&gt;CTRL&lt;/b&gt; para manter a direção da curva.</translation>
     </message>
     <message>
         <source>Press OK to create pattern piece</source>
@@ -8154,6 +8154,11 @@ Prima enter para o adicionar temporariamente à lista.</translation>
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
         <translation>Lungimea nu poate fi mai mică decât lungimea a 2 săgeți</translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translatorcomment>Pressionar &lt;b&gt;ENTER&lt;/b&gt; para terminar a criação da peça.</translatorcomment>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -12415,6 +12420,11 @@ carregar no SeamlyME como de costume.
     <message>
         <source>Validation error file %1</source>
         <translation>Arquivo de erro de validação %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -7944,8 +7944,8 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
         <translation>Numărătoare:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
-        <translation>Selectați obiectele principale ale căii în sensul acelor de ceasornic. Folosiți &lt;b&gt;SHIFT&lt;/b&gt; pentru a inversa direcția curbei sau &lt;b&gt;CTRL&lt;/b&gt; pentru a păstra direcția curbei. Apăsați &lt;b&gt;ENTER&lt;/b&gt; pentru a finaliza crearea piesei </translation>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Selectați obiectele principale ale căii în sensul acelor de ceasornic. Folosiți &lt;b&gt;SHIFT&lt;/b&gt; pentru a inversa direcția curbei sau &lt;b&gt;CTRL&lt;/b&gt; pentru a păstra direcția curbei.</translation>
     </message>
     <message>
         <source>Press OK to create pattern piece</source>
@@ -8170,6 +8170,10 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
         <translation>Lungimea nu poate fi mai mică decât lungimea a 2 săgeți</translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation>Apăsați &lt;b&gt;ENTER&lt;/b&gt; pentru a finaliza crearea piesei.</translation>
     </message>
 </context>
 <context>
@@ -12430,6 +12434,11 @@ load in SeamlyME as usual.
     <message>
         <source>Validation error file %1</source>
         <translation>Fișier de eroare de validare %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -8175,6 +8175,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Length can&apos;t be less than length of 2 arrows</source>
         <translation>Длина не может быть меньше длины двух стрелок</translation>
     </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -12436,6 +12440,11 @@ load in SeamlyME as usual.
     <message>
         <source>Validation error file %1</source>
         <translation>Файл ошибки проверки %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -7942,8 +7942,8 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
         <translation>Sayım:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
-        <translation>Ana yol nesnelerini saat yönünde seçin. Eğri yönünü tersine çevirmek için &lt;b&gt;SHIFT&lt;/b&gt;&apos;i veya eğri yönünü korumak için &lt;b&gt;CTRL&lt;/b&gt;&apos;yi kullanın. Parça oluşturmayı tamamlamak için &lt;b&gt;ENTER&lt;/b&gt;&apos;a basın </translation>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Ana yol nesnelerini saat yönünde seçin. Eğri yönünü tersine çevirmek için &lt;b&gt;SHIFT&lt;/b&gt;&apos;i veya eğri yönünü korumak için &lt;b&gt;CTRL&lt;/b&gt;&apos;yi kullanın.</translation>
     </message>
     <message>
         <source>Press OK to create pattern piece</source>
@@ -8168,6 +8168,10 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
         <translation>Uzunluk 2 okun uzunluğundan az olamaz</translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation>Parça oluşturmayı tamamlamak için &lt;b&gt;ENTER&lt;/b&gt;&apos;a basın.</translation>
     </message>
 </context>
 <context>
@@ -12428,6 +12432,11 @@ load in SeamlyME as usual.
     <message>
         <source>Validation error file %1</source>
         <translation>Doğrulama hatası dosyası %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -7943,8 +7943,8 @@ Press enter to temporarily add it to the list.</source>
         <translation>Αριθμός:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
-        <translation>Επιλέξτε αντικείμενα κύριας διαδρομής δεξιόστροφα, χρησιμοποιήστε το &lt;b&gt;SHIFT&lt;/b&gt; για να αντιστρέψετε την κατεύθυνση της καμπύλης ή το &lt;b&gt;CTRL&lt;/b&gt; για να διατηρήσετε την κατεύθυνση της καμπύλης. Πατήστε το &lt;b&gt;ENTER&lt;/b&gt; για να ολοκληρώσετε τη δημιουργία κομματιών </translation>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Επιλέξτε αντικείμενα κύριας διαδρομής δεξιόστροφα, χρησιμοποιήστε το &lt;b&gt;SHIFT&lt;/b&gt; για να αντιστρέψετε την κατεύθυνση της καμπύλης ή το &lt;b&gt;CTRL&lt;/b&gt; για να διατηρήσετε την κατεύθυνση της καμπύλης.</translation>
     </message>
     <message>
         <source>Press OK to create pattern piece</source>
@@ -8169,6 +8169,10 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
         <translation>Довжина не може бути меншою за довжину двох стріл</translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation>Πατήστε το &lt;b&gt;ENTER&lt;/b&gt; για να ολοκληρώσετε τη δημιουργία κομματιών.</translation>
     </message>
 </context>
 <context>
@@ -12429,6 +12433,11 @@ load in SeamlyME as usual.
     <message>
         <source>Validation error file %1</source>
         <translation>Файл помилки перевірки %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7906,7 +7906,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8131,6 +8131,10 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12383,6 +12387,11 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Validation error file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t open pattern file %1:
+%2.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
@@ -493,8 +493,7 @@ void PatternPieceDialog::ChosenObject(quint32 id, const SceneObject &type)
             if (p.GetPath().nodeCount() == 1)
             {
                 emit ToolTip(tr("Select main path objects clockwise, Use <b>SHIFT</b> to reverse curve direction, "
-                                " or <b>CTRL</b> to keep curve direction. "
-                                "Press <b>ENTER</b> to finish piece creation "));
+                                "or <b>CTRL</b> to keep curve direction."));
 
                 if (!qApp->getCurrentScene()->items().contains(visPath))
                 {
@@ -507,6 +506,7 @@ void PatternPieceDialog::ChosenObject(quint32 id, const SceneObject &type)
             }
             else
             {
+                emit ToolTip(tr("Press <b>ENTER</b> to finish piece creation."));
                 visPath->RefreshGeometry();
             }
         }


### PR DESCRIPTION
This PR fixes the issue of some translated Pattern Piece status bar tooltips causing the Main Window to resize larger than screen size. 

<img width="1354" height="72" alt="Screenshot 2025-10-29 082750" src="https://github.com/user-attachments/assets/a37c7892-c120-4fec-b51c-13cb5cf13a76" />

- Splits the tooltip into 2 tooltips so neither one is long enough to force the Main Window to expand. The first part is displayed when the first object is selected. The second part is displayed when the second object is selected. 
 
<img width="1349" height="108" alt="image" src="https://github.com/user-attachments/assets/a69e51f6-fb2f-4099-acf5-93c75dcbb776" />

<img width="1360" height="107" alt="image" src="https://github.com/user-attachments/assets/0ae844a4-2005-4c95-8678-b55687eb85ac" />

- lupdate

fixes issue #1420 