### PR TITLE
Qt6: Qt5 compat module no longer required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           version: ${{ env.QT_VERSION }}
           cache: true
-          modules: qt5compat qtmultimedia
+          modules: qtmultimedia
 
       - name: install build dependencies
         run: |
@@ -95,7 +95,7 @@ jobs:
         with:
           version: ${{ env.QT_VERSION }}
           cache: true
-          modules: qt5compat qtmultimedia
+          modules: qtmultimedia
           
       - name: update version
         run: |
@@ -139,7 +139,7 @@ jobs:
         with:
           version: ${{ env.QT_VERSION }}
           cache: true
-          modules: qt5compat qtmultimedia
+          modules: qtmultimedia
 
       - name: update version
         run: |
@@ -204,7 +204,7 @@ jobs:
         with:
           version: ${{ env.QT_VERSION }}
           cache: true
-          modules: qt5compat qtmultimedia
+          modules: qtmultimedia
 
       - name: update version
         shell: bash

--- a/src/app/seamly2d/seamly2d.pro
+++ b/src/app/seamly2d/seamly2d.pro
@@ -12,7 +12,7 @@ include(../../../common.pri)
 
 # Here we don't see "network" library, but, i think, "printsupport" depend on this library, so we still need this
 # library in installer.
-QT       += core gui widgets xml svg printsupport network core5compat multimedia
+QT       += core gui widgets xml svg printsupport network multimedia
 
 # We want create executable file
 TEMPLATE = app

--- a/src/app/seamlyme/seamlyme.pro
+++ b/src/app/seamlyme/seamlyme.pro
@@ -8,7 +8,7 @@ message("Entering seamlyme.pro")
 # File with common stuff for whole project
 include(../../../common.pri)
 
-QT       += core gui widgets network xml printsupport svg core5compat
+QT       += core gui widgets network xml printsupport svg
 
 # Name of binary file
 TARGET = seamlyme

--- a/src/test/CollectionTest/CollectionTest.pro
+++ b/src/test/CollectionTest/CollectionTest.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += testlib widgets printsupport core5compat
+QT       += testlib widgets printsupport
 
 QT       -= gui
 

--- a/src/test/Seamly2DTest/Seamly2DTest.pro
+++ b/src/test/Seamly2DTest/Seamly2DTest.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += core testlib gui printsupport xml core5compat
+QT       += core testlib gui printsupport xml
 
 TARGET = Seamly2DTests
 

--- a/src/test/TranslationsTest/TranslationsTest.pro
+++ b/src/test/TranslationsTest/TranslationsTest.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += testlib widgets xml printsupport core5compat
+QT       += testlib widgets xml printsupport
 
 QT       -= gui
 


### PR DESCRIPTION
Removed with #1446 and #1447
