### PR TITLE
fix: Wrong path is tested when loading a high dpi cursor

### DIFF
--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -776,7 +776,7 @@ void MainWindow::SetToolButton(bool checked, Tool t, const QString &cursor, cons
         {
             // Try to load HiDPI versions of the cursors if available
             auto cursorHidpiResource = QString(cursor).replace(".png", "@2x.png");
-            if (QFileInfo(cursorResource).exists())
+            if (QFileInfo(cursorHidpiResource).exists())
             {
                 cursorResource = cursorHidpiResource;
             }


### PR DESCRIPTION
Closes #1422 	