### PR TITLE
feature: add default values to arc tools

### DIFF
--- a/src/libs/vtools/dialogs/tools/dialogarc.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogarc.cpp
@@ -171,8 +171,8 @@ DialogArc::DialogArc(const VContainer *data, const quint32 &toolId, QWidget *par
 
     connect(ui->centerPoint_ComboBox, &QComboBox::currentTextChanged, this, &DialogArc::pointNameChanged);
 
-    ui->plainTextEditF1->setPlainText("0.0");
-    ui->plainTextEditF2->setPlainText("360.0");
+    ui->plainTextEditF1->setPlainText("0");
+    ui->plainTextEditF2->setPlainText("360");
     ui->plainTextEditFormula->setFocus();
 
     vis = new VisToolArc(data);

--- a/src/libs/vtools/dialogs/tools/dialogarc.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogarc.cpp
@@ -171,6 +171,10 @@ DialogArc::DialogArc(const VContainer *data, const quint32 &toolId, QWidget *par
 
     connect(ui->centerPoint_ComboBox, &QComboBox::currentTextChanged, this, &DialogArc::pointNameChanged);
 
+    ui->plainTextEditF1->setPlainText("0.0");
+    ui->plainTextEditF2->setPlainText("360.0");
+    ui->plainTextEditFormula->setFocus();
+
     vis = new VisToolArc(data);
 }
 

--- a/src/libs/vtools/dialogs/tools/dialogarc.ui
+++ b/src/libs/vtools/dialogs/tools/dialogarc.ui
@@ -91,6 +91,9 @@
             <bold>false</bold>
            </font>
           </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
          </widget>
         </item>
         <item row="1" column="0">

--- a/src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp
@@ -163,6 +163,8 @@ DialogArcWithLength::DialogArcWithLength(const VContainer *data, const quint32 &
 
     connect(ui->centerPoint_ComboBox, &QComboBox::currentTextChanged, this, &DialogArcWithLength::pointNameChanged);
 
+    ui->plainTextEditRadius->setFocus();
+
     vis = new VisToolArcWithLength(data);
 }
 

--- a/src/libs/vtools/dialogs/tools/dialogarcwithlength.ui
+++ b/src/libs/vtools/dialogs/tools/dialogarcwithlength.ui
@@ -83,6 +83,9 @@
             <bold>false</bold>
            </font>
           </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
          </widget>
         </item>
         <item row="1" column="0">

--- a/src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp
@@ -196,9 +196,9 @@ DialogEllipticalArc::DialogEllipticalArc(const VContainer *data, const quint32 &
 
     connect(ui->centerPoint_ComboBox, &QComboBox::currentTextChanged, this, &DialogEllipticalArc::pointNameChanged);
 
-    ui->plainTextEditF1->setPlainText("0.0");
-    ui->plainTextEditF2->setPlainText("360.0");
-    ui->plainTextEditRotationAngle->setPlainText("0.0");
+    ui->plainTextEditF1->setPlainText("0");
+    ui->plainTextEditF2->setPlainText("360");
+    ui->plainTextEditRotationAngle->setPlainText("0");
     ui->plainTextEditRadius1->setFocus();
 
     vis = new VisToolEllipticalArc(data);

--- a/src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp
@@ -196,6 +196,11 @@ DialogEllipticalArc::DialogEllipticalArc(const VContainer *data, const quint32 &
 
     connect(ui->centerPoint_ComboBox, &QComboBox::currentTextChanged, this, &DialogEllipticalArc::pointNameChanged);
 
+    ui->plainTextEditF1->setPlainText("0.0");
+    ui->plainTextEditF2->setPlainText("360.0");
+    ui->plainTextEditRotationAngle->setPlainText("0.0");
+    ui->plainTextEditRadius1->setFocus();
+
     vis = new VisToolEllipticalArc(data);
 }
 

--- a/src/libs/vtools/dialogs/tools/dialogellipticalarc.ui
+++ b/src/libs/vtools/dialogs/tools/dialogellipticalarc.ui
@@ -93,6 +93,9 @@
                 <bold>false</bold>
                </font>
               </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
              </widget>
             </item>
             <item row="1" column="0">


### PR DESCRIPTION
This PR adds or changes the following to the arc tools:

- Since arcs are automatically named by the app, there is no reason to edit the name. The name field for the following tools is changed to read only, and the focus of the cursor is now placed on the 1st open field.
    - Arc - Radius and Angles
    - Arc - Radius and Length
    - Arc - Ellipitcal

- Added the 0 and 360 default angle values for the Arc - Radius and Angles:

  <img width="357" height="570" alt="image" src="https://github.com/user-attachments/assets/67f896ce-f0d5-41e3-afea-5749dacf7c28" />

- Added the default 0 and 360  angle values, and 0 rotation angle for the Arc - Elliptical:

  <img width="631" height="537" alt="image" src="https://github.com/user-attachments/assets/0c1502f5-78a3-45dc-aa0a-57822f15e5fd" />


  Closes issue #1430 
