### PR TITLE
BUG: Fix measurement sync issue

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -5692,10 +5692,6 @@ Chcete uložit své změny?</translation>
         <translation>Soubor s měřeními &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; nebyl nalezen. Chcete aktualizovat umístění souboru?</translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation>Měření byla změněna. Chcete nyní synchronizovat měření?</translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>Gradace nepodporuje palce</translation>
     </message>
@@ -7940,10 +7936,6 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
         <translation>Počet:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation>Vyberte objekty hlavní cesty ve směru hodinových ručiček. Pomocí klávesy &lt;b&gt;SHIFT&lt;/b&gt; obraťte směr křivky nebo klávesou &lt;b&gt;CTRL&lt;/b&gt; zachovejte směr křivky.</translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation>Stisknutím tlačítka OK vytvoříte vzor</translation>
     </message>
@@ -8170,6 +8162,10 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translation>Stisknutím klávesy &lt;b&gt;ENTER&lt;/b&gt; dokončete vytváření dílce.</translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Vyberte objekty hlavní cesty ve směru hodinových ručiček. Pomocí klávesy &lt;b&gt;SHIFT&lt;/b&gt; obraťte směr křivky nebo klávesou &lt;b&gt;CTRL&lt;/b&gt; zachovejte směr křivky.</translation>
     </message>
 </context>
 <context>
@@ -12435,7 +12431,8 @@ SeamlyME jako obvykle.
     <message>
         <source>Can&apos;t open pattern file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>Nelze otevřít soubor se vzorem %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -5677,10 +5677,6 @@ Sollen die Änderungen gespeichert werden?</translation>
         <translation>Die Maßdateien &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; konnten nicht gefunden werden. Möchtest Du den Speicherort aktualisieren?</translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation>Die Maße wurden geändert. Sollen die Maße jetzt synchronisiert werden?</translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>Gradierung unterstützt Zoll nicht</translation>
     </message>
@@ -7925,10 +7921,6 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <translation>Zählen:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation>Hauptpfad Objekte im Uhrzeigersinn auswählen, mit &lt;b&gt;SHIFT&lt;/b&gt; Kurvenrichtung umkehren,  oder &lt;b&gt;Strg&lt;/b&gt; um Kurvenrichtung beizubehalten.</translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation>OK drücken um ein Schnittteil zu erstellen</translation>
     </message>
@@ -8155,6 +8147,10 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translation>Mit &lt;b&gt;Enter&lt;/b&gt; Teilerstellung abschließen.</translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Hauptpfad Objekte im Uhrzeigersinn auswählen, mit &lt;b&gt;SHIFT&lt;/b&gt; Kurvenrichtung umkehren, oder &lt;b&gt;Strg&lt;/b&gt; um Kurvenrichtung beizubehalten.</translation>
     </message>
 </context>
 <context>
@@ -12422,7 +12418,8 @@ wie gewohnt in SeamlyME laden können.
     <message>
         <source>Can&apos;t open pattern file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>Die Musterdatei %1 kann nicht geöffnet werden:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -5696,10 +5696,6 @@ Do you want to save your changes?</source>
         <translation>Δεν ήταν δυνατή η εύρεση του αρχείου μετρήσεων &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt;. Θέλετε να ενημερώσετε την τοποθεσία του αρχείου?</translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation>Έγινε αλλαγή των μετρήσεων. Θέλετε να συγχρονίσετε τις μετρήσεις τώρα?</translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>Η διαβάθμιση δεν υποστηρίζει ίντσες</translation>
     </message>
@@ -7944,10 +7940,6 @@ Press enter to temporarily add it to the list.</source>
         <translation>Αριθμός:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation>Επιλέξτε αντικείμενα κύριας διαδρομής δεξιόστροφα, χρησιμοποιήστε το &lt;b&gt;SHIFT&lt;/b&gt; για να αντιστρέψετε την κατεύθυνση της καμπύλης ή το &lt;b&gt;CTRL&lt;/b&gt; για να διατηρήσετε την κατεύθυνση της καμπύλης.</translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation>Πατήστε OK για να δημιουργήσετε το κομμάτι του πατρόν</translation>
     </message>
@@ -8174,6 +8166,10 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translation>Πατήστε το &lt;b&gt;ENTER&lt;/b&gt; για να ολοκληρώσετε τη δημιουργία κομματιών.</translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Επιλέξτε αντικείμενα κύριας διαδρομής δεξιόστροφα, χρησιμοποιήστε το &lt;b&gt;SHIFT&lt;/b&gt; για να αντιστρέψετε την κατεύθυνση της καμπύλης ή το &lt;b&gt;CTRL&lt;/b&gt; για να διατηρήσετε την κατεύθυνση της καμπύλης.</translation>
     </message>
 </context>
 <context>
@@ -12439,7 +12435,8 @@ load in SeamlyME as usual.
     <message>
         <source>Can&apos;t open pattern file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>Δεν είναι δυνατό το άνοιγμα του αρχείου μοτίβου %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -5663,10 +5663,6 @@ Do you want to save your changes?</translation>
         <translation>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation>Measurements were changed. Do you want to sync measurements now?</translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>Gradation doesn&apos;t support inches</translation>
     </message>
@@ -7910,10 +7906,6 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8139,6 +8131,10 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -5663,10 +5663,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7910,10 +7906,6 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8139,6 +8131,10 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -5663,10 +5663,6 @@ Do you want to save your changes?</translation>
         <translation>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation>Measurements were changed. Do you want to sync measurements now?</translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>Gradation doesn&apos;t support inches</translation>
     </message>
@@ -7910,10 +7906,6 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8139,6 +8131,10 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -5663,10 +5663,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7910,10 +7906,6 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8139,6 +8131,10 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -5714,10 +5714,6 @@ Do you want to save your changes?</source>
         <translation>El archivo de medidas &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; podría no ser encontrado. ¿Quiere actualizar la ubicación del archivo?</translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation>Las medidas estaban cambiadas. ¿Quiere sincronizar las medidas ahora?</translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>El escalonado no spoorta pulgadas</translation>
     </message>
@@ -12477,7 +12473,8 @@ load in SeamlyME as usual.
     <message>
         <source>Can&apos;t open pattern file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>No se puede abrir el archivo de patrón %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -5694,10 +5694,6 @@ Haluatko tallentaa muutokset?</translation>
         <translation>Mittaustiedostoa &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; ei löytynyt. Haluatko päivittää tiedoston sijainnin?</translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation>Mittauksia on muutettu. Haluatko synkronoida mittaukset nyt?</translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>Sävyt eivät tue tuumia</translation>
     </message>
@@ -7942,10 +7938,6 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
         <translation>Lasku:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation>Valitse pääpolun objektit myötäpäivään. Käytä &lt;b&gt;SHIFT&lt;/b&gt;-näppäintä kääntääksesi käyrän suunnan tai &lt;b&gt;CTRL&lt;/b&gt;-näppäintä säilyttääksesi käyrän suunnan.</translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation>Paina OK luodaksesi kuviopalan</translation>
     </message>
@@ -8172,6 +8164,10 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translation>Paina &lt;b&gt;ENTER&lt;/b&gt;-näppäintä viimeistelläksesi osan luomisen.</translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Valitse pääpolun objektit myötäpäivään. Käytä &lt;b&gt;SHIFT&lt;/b&gt;-näppäintä kääntääksesi käyrän suunnan tai &lt;b&gt;CTRL&lt;/b&gt;-näppäintä säilyttääksesi käyrän suunnan.</translation>
     </message>
 </context>
 <context>
@@ -12437,7 +12433,8 @@ Haluatko tallentaa muutokset?</translation>
     <message>
         <source>Can&apos;t open pattern file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuviotiedostoa %1 ei voida avata:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -5718,10 +5718,6 @@ Voulez-vous sauvegarder les changements ?</translation>
         <translation>Le tableau de mesure &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt;est introuvable. Voulez-vous le rechercher?</translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation>Les mesures ont été modifiées. Voulez-vous synchroniser les mesures maintenant ?</translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>La gradation ne prend pas en charge les pouces</translation>
     </message>
@@ -7970,10 +7966,6 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
         <translation>Nombre :</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation>Sélectionnez les objets du chemin principal dans le sens des aiguilles d&apos;une montre. Utilisez &lt;b&gt;MAJ&lt;/b&gt; pour inverser le sens de la courbe ou &lt;b&gt;CTRL&lt;/b&gt; pour conserver le sens de la courbe.</translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation>Appuyez sur OK pour créer la pièce de patron</translation>
     </message>
@@ -8196,6 +8188,10 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translation>Appuyez sur &lt;b&gt;ENTRÉE&lt;/b&gt; pour terminer la création de la pièce .</translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Sélectionnez les objets du chemin principal dans le sens des aiguilles d&apos;une montre. Utilisez &lt;b&gt;MAJ&lt;/b&gt; pour inverser le sens de la courbe ou &lt;b&gt;CTRL&lt;/b&gt; pour conserver le sens de la courbe.</translation>
     </message>
 </context>
 <context>
@@ -12465,7 +12461,8 @@ charger dans SeamlyME comme d&apos;habitude.
     <message>
         <source>Can&apos;t open pattern file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossible d'ouvrir le fichier de motifs %1 :
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -5659,10 +5659,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7906,10 +7902,6 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8135,6 +8127,10 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -5694,10 +5694,6 @@ Apakah anda ingin menyimpan perubahan anda?</translation>
         <translation>File pengukuran &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; tidak dapat ditemukan. Apakah Anda ingin memperbarui lokasi file?</translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation>Pengukuran telah diubah. Apakah Anda ingin menyinkronkan pengukuran sekarang?</translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>Gradasi tidak mendukung inci</translation>
     </message>
@@ -7942,10 +7938,6 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
         <translation>Hitung:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation>Pilih objek jalur utama searah jarum jam, Gunakan &lt;b&gt;SHIFT&lt;/b&gt; untuk membalikkan arah lengkung, atau &lt;b&gt;CTRL&lt;/b&gt; untuk mempertahankan arah lengkung.</translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation>Tekan OK untuk membuat potongan pola</translation>
     </message>
@@ -8172,6 +8164,10 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translation>Tekan &lt;b&gt;ENTER&lt;/b&gt; untuk menyelesaikan pembuatan bagian.</translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Pilih objek jalur utama searah jarum jam, Gunakan &lt;b&gt;SHIFT&lt;/b&gt; untuk membalikkan arah lengkung, atau &lt;b&gt;CTRL&lt;/b&gt; untuk mempertahankan arah lengkung.</translation>
     </message>
 </context>
 <context>
@@ -12437,7 +12433,8 @@ unggah ke SeamlyME seperti biasa.
     <message>
         <source>Can&apos;t open pattern file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>Tidak dapat membuka file pola %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -5682,10 +5682,6 @@ Vuoi salvare i cambiamenti?</translation>
         <translation>Il file delle misure &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; non è stato trovato. Vuoi aggiornare la posizione del file?</translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation>Le misurazioni sono state modificate. Vuoi sincronizzare le misurazioni ora?</translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>La gradazione non supporta i pollici</translation>
     </message>
@@ -7930,10 +7926,6 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
         <translation>Contare:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation>Selezionare gli oggetti del percorso principale in senso orario, Utilizzare &lt;b&gt;SHIFT&lt;/b&gt; per invertire la direzione della curva, oppure &lt;b&gt;CTRL&lt;/b&gt; per mantenere la direzione della curva.</translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation>Premere OK per creare il pezzo del modello</translation>
     </message>
@@ -8160,6 +8152,10 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translation>Premere &lt;b&gt;ENTER&lt;/b&gt; per terminare la creazione del pezzo.</translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Selezionare gli oggetti del percorso principale in senso orario, Utilizzare &lt;b&gt;SHIFT&lt;/b&gt; per invertire la direzione della curva, oppure &lt;b&gt;CTRL&lt;/b&gt; per mantenere la direzione della curva.</translation>
     </message>
 </context>
 <context>
@@ -12425,7 +12421,8 @@ caricare in SeamlyME come di consueto.
     <message>
         <source>Can&apos;t open pattern file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile aprire il file del modello %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -5677,10 +5677,6 @@ Wil je de veranderingen opslaan?</translation>
         <translation>Het maten bestand&lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; kon niet gevonden worden. Wil je de bestanden locatie bijwerken?</translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation>Maten zijn gewijzigd. Wil je ze nu synchroniseren?</translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>Graderen ondersteunt geen inches</translation>
     </message>
@@ -7925,10 +7921,6 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
         <translation>Aantal:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation>Selecteer het pad van objecten met de klok mee, Gebruik &lt;b&gt;SHIFT&lt;/b&gt; om de richting van krommes om te draaien, of &lt;b&gt;Ctrl&lt;/b&gt; om de richting te bewaren.</translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation>Druk OK om een patroondeel te maken</translation>
     </message>
@@ -8155,6 +8147,10 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translation>Druk &lt;b&gt;ENTER&lt;/b&gt; om het maken van het patroondeel te beëindigen.</translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Selecteer het pad van objecten met de klok mee, Gebruik &lt;b&gt;SHIFT&lt;/b&gt; om de richting van krommes om te draaien, of &lt;b&gt;Ctrl&lt;/b&gt; om de richting te bewaren.</translation>
     </message>
 </context>
 <context>
@@ -12419,7 +12415,8 @@ load in SeamlyME as usual.
     <message>
         <source>Can&apos;t open pattern file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kan het patroonbestand %1 niet openen:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -5680,10 +5680,6 @@ Pretende guardar as suas alterações?</translation>
         <translation>O arquivo de medições &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; nâo pâde ser encontrado. Vocâ quer atualizar o local do arquivo?</translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation>As medições foram alteradas. Vocâ quer sincronizar as medições agora?</translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>A gradação nâo suporta polegadas</translation>
     </message>
@@ -7928,10 +7924,6 @@ Prima enter para o adicionar temporariamente à lista.</translation>
         <translation>Contar:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation>Selecionar os objectos da trajetória principal no sentido dos ponteiros do relógio, Utilizar &lt;b&gt;SHIFT&lt;/b&gt; para inverter a direção da curva, ou &lt;b&gt;CTRL&lt;/b&gt; para manter a direção da curva.</translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation>Pressione OK para criar a peâa do molde</translation>
     </message>
@@ -8159,6 +8151,10 @@ Prima enter para o adicionar temporariamente à lista.</translation>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translatorcomment>Pressionar &lt;b&gt;ENTER&lt;/b&gt; para terminar a criação da peça.</translatorcomment>
         <translation></translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Selecionar os objectos da trajetória principal no sentido dos ponteiros do relógio, Utilizar &lt;b&gt;SHIFT&lt;/b&gt; para inverter a direção da curva, ou &lt;b&gt;CTRL&lt;/b&gt; para manter a direção da curva.</translation>
     </message>
 </context>
 <context>
@@ -12424,7 +12420,8 @@ carregar no SeamlyME como de costume.
     <message>
         <source>Can&apos;t open pattern file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>Não é possível abrir o arquivo de padrão %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -5696,10 +5696,6 @@ Doriți să salvați modificările?</translation>
         <translation>Fișierul de măsurători &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; nu a putut fi găsit. Doriți să actualizați locația fișierului?</translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation>Măsurătorile au fost modificate. Doriți să sincronizați măsurătorile acum?</translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>Gradația nu acceptă inci</translation>
     </message>
@@ -7944,10 +7940,6 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
         <translation>Numărătoare:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation>Selectați obiectele principale ale căii în sensul acelor de ceasornic. Folosiți &lt;b&gt;SHIFT&lt;/b&gt; pentru a inversa direcția curbei sau &lt;b&gt;CTRL&lt;/b&gt; pentru a păstra direcția curbei.</translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation>Apăsați OK pentru a crea piesa din model</translation>
     </message>
@@ -8174,6 +8166,10 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translation>Apăsați &lt;b&gt;ENTER&lt;/b&gt; pentru a finaliza crearea piesei.</translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Selectați obiectele principale ale căii în sensul acelor de ceasornic. Folosiți &lt;b&gt;SHIFT&lt;/b&gt; pentru a inversa direcția curbei sau &lt;b&gt;CTRL&lt;/b&gt; pentru a păstra direcția curbei.</translation>
     </message>
 </context>
 <context>
@@ -12438,7 +12434,8 @@ load in SeamlyME as usual.
     <message>
         <source>Can&apos;t open pattern file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>Nu se poate deschide fișierul de model %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -8173,7 +8173,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation>Выберите объекты основного контура по часовой стрелке. Используйте &lt;b&gt;SHIFT&lt;/b&gt;, чтобы изменить направление кривой, или &lt;b&gt;CTRL&lt;/b&gt;, чтобы сохранить направление кривой. Нажмите &lt;b&gt;ENTER&lt;/b&gt;, чтобы завершить создание детали </translation>
+        <translation>Выберите объекты основного контура по часовой стрелке. Используйте &lt;b&gt;SHIFT&lt;/b&gt;, чтобы изменить направление кривой, или &lt;b&gt;CTRL&lt;/b&gt;, чтобы сохранить направление кривой. Нажмите &lt;b&gt;ENTER&lt;/b&gt;, чтобы завершить создание детали.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -5694,10 +5694,6 @@ Do you want to save your changes?</source>
         <translation>Файл меток &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; не найден. Хотите обновить данные о местоположении файла?</translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation>Мрки были изменены. Хотите обновить мерки сейчас?</translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>Градация не поддерживает дюймы</translation>
     </message>
@@ -7948,10 +7944,6 @@ Press enter to temporarily add it to the list.</source>
         <translation>Число:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
-        <translation>Выберите объекты основного контура по часовой стрелке. Используйте &lt;b&gt;SHIFT&lt;/b&gt;, чтобы изменить направление кривой, или &lt;b&gt;CTRL&lt;/b&gt;, чтобы сохранить направление кривой. Нажмите &lt;b&gt;ENTER&lt;/b&gt;, чтобы завершить создание детали </translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation>Нажмите на ОК, чтобы создать выкройку</translation>
     </message>
@@ -8177,7 +8169,11 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
-        <translation type="unfinished"></translation>
+        <translation>Нажмите &lt;b&gt;ENTER&lt;/b&gt;, чтобы завершить создание элемента.</translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Выберите объекты основного контура по часовой стрелке. Используйте &lt;b&gt;SHIFT&lt;/b&gt;, чтобы изменить направление кривой, или &lt;b&gt;CTRL&lt;/b&gt;, чтобы сохранить направление кривой. Нажмите &lt;b&gt;ENTER&lt;/b&gt;, чтобы завершить создание детали </translation>
     </message>
 </context>
 <context>
@@ -12444,7 +12440,8 @@ load in SeamlyME as usual.
     <message>
         <source>Can&apos;t open pattern file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось открыть файл шаблона %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -5694,10 +5694,6 @@ Do you want to save your changes?</translation>
         <translation>Ölçüm dosyası &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; bulunamadı. Dosya konumunu güncellemek ister misiniz?</translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation>Ölçümler değiştirildi. Ölçümleri şimdi senkronize etmek ister misiniz?</translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>Dereceleme inçleri desteklemiyor</translation>
     </message>
@@ -7942,10 +7938,6 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
         <translation>Sayım:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation>Ana yol nesnelerini saat yönünde seçin. Eğri yönünü tersine çevirmek için &lt;b&gt;SHIFT&lt;/b&gt;&apos;i veya eğri yönünü korumak için &lt;b&gt;CTRL&lt;/b&gt;&apos;yi kullanın.</translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation>Desen parçasını oluşturmak için Tamam&apos;a basın</translation>
     </message>
@@ -8172,6 +8164,10 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translation>Parça oluşturmayı tamamlamak için &lt;b&gt;ENTER&lt;/b&gt;&apos;a basın.</translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Ana yol nesnelerini saat yönünde seçin. Eğri yönünü tersine çevirmek için &lt;b&gt;SHIFT&lt;/b&gt;&apos;i veya eğri yönünü korumak için &lt;b&gt;CTRL&lt;/b&gt;&apos;yi kullanın.</translation>
     </message>
 </context>
 <context>
@@ -12436,7 +12432,8 @@ load in SeamlyME as usual.
     <message>
         <source>Can&apos;t open pattern file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>Desen dosyası %1 açılamıyor:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -5695,10 +5695,6 @@ Do you want to save your changes?</source>
         <translation>Файл мірок &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; не вдалося знайти. Ви хочете оновити місце знаходження?</translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation>Мірки були змінені. Бажаєте синхронізувати мірки зараз?</translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>Програма не підтримує стандарнту таблицю з дюймами</translation>
     </message>
@@ -7943,10 +7939,6 @@ Press enter to temporarily add it to the list.</source>
         <translation>Αριθμός:</translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation>Επιλέξτε αντικείμενα κύριας διαδρομής δεξιόστροφα, χρησιμοποιήστε το &lt;b&gt;SHIFT&lt;/b&gt; για να αντιστρέψετε την κατεύθυνση της καμπύλης ή το &lt;b&gt;CTRL&lt;/b&gt; για να διατηρήσετε την κατεύθυνση της καμπύλης.</translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation>Πατήστε OK για να δημιουργήσετε το κομμάτι του πατρόν</translation>
     </message>
@@ -8173,6 +8165,10 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translation>Πατήστε το &lt;b&gt;ENTER&lt;/b&gt; για να ολοκληρώσετε τη δημιουργία κομματιών.</translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation>Επιλέξτε αντικείμενα κύριας διαδρομής δεξιόστροφα, χρησιμοποιήστε το &lt;b&gt;SHIFT&lt;/b&gt; για να αντιστρέψετε την κατεύθυνση της καμπύλης ή το &lt;b&gt;CTRL&lt;/b&gt; για να διατηρήσετε την κατεύθυνση της καμπύλης.</translation>
     </message>
 </context>
 <context>
@@ -12437,7 +12433,8 @@ load in SeamlyME as usual.
     <message>
         <source>Can&apos;t open pattern file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>Не вдається відкрити файл візерунка %1:
+%2.</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -5659,10 +5659,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Measurements were changed. Do you want to sync measurements now?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Gradation doesn&apos;t support inches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7906,10 +7902,6 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8135,6 +8127,10 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -127,6 +127,7 @@
 #include <QSettings>
 #include <QSharedPointer>
 #include <QShowEvent>
+#include <QStatusBar>
 #include <QTextCodec>
 #include <QTimer>
 #include <QToolBar>
@@ -173,7 +174,6 @@ MainWindow::MainWindow(QWidget *parent)
     , m_statusMessage(new QLabel())
     , isInitialized(false)
     , mChanges(false)
-    , mChangesAsked(true)
     , patternReadOnly(false)
     , dialogTable(nullptr)
     , dialogTool()
@@ -293,33 +293,7 @@ MainWindow::MainWindow(QWidget *parent)
         connect(ui->listWidget, &QListWidget::currentRowChanged, this, &MainWindow::showLayoutPages);
 
         // Handle changes made to a measurment file.
-        connect(watcher, &QFileSystemWatcher::fileChanged, this, &MainWindow::MeasurementsChanged);
-
-        // Sync measurements if they were changed.
-        connect(qApp, &QApplication::focusChanged, this, [this](QWidget *old, QWidget *now)
-        {
-            if (old == nullptr && isAncestorOf(now) == true)
-            {   // Focus IN
-                static bool asking = false;
-                if (!asking && mChanges && !mChangesAsked)
-                {
-                    asking = true;
-                    mChangesAsked = true;
-                    const auto answer = QMessageBox::question(this, tr("Measurements"),
-                                                            tr("Measurements were changed. Do you want to sync measurements now?"),
-                                                            QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
-                    if (answer == QMessageBox::Yes)
-                    {
-                        SyncMeasurements();
-                    }
-                    asking = false;
-                }
-            }
-
-            // In case we will need it
-            // else if (isAncestorOf(old) == true && now == nullptr)
-            // focus OUT
-        });
+        connect(watcher, &QFileSystemWatcher::fileChanged, this, &MainWindow::measurementsChanged);
 
         #if defined(Q_OS_MAC)
             // Set MacOS specific icon sizes for various toolbars and unify title and toolbar.
@@ -1919,7 +1893,7 @@ void MainWindow::changeEvent(QEvent *event)
             ui->groups_DockWidget->setWindowTitle(tr("Pattern Pieces"));
         }
 
-        UpdateWindowTitle();
+        updateWindowTitle();
         initPenToolBar();
         initBasePointComboBox();
         emit pieceScene->LanguageChanged();
@@ -2095,7 +2069,7 @@ void MainWindow::LoadIndividual()
             setStatusMessage(tr("Measurements loaded"));
             doc->LiteParseTree(Document::LiteParse);
 
-            UpdateWindowTitle();
+            updateWindowTitle();
         }
     }
 
@@ -2151,7 +2125,7 @@ void MainWindow::LoadMultisize()
             setStatusMessage(tr("Measurements loaded"));
             doc->LiteParseTree(Document::LiteParse);
 
-            UpdateWindowTitle();
+            updateWindowTitle();
 
             if (qApp->patternType() == MeasurementsType::Multisize)
             {
@@ -2193,7 +2167,7 @@ void MainWindow::UnloadMeasurements()
         ui->unloadMeasurements_Action->setDisabled(true);
         setStatusMessage(tr("Measurements unloaded"));
 
-        UpdateWindowTitle();
+        updateWindowTitle();
     }
     else
     {
@@ -2203,11 +2177,15 @@ void MainWindow::UnloadMeasurements()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void MainWindow::ShowMeasurements()
+void MainWindow::editMeasurements()
 {
+
     if (!doc->MPath().isEmpty())
     {
         const QString absoluteMPath = AbsoluteMPath(qApp->getFilePath(), doc->MPath());
+
+        // Stop watching file while opening SeamlyMe so as to not trigger syncing.
+        watcher->removePath(absoluteMPath);
 
         QStringList arguments;
         if (qApp->patternType() == MeasurementsType::Multisize)
@@ -2236,6 +2214,13 @@ void MainWindow::ShowMeasurements()
         const QString seamlyme = qApp->seamlyMeFilePath();
         const QString workingDirectory = QFileInfo(seamlyme).absoluteDir().absolutePath();
         QProcess::startDetached(seamlyme, arguments, workingDirectory);
+
+        if (!watcher->files().contains(absoluteMPath))
+        {
+            // Allow time for SeamlyMe to open before watching file again.
+            std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+            watcher->addPath(absoluteMPath);
+        }
     }
     else
     {
@@ -2244,23 +2229,22 @@ void MainWindow::ShowMeasurements()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void MainWindow::MeasurementsChanged(const QString &path)
+void MainWindow::measurementsChanged(const QString &path)
 {
     mChanges = false;
     QFileInfo checkFile(path);
     if (checkFile.exists())
     {
         mChanges = true;
-        mChangesAsked = false;
     }
     else
     {
+        // Check every 10ms for upto 10 secs to see if file is done writing.
         for(int i=0; i<=1000; i=i+10)
         {
             if (checkFile.exists())
             {
                 mChanges = true;
-                mChangesAsked = false;
                 break;
             }
             else
@@ -2270,36 +2254,38 @@ void MainWindow::MeasurementsChanged(const QString &path)
         }
     }
 
-    UpdateWindowTitle();
-    ui->syncMeasurements_Action->setEnabled(mChanges);
+    if (mChanges)
+    {
+        syncMeasurements();
+    }
+    updateWindowTitle();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void MainWindow::SyncMeasurements()
+void MainWindow::syncMeasurements()
 {
-    if (mChanges)
+    const QString path = AbsoluteMPath(qApp->getFilePath(), doc->MPath());
+
+    // Stop watching measurement file while updating to avoid recursive syncing.
+    watcher->removePath(path);
+
+    if(updateMeasurements(path, static_cast<int>(VContainer::size()), static_cast<int>(VContainer::height())))
     {
-        const QString path = AbsoluteMPath(qApp->getFilePath(), doc->MPath());
-        if(updateMeasurements(path, static_cast<int>(VContainer::size()), static_cast<int>(VContainer::height())))
-        {
-            if (!watcher->files().contains(path))
-            {
-                watcher->addPath(path);
-            }
-            const QString msg = tr("Measurements have been synced");
-            qCDebug(vMainWindow, "%s", qUtf8Printable(msg));
-            setStatusMessage(msg);
-            VWidgetPopup::PopupMessage(this, msg);
-            doc->LiteParseTree(Document::LiteParse);
-            mChanges = false;
-            mChangesAsked = true;
-            UpdateWindowTitle();
-            ui->syncMeasurements_Action->setEnabled(mChanges);
-        }
-        else
-        {
-            qCWarning(vMainWindow, "%s", qUtf8Printable(tr("Couldn't sync measurements.")));
-        }
+        setStatusMessage(tr("Measurements have been synced"));
+        QApplication::beep();
+        doc->LiteParseTree(Document::LiteParse);
+        mChanges = false;
+        updateWindowTitle();
+    }
+    else
+    {
+        qCWarning(vMainWindow, "%s", qUtf8Printable(tr("Couldn't sync measurements.")));
+    }
+
+    if (!watcher->files().contains(path))
+    {
+        // Start watching measurement file again.
+        watcher->addPath(path);
     }
 }
 
@@ -5252,7 +5238,7 @@ void MainWindow::setCurrentFile(const QString &fileName)
         settings->SetRestoreFileList(restoreFiles);
     }
 
-    UpdateWindowTitle();
+    updateWindowTitle();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -6241,11 +6227,10 @@ void MainWindow::createActions()
         QProcess::startDetached(seamlyme, arguments, workingDirectory);
     });
 
-    connect(ui->editCurrent_Action, &QAction::triggered, this, &MainWindow::ShowMeasurements);
+    connect(ui->editCurrent_Action, &QAction::triggered, this, &MainWindow::editMeasurements);
     connect(ui->unloadMeasurements_Action, &QAction::triggered, this, &MainWindow::UnloadMeasurements);
     connect(ui->loadIndividual_Action, &QAction::triggered, this, &MainWindow::LoadIndividual);
     connect(ui->loadMultisize_Action, &QAction::triggered, this, &MainWindow::LoadMultisize);
-    connect(ui->syncMeasurements_Action, &QAction::triggered, this, &MainWindow::SyncMeasurements);
     connect(ui->table_Action, &QAction::triggered, this, [this](bool checked)
     {
         if (checked)
@@ -7210,7 +7195,7 @@ QString MainWindow::checkPathToMeasurements(const QString &patternPath, const QS
                             const bool result = measurements->SaveDocument(filename, error);
                             if (result)
                             {
-                                UpdateWindowTitle();
+                                updateWindowTitle();
                             }
                         }
                         measurements->setXMLContent(filename);// Read again after conversion
@@ -7226,7 +7211,7 @@ QString MainWindow::checkPathToMeasurements(const QString &patternPath, const QS
                             const bool result = measurements->SaveDocument(filename, error);
                             if (result)
                             {
-                                UpdateWindowTitle();
+                                updateWindowTitle();
                             }
                         }
                         measurements->setXMLContent(filename);// Read again after conversion
@@ -7274,6 +7259,8 @@ void MainWindow::changeDraftBlock(int index, bool zoomBestFit)
     }
 }
 
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief EndVisualization try show dialog after and working with tool visualization.
 //---------------------------------------------------------------------------------------------------------------------
 void MainWindow::EndVisualization(bool click)
 {
@@ -7566,20 +7553,13 @@ QString MainWindow::GetMeasurementFileName()
     else
     {
         QString shownName(" - [");
-        shownName += strippedName(AbsoluteMPath(qApp->getFilePath(), doc->MPath()));
-
-        if(mChanges)
-        {
-            shownName += QLatin1String("*");
-        }
-
-        shownName += QLatin1String("]");
+        shownName += strippedName(AbsoluteMPath(qApp->getFilePath(), doc->MPath())) + QLatin1String("]");
         return shownName;
     }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void MainWindow::UpdateWindowTitle()
+void MainWindow::updateWindowTitle()
 {
     bool isFileWritable = true;
     if (!qApp->getFilePath().isEmpty())

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -269,9 +269,9 @@ private slots:
     void LoadIndividual();
     void LoadMultisize();
     void UnloadMeasurements();
-    void ShowMeasurements();
-    void MeasurementsChanged(const QString &path);
-    void SyncMeasurements();
+    void editMeasurements();
+    void measurementsChanged(const QString &path);
+    void syncMeasurements();
 #if defined(Q_OS_MAC)
     void OpenAt(QAction *where);
 #endif //defined(Q_OS_MAC)
@@ -281,38 +281,18 @@ private slots:
 
 private:
     Q_DISABLE_COPY(MainWindow)
-    /** @brief ui keeps information about user interface */
-    Ui::MainWindow                   *ui;
 
+    Ui::MainWindow                   *ui;              /// @brief ui keeps information about user interface.
     QFileSystemWatcher               *watcher;
-
-    /** @brief tool current tool */
-    Tool                              currentTool;
-
-    /** @brief tool last used tool */
-    Tool                              lastUsedTool;
-
-    /** @brief draftScene draft block scene. */
-    VMainGraphicsScene               *draftScene;
-
-    /** @brief pieceScene pattern piece scene. */
-    VMainGraphicsScene               *pieceScene;
-
-    /** @brief mouseCoordinates pointer to label who show mouse coordinate. */
-    QPointer<MouseCoordinates>        mouseCoordinates;
-
+    Tool                              currentTool;     /// @brief tool current tool.
+    Tool                              lastUsedTool;    /// @brief tool last used tool.
+    VMainGraphicsScene               *draftScene;      /// @brief draftScene draft block scene.
+    VMainGraphicsScene               *pieceScene;      /// @brief pieceScene pattern piece scene.
+    QPointer<MouseCoordinates>        mouseCoordinates;/// @brief pointer to mouse coordinates label.
     QPointer<QToolButton>             infoToolButton;
-
-    /** @brief helpLabel help show tooltip. */
-    QLabel                           *m_statusMessage;
-
-    /** @brief isInitialized true after first show window. */
-    bool                              isInitialized;
-
-    /** @brief mChanges true if measurement file was changed. */
-    bool                              mChanges;
-    bool                              mChangesAsked;
-
+    QLabel                           *m_statusMessage; /// @brief helpLabel help show tooltip.
+    bool                              isInitialized;   /// @brief isInitialized true after first show window.
+    bool                              mChanges;        /// @brief mChanges true if measurement file was changed.
     bool                              patternReadOnly;
 
     QPointer<DialogVariables>         dialogTable;
@@ -322,15 +302,15 @@ private:
     QFontComboBox                    *fontComboBox;
     QComboBox                        *fontSizeComboBox;
     QComboBox                        *basePointComboBox;
-    QComboBox                        *draftBlockComboBox;  /** @brief draftBlockComboBox stores names of draft blocks.*/
+    QComboBox                        *draftBlockComboBox;  /// @brief draftBlockComboBox stores names of draft blocks.
     QLabel                           *draftBlockLabel;
-    qint32                            currentBlockIndex;   /** @brief currentBlockIndex  current selected draft block.*/
-    qint32                            currentToolBoxIndex; /** @brief currentToolBoxIndex  current set of tools. */
+    qint32                            currentBlockIndex;   /// @brief currentBlockIndex  current selected draft block.
+    qint32                            currentToolBoxIndex; /// @brief currentToolBoxIndex  current set of tools.
     bool                              isToolOptionsDockVisible;
     bool                              isGroupsDockVisible;
     bool                              isLayoutsDockVisible;
     bool                              isToolboxDockVisible;
-    bool                              drawMode;            /** @brief drawMode true if draft scene active. */
+    bool                              drawMode;            /// @brief drawMode true if draft scene active.
 
     enum { MaxRecentFiles = 5 };
     QAction                          *recentFileActs[MaxRecentFiles];
@@ -351,7 +331,7 @@ private:
 
     QDoubleSpinBox                   *zoomScaleSpinBox;
 
-    PenToolBar                       *m_penToolBar; //!< for selecting the current pen
+    PenToolBar                       *m_penToolBar;        /// @brief pointer to the current pen.
     PenToolBar                       *m_penReset;
     QComboBox                        *m_zoomToPointComboBox;
 
@@ -437,9 +417,6 @@ private:
     QString            createDraftBlockName(const QString &text);
     QString            checkPathToMeasurements(const QString &patternPath, const QString &path);
     void               changeDraftBlock(int index, bool zoomBestFit = true);
-    /**
-     * @brief EndVisualization try show dialog after and working with tool visualization.
-     */
     void               EndVisualization(bool click = false);
     void               zoomFirstShow();
     void               UpdateHeightsList(const QStringList &list);
@@ -470,7 +447,7 @@ private:
     QString            GetPatternFileName();
     QString            GetMeasurementFileName();
 
-    void               UpdateWindowTitle();
+    void               updateWindowTitle();
     void               upDateScenes();
     void               updateViewToolbar();
     void               resetPanShortcuts();

--- a/src/app/seamly2d/mainwindow.ui
+++ b/src/app/seamly2d/mainwindow.ui
@@ -133,7 +133,6 @@
     <addaction name="unloadMeasurements_Action"/>
     <addaction name="loadIndividual_Action"/>
     <addaction name="loadMultisize_Action"/>
-    <addaction name="syncMeasurements_Action"/>
     <addaction name="table_Action"/>
     <addaction name="exportVariablesToCSV_Action"/>
    </widget>
@@ -373,7 +372,6 @@
    <addaction name="actionNew"/>
    <addaction name="actionOpen"/>
    <addaction name="save_Action"/>
-   <addaction name="syncMeasurements_Action"/>
   </widget>
   <widget class="QToolBar" name="mode_ToolBar">
    <property name="enabled">
@@ -4829,8 +4827,8 @@
  </customwidgets>
  <resources>
   <include location="share/resources/toolicon.qrc"/>
-  <include location="../../libs/vmisc/share/resources/theme.qrc"/>
   <include location="../../libs/vmisc/share/resources/icon.qrc"/>
+  <include location="../../libs/vmisc/share/resources/theme.qrc"/>
  </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
The PR addresses the repeating syncing of the measurements.

- Fixes the recursion causing Seamly2D to constantly resync measurements.

- Removes the Sync dialog and Sync Tool button / action which have no real use other than delaying syncing the measurements. The measurements will now automatically sync when ever changes to the current measurements are saved.

- Status message is displayed that measurements have been synced. 

     <img width="202" height="33" alt="image" src="https://github.com/user-attachments/assets/e62e10c3-a451-4b79-a6be-11796e26c698" />

closes issue #1432 