### PR TITLE
Replace QTextCodec with Qt6 QStringConverter

### DIFF
--- a/src/app/seamly2d/dialogs/about2d_dialog.cpp
+++ b/src/app/seamly2d/dialogs/about2d_dialog.cpp
@@ -63,7 +63,7 @@
 #include <QSoundEffect>
 #include <QSysInfo>
 #include <QtDebug>
-#include <QTextCodec>
+#include <QStringConverter>
 
 #include "../options.h"
 #include "../core/application_2d.h"
@@ -175,7 +175,8 @@ About2DAppDialog::About2DAppDialog(QWidget *parent)
     }
 
     ui->sysLocalDirection_value->setText(direction);
-    ui->sysCodec_value->setText(QTextCodec::codecForLocale()->name());
+    // Qt6 uses UTF-8 internally as the default encoding
+    ui->sysCodec_value->setText(QStringLiteral("UTF-8"));
     ui->sysArguments_value->setText(QCoreApplication::arguments().join(","));
 }
 

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -113,7 +113,6 @@
 #include <QAction>
 #include <QComboBox>
 #include <QFontComboBox>
-#include <QtCore5Compat/QTextCodec>
 #include <QDoubleSpinBox>
 #include <QFileDialog>
 #include <QFileSystemWatcher>
@@ -128,7 +127,7 @@
 #include <QSharedPointer>
 #include <QShowEvent>
 #include <QStatusBar>
-#include <QTextCodec>
+#include <QStringConverter>
 #include <QTimer>
 #include <QToolBar>
 #include <QtDebug>
@@ -2013,7 +2012,7 @@ void MainWindow::exportToCSVData(const QString &fileName, const DialogExportToCS
         csv.setText(currentRow, 2, formula); // formula
     }
 
-    csv.toCSV(fileName, dialog.WithHeader(), dialog.Separator(), QTextCodec::codecForMib(dialog.SelectedMib()));
+    csv.toCSV(fileName, dialog.WithHeader(), dialog.Separator(), dialog.SelectedEncoding());
 }
 
 void MainWindow::handleExportToCSV()

--- a/src/app/seamlyme/tmainwindow.cpp
+++ b/src/app/seamlyme/tmainwindow.cpp
@@ -90,7 +90,7 @@
 #include <QPrintPreviewDialog>
 #include <QProcess>
 #include <QtNumeric>
-#include <QtCore5Compat/QTextCodec>
+#include <QStringConverter>
 
 #if defined(Q_OS_MAC)
 #include <QMimeData>
@@ -830,7 +830,7 @@ void TMainWindow::exportToCSVData(const QString &fileName, const DialogExportToC
 		}
 	}
 
-	csv.toCSV(fileName, dialog.WithHeader(), dialog.Separator(), QTextCodec::codecForMib(dialog.SelectedMib()));
+	csv.toCSV(fileName, dialog.WithHeader(), dialog.Separator(), dialog.SelectedEncoding());
 }
 
 void TMainWindow::handleExportToCSV()

--- a/src/libs/vmisc/dialogs/dialogexporttocsv.cpp
+++ b/src/libs/vmisc/dialogs/dialogexporttocsv.cpp
@@ -61,7 +61,28 @@
 
 #include <QPushButton>
 #include <QShowEvent>
-#include <QtCore5Compat/QTextCodec>
+#include <QStringConverter>
+
+namespace
+{
+// Helper function to get encoding name as QString
+QString encodingName(QStringConverter::Encoding encoding)
+{
+    switch (encoding)
+    {
+        case QStringConverter::Utf8: return QStringLiteral("UTF-8");
+        case QStringConverter::Utf16: return QStringLiteral("UTF-16");
+        case QStringConverter::Utf16BE: return QStringLiteral("UTF-16BE");
+        case QStringConverter::Utf16LE: return QStringLiteral("UTF-16LE");
+        case QStringConverter::Utf32: return QStringLiteral("UTF-32");
+        case QStringConverter::Utf32BE: return QStringLiteral("UTF-32BE");
+        case QStringConverter::Utf32LE: return QStringLiteral("UTF-32LE");
+        case QStringConverter::Latin1: return QStringLiteral("ISO-8859-1");
+        case QStringConverter::System: return QStringLiteral("System");
+        default: return QStringLiteral("UTF-8");
+    }
+}
+} // anonymous namespace
 
 //---------------------------------------------------------------------------------------------------------------------
 DialogExportToCSV::DialogExportToCSV(QWidget *parent)
@@ -74,9 +95,22 @@ DialogExportToCSV::DialogExportToCSV(QWidget *parent)
 
     ui->checkBoxWithHeader->setChecked(qApp->Settings()->GetCSVWithHeader());
 
-    foreach (int mib, QTextCodec::availableMibs())
+    // Populate combo box with available QStringConverter encodings
+    const QList<QStringConverter::Encoding> encodings = {
+        QStringConverter::Utf8,
+        QStringConverter::Utf16,
+        QStringConverter::Utf16BE,
+        QStringConverter::Utf16LE,
+        QStringConverter::Utf32,
+        QStringConverter::Utf32BE,
+        QStringConverter::Utf32LE,
+        QStringConverter::Latin1,
+        QStringConverter::System
+    };
+
+    for (const QStringConverter::Encoding encoding : encodings)
     {
-        ui->comboBoxCodec->addItem(QTextCodec::codecForMib(mib)->name(), mib);
+        ui->comboBoxCodec->addItem(encodingName(encoding), static_cast<int>(encoding));
     }
 
     ui->comboBoxCodec->setCurrentIndex(ui->comboBoxCodec->findData(qApp->Settings()->GetCSVCodec()));
@@ -107,9 +141,9 @@ bool DialogExportToCSV::WithHeader() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-int DialogExportToCSV::SelectedMib() const
+QStringConverter::Encoding DialogExportToCSV::SelectedEncoding() const
 {
-    return ui->comboBoxCodec->currentData().toInt();
+    return static_cast<QStringConverter::Encoding>(ui->comboBoxCodec->currentData().toInt());
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vmisc/dialogs/dialogexporttocsv.h
+++ b/src/libs/vmisc/dialogs/dialogexporttocsv.h
@@ -57,6 +57,7 @@
 #define DIALOGEXPORTTOCSV_H
 
 #include <QDialog>
+#include <QStringConverter>
 
 namespace Ui {
 class DialogExportToCSV;
@@ -71,7 +72,7 @@ public:
     virtual               ~DialogExportToCSV();
 
     bool                   WithHeader() const;
-    int                    SelectedMib() const;
+    QStringConverter::Encoding SelectedEncoding() const;
     QChar                  Separator() const;
 
 protected:

--- a/src/libs/vmisc/qxtcsvmodel.cpp
+++ b/src/libs/vmisc/qxtcsvmodel.cpp
@@ -175,16 +175,17 @@ QVariant QxtCsvModel::headerData(int section, Qt::Orientation orientation, int r
 /*!
   \overload
 
-  Reads in a CSV file from the provided \a file using \a codec.
+  Reads in a CSV file from the provided \a file using \a encoding.
   */
-void QxtCsvModel::setSource(const QString &filename, bool withHeader, QChar separator, QTextCodec* codec)
+void QxtCsvModel::setSource(const QString &filename, bool withHeader, QChar separator,
+                            std::optional<QStringConverter::Encoding> encoding)
 {
     QFile src(filename);
-    setSource(&src, withHeader, separator, codec);
+    setSource(&src, withHeader, separator, encoding);
 }
 
 /*!
-  Reads in a CSV file from the provided \a file using \a codec.
+  Reads in a CSV file from the provided \a file using \a encoding.
 
   The value of \a separator will be used to delimit fields, subject to the specified \a quoteMode.
   If \a withHeader is set to true, the first line of the file will be used to populate the model's
@@ -192,7 +193,8 @@ void QxtCsvModel::setSource(const QString &filename, bool withHeader, QChar sepa
 
   \sa quoteMode
   */
-void QxtCsvModel::setSource(QIODevice *file, bool withHeader, QChar separator, QTextCodec* codec)
+void QxtCsvModel::setSource(QIODevice *file, bool withHeader, QChar separator,
+                            std::optional<QStringConverter::Encoding> encoding)
 {
     QxtCsvModelPrivate* d_ptr = &qxt_d();
     bool headerSet = !withHeader;
@@ -215,10 +217,9 @@ void QxtCsvModel::setSource(QIODevice *file, bool withHeader, QChar separator, Q
     QChar ch, buffer(0);
     bool readCR = false;
     QTextStream stream(file);
-    std::optional<QStringConverter::Encoding> text_encoding = QStringConverter::encodingForName(codec->name());
-    if (text_encoding.has_value())
+    if (encoding.has_value())
     {
-        stream.setEncoding(text_encoding.value());
+        stream.setEncoding(encoding.value());
     }
     else
     {
@@ -587,13 +588,14 @@ static QString qxt_addCsvQuotes(QxtCsvModel::QuoteMode mode, QString field)
 }
 
 /*!
-  Outputs the content of the model as a CSV file to the device \a dest using \a codec.
+  Outputs the content of the model as a CSV file to the device \a dest using \a encoding.
 
   Fields in the output file will be separated by \a separator. Set \a withHeader to true
   to output a row of headers at the top of the file.
  */
 // cppcheck-suppress funcArgNamesDifferent
-void QxtCsvModel::toCSV(QIODevice* dest, bool withHeader, QChar separator, QTextCodec* codec) const
+void QxtCsvModel::toCSV(QIODevice* dest, bool withHeader, QChar separator,
+                        std::optional<QStringConverter::Encoding> encoding) const
 {
     const QxtCsvModelPrivate& d_ptr = qxt_d();
     int row, col, rows, cols;
@@ -605,10 +607,14 @@ void QxtCsvModel::toCSV(QIODevice* dest, bool withHeader, QChar separator, QText
         dest->open(QIODevice::WriteOnly | QIODevice::Truncate);
     }
     QTextStream stream(dest);
-    std::optional<QStringConverter::Encoding> text_encoding = QStringConverter::encodingForName(codec->name());
-    if (text_encoding.has_value())
+    if (encoding.has_value())
     {
-        stream.setEncoding(text_encoding.value());
+        stream.setEncoding(encoding.value());
+    }
+    else
+    {
+        // Default to UTF-8 for consistent output encoding
+        stream.setEncoding(QStringConverter::Utf8);
     }
     if (withHeader)
     {
@@ -651,15 +657,16 @@ void QxtCsvModel::toCSV(QIODevice* dest, bool withHeader, QChar separator, QText
 /*!
   \overload
 
-  Outputs the content of the model as a CSV file to the file specified by \a filename using \a codec.
+  Outputs the content of the model as a CSV file to the file specified by \a filename using \a encoding.
 
   Fields in the output file will be separated by \a separator. Set \a withHeader to true
   to output a row of headers at the top of the file.
  */
-void QxtCsvModel::toCSV(const QString &filename, bool withHeader, QChar separator, QTextCodec* codec) const
+void QxtCsvModel::toCSV(const QString &filename, bool withHeader, QChar separator,
+                        std::optional<QStringConverter::Encoding> encoding) const
 {
     QFile dest(filename);
-    toCSV(&dest, withHeader, separator, codec);
+    toCSV(&dest, withHeader, separator, encoding);
 }
 
 /*!

--- a/src/libs/vmisc/qxtcsvmodel.h
+++ b/src/libs/vmisc/qxtcsvmodel.h
@@ -42,10 +42,12 @@
 #include <QObject>
 #include <QString>
 #include <QStringList>
+#include <QStringConverter>
 #include <QVariant>
 #include <Qt>
 #include <QtGlobal>
-#include <QtCore5Compat/QTextCodec>
+
+#include <optional>
 
 #include "def.h"
 
@@ -90,13 +92,15 @@ public:
     bool removeColumn(int col, const QModelIndex& parent = QModelIndex());
     virtual bool removeColumns(int col, int count, const QModelIndex& parent = QModelIndex()) override;
 
-    void setSource(QIODevice *file, bool withHeader = false, QChar separator = ',', QTextCodec* codec = nullptr);
+    void setSource(QIODevice *file, bool withHeader = false, QChar separator = ',',
+                   std::optional<QStringConverter::Encoding> encoding = std::nullopt);
     void setSource(const QString &filename, bool withHeader = false, QChar separator = ',',
-                   QTextCodec* codec = nullptr);
+                   std::optional<QStringConverter::Encoding> encoding = std::nullopt);
 
-    void toCSV(QIODevice *file, bool withHeader = false, QChar separator = ',', QTextCodec* codec = nullptr) const;
+    void toCSV(QIODevice *file, bool withHeader = false, QChar separator = ',',
+               std::optional<QStringConverter::Encoding> encoding = std::nullopt) const;
     void toCSV(const QString &filename, bool withHeader = false, QChar separator = ',',
-               QTextCodec* codec = nullptr) const;
+               std::optional<QStringConverter::Encoding> encoding = std::nullopt) const;
 
     enum QuoteOption { NoQuotes = 0,
                        SingleQuote = 1,

--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -60,9 +60,9 @@
 #include <QLocale>
 #include <QMessageLogger>
 #include <QString>
+#include <QStringConverter>
 #include <QVariant>
 #include <QtDebug>
-#include <QtCore5Compat/QTextCodec>
 
 #include "../ifc/ifcdef.h"
 #include "../vmisc/def.h"
@@ -1765,9 +1765,12 @@ int VCommonSettings::GetCSVCodec() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+// Returns the default encoding as a QStringConverter::Encoding value cast to int.
+// Previously used QTextCodec MIB values, now stores QStringConverter::Encoding enum values.
 int VCommonSettings::GetDefCSVCodec() const
 {
-    return QTextCodec::codecForLocale()->mibEnum();
+    // Default to UTF-8 encoding (Qt6 default)
+    return static_cast<int>(QStringConverter::Utf8);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -1751,26 +1751,26 @@ bool VCommonSettings::GetDefCSVWithHeader() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VCommonSettings::SetCSVCodec(int mib)
+void VCommonSettings::SetCSVCodec(QStringConverter::Encoding encoding)
 {
     QSettings settings(this->format(), this->scope(), this->organizationName(), commonIniFilename);
-    settings.setValue(settingCSVCodec, mib);
+    settings.setValue(settingCSVCodec, encoding);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-int VCommonSettings::GetCSVCodec() const
+QStringConverter::Encoding VCommonSettings::GetCSVCodec() const
 {
     QSettings settings(this->format(), this->scope(), this->organizationName(), commonIniFilename);
-    return settings.value(settingCSVCodec, GetDefCSVCodec()).toInt();
+    return settings.value(settingCSVCodec, GetDefCSVCodec()).value<QStringConverter::Encoding>();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 // Returns the default encoding as a QStringConverter::Encoding value cast to int.
 // Previously used QTextCodec MIB values, now stores QStringConverter::Encoding enum values.
-int VCommonSettings::GetDefCSVCodec() const
+QStringConverter::Encoding VCommonSettings::GetDefCSVCodec() const
 {
     // Default to UTF-8 encoding (Qt6 default)
-    return static_cast<int>(QStringConverter::Utf8);
+    return QStringConverter::Utf8;
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vmisc/vcommonsettings.h
+++ b/src/libs/vmisc/vcommonsettings.h
@@ -389,9 +389,9 @@ public:
     bool                 GetCSVWithHeader() const;
     bool                 GetDefCSVWithHeader() const;
 
-    void                 SetCSVCodec(int mib);
-    int                  GetCSVCodec() const;
-    int                  GetDefCSVCodec() const;
+    void                 SetCSVCodec(QStringConverter::Encoding encoding);
+    QStringConverter::Encoding                  GetCSVCodec() const;
+    QStringConverter::Encoding                  GetDefCSVCodec() const;
 
     void                 SetCSVSeparator(const QChar &separator);
     QChar                GetCSVSeparator() const;

--- a/src/libs/vwidgets/vabstractmainwindow.cpp
+++ b/src/libs/vwidgets/vabstractmainwindow.cpp
@@ -143,7 +143,7 @@ void VAbstractMainWindow::exportToCSV(QString &file)
         exportToCSVData(fileName, dialog);
 
         qApp->Settings()->SetCSVSeparator(dialog.Separator());
-        qApp->Settings()->SetCSVCodec(dialog.SelectedMib());
+        qApp->Settings()->SetCSVCodec(dialog.SelectedEncoding());
         qApp->Settings()->SetCSVWithHeader(dialog.WithHeader());
     }
 }


### PR DESCRIPTION
- Update qxtcsvmodel.h/cpp: Replace QTextCodec* parameter with
  std::optional<QStringConverter::Encoding>
- Update dialogexporttocsv.h/cpp: Replace QTextCodec with QStringConverter
  encoding selection, rename SelectedMib() to SelectedEncoding()
- Update vcommonsettings.cpp: Use QStringConverter::Utf8 as default codec
  instead of QTextCodec::codecForLocale()
- Update mainwindow.cpp (seamly2d): Use new SelectedEncoding() API
- Update tmainwindow.cpp (seamlyme): Use new SelectedEncoding() API
- Update about2d_dialog.cpp: Display "UTF-8" instead of system codec name

Co-authored by Github code agent.
