### PR TITLE
fix: remove macro for Qt ver 6.7.0 or later

### DIFF
--- a/src/libs/vgeometry/vabstractcurve.h
+++ b/src/libs/vgeometry/vabstractcurve.h
@@ -137,8 +137,4 @@ private:
     static QVector<QPointF>  ToEnd(const QVector<QPointF> &points, const QPointF &end, bool *ok = nullptr);
 };
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
-Q_DECLARE_TYPEINFO(VAbstractCurve, Q_MOVABLE_TYPE);
-#endif
-
 #endif // VABSTRACTCURVE_H

--- a/src/libs/vgeometry/vabstractcurve.h
+++ b/src/libs/vgeometry/vabstractcurve.h
@@ -1,48 +1,51 @@
-/******************************************************************************
- *   @file   vabstractcurve.h
- **  @author Douglas S Caskey
- **  @date   21 Mar, 2023
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Seamly2D project, a pattern making
- **  program to create and model patterns of clothing.
- **  Copyright (C) 2017-2023 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *****************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vabstractcurve.h
+//  @author Douglas S Caskey
+//  @date   21 Mar, 2023
+//
+//  @copyright
+//  Copyright (C) 2017 - 2025 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
-/************************************************************************
- **
- **  @file   vabstractcurve.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   25 6, 2014
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vabstractcurve.h
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   25 Jun, 2014
+//
+//  @copyright
+//  Copyright (C) 2013 Valentina project.
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published
+//  by the Free Software Foundation, either version 3 of the License,
+//  or (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #ifndef VABSTRACTCURVE_H
 #define VABSTRACTCURVE_H
@@ -134,6 +137,8 @@ private:
     static QVector<QPointF>  ToEnd(const QVector<QPointF> &points, const QPointF &end, bool *ok = nullptr);
 };
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
 Q_DECLARE_TYPEINFO(VAbstractCurve, Q_MOVABLE_TYPE);
+#endif
 
 #endif // VABSTRACTCURVE_H


### PR DESCRIPTION
This removes the Q_DECLARE_TYPEINFO Macro from the VAbstractCurve class for Qt ver 6.7.0 or later that prevents the apps from building. 

Closes issue #1427 