### PR TITLE
Qt: Upgrade to current LTS version 6.8

### DIFF
--- a/.github/README-DEVELOPER.md
+++ b/.github/README-DEVELOPER.md
@@ -1,7 +1,7 @@
 # Build Seamly2D
 
 ## Basic Software Prerequisites:  
-* [Qt 6.5.3](https://www.qt.io/download-open-source) (includes Qt, QtCreator, QtChooser, and Qt Maintenance Tool)
+* [Qt 6.8.3](https://www.qt.io/download-open-source) (includes Qt, QtCreator, QtChooser, and Qt Maintenance Tool)
 * [Visual Studio](https://visualstudio.microsoft.com/downloads/) Qt Visual Studio Tools extension - needed to build with MSVC.
 * [Git](https://git-scm.com/downloads) or [Github Desktop for Windows and MacOS](https://desktop.github.com)
 * Compiler - MSVC 2019, gcc, and g++ are included with QtCreator, and you can add or update them using the Qt Maintenance Tool (Maintenance.exe).
@@ -30,7 +30,7 @@ ___________________________________________________
 
   _These instructions apply in general_
 
-* Install Qt 6.5.3, eg via [Qt unified installer](https://www.qt.io/download-qt-installer) or https://github.com/miurahr/aqtinstall
+* Install Qt 6.8.3, eg via [Qt unified installer](https://www.qt.io/download-qt-installer) or https://github.com/miurahr/aqtinstall
 * Install QtCreator https://wiki.qt.io/VendorPackages
 * Install Additional libraries
   - gnu compiler
@@ -66,8 +66,8 @@ ___________________________________________________
       - Select:
         * Custom Installation
         * Qt  - _Minimize your options, otherwise your download size could be in Gs_
-          * Qt 6.5.3
-            * MSVC 2019
+          * Qt 6.8.3
+            * MSVC 2022
             * Qt Debug Information Files
           * Developer and Designer Tools
             * Qt Creator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
   contents: write
 
 env:
-  QT_VERSION: '6.5.3' # quotes required or YAML parser will interpret as float
+  QT_VERSION: '6.8.3' # quotes required or YAML parser will interpret as float
 
 jobs:
 

--- a/out/out.pro
+++ b/out/out.pro
@@ -7,7 +7,7 @@ macx{
     APPLE_NOTARIZE_ISSUER_ID = $(APPLE_NOTARIZE_ISSUER_ID)
 
     seamly2ddmg.target = Seamly2D.dmg
-    seamly2ddmg.commands = hdiutil create -fs HFS+ -srcfolder $${OUT_PWD}/../src/app/seamly2d/bin/Seamly2D.app -volname "Seamly2D" $$seamly2ddmg.target
+    seamly2ddmg.commands = hdiutil create -srcfolder $${OUT_PWD}/../src/app/seamly2d/bin/Seamly2D.app -volname "Seamly2D" $$seamly2ddmg.target
 
     macSign {
         seamly2ddmg.commands += && codesign --options runtime --timestamp -s $${APPLE_SIGN_IDENTITY} $$seamly2ddmg.target
@@ -16,7 +16,7 @@ macx{
     }
 
     seamlymedmg.target = SeamlyME.dmg
-    seamlymedmg.commands = hdiutil create -fs HFS+ -srcfolder $${OUT_PWD}/../src/app/seamlyme/bin/seamlyme.app -volname "SeamlyME" $$seamlymedmg.target
+    seamlymedmg.commands = hdiutil create -srcfolder $${OUT_PWD}/../src/app/seamlyme/bin/seamlyme.app -volname "SeamlyME" $$seamlymedmg.target
 
     macSign {
         seamlymedmg.commands += && codesign --options runtime --timestamp -s $${APPLE_SIGN_IDENTITY} $$seamlymedmg.target

--- a/src/app/seamly2d/seamly2d.pro
+++ b/src/app/seamly2d/seamly2d.pro
@@ -361,7 +361,7 @@ macx{
         # we need --force as seamlyme is already signed, but we need to resign it
         QMAKE_POST_LINK += $$[QT_INSTALL_BINS]/macdeployqt $${OUT_PWD}/$${DESTDIR}/$${TARGET}.app &&
         QMAKE_POST_LINK += codesign --deep --timestamp --options runtime --force -s $${APPLE_SIGN_IDENTITY} $${OUT_PWD}/$${DESTDIR}/$${TARGET}.app &&
-        QMAKE_POST_LINK += codesign --verify $${OUT_PWD}/$${DESTDIR}/$${TARGET}.app
+        QMAKE_POST_LINK += codesign -vvv --deep --strict $${OUT_PWD}/$${DESTDIR}/$${TARGET}.app
     }
 }
 

--- a/src/app/seamlyme/seamlyme.pro
+++ b/src/app/seamlyme/seamlyme.pro
@@ -241,8 +241,8 @@ macx{
     QMAKE_POST_LINK += $$[QT_INSTALL_BINS]/macdeployqt $${OUT_PWD}/$${DESTDIR}/$${TARGET}.app
 
     macSign {
-        QMAKE_POST_LINK += && codesign --deep --timestamp --options runtime -s $${APPLE_SIGN_IDENTITY} $${OUT_PWD}/$${DESTDIR}/$${TARGET}.app
-        QMAKE_POST_LINK += && codesign --verify $${OUT_PWD}/$${DESTDIR}/$${TARGET}.app
+        QMAKE_POST_LINK += && codesign --deep --timestamp --options runtime --force -s $${APPLE_SIGN_IDENTITY} $${OUT_PWD}/$${DESTDIR}/$${TARGET}.app
+        QMAKE_POST_LINK += && codesign -vvv --deep --strict $${OUT_PWD}/$${DESTDIR}/$${TARGET}.app
     }
 }
 


### PR DESCRIPTION
From a platform perspective, no change for windows and linux. On macOS Qt 6.8 drops support for macOS 11 (Release 2020, no longer supported by Apple since Nov 2023). So I dont think this is an issue.