### PR TITLE
Refactor import measurements from pattern

### DIFF
--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -12461,7 +12461,7 @@ charger dans SeamlyME comme d&apos;habitude.
     <message>
         <source>Can&apos;t open pattern file %1:
 %2.</source>
-        <translation>Impossible d'ouvrir le fichier de motifs %1 :
+        <translation>Impossible d&apos;ouvrir le fichier de motifs %1 :
 %2.</translation>
     </message>
 </context>

--- a/src/app/seamlyme/tmainwindow.cpp
+++ b/src/app/seamlyme/tmainwindow.cpp
@@ -1652,12 +1652,19 @@ void TMainWindow::ImportFromPattern()
 		return;
 	}
 
+    QMessageBox::StandardButton answer = QMessageBox::Abort;
 	VLockGuard<char> lock(filename);
-	if (!lock.IsLocked())
-	{
-		qCCritical(tMainWindow, "%s", qUtf8Printable(tr("This file already opened in another window.")));
-		return;
-	}
+    if (!lock.IsLocked())
+    {
+        answer = QMessageBox::warning(this, tr("Locking file"),
+                                      tr("This file already opened in another window. Ignore if you want "
+                                      "to continue (not recommended, can cause a data corruption)."),
+                                      QMessageBox::Abort|QMessageBox::Ignore, QMessageBox::Abort);
+        if (answer == QMessageBox::Abort)
+        {
+            return;
+        }
+    }
 
 	QStringList measurements;
 	try


### PR DESCRIPTION
This PR changes the measurement import critical messagebox - if the pattern file is currently ope - to a warning message box with the option to ignore allowing the user to contunue importing the measurements. 

<img width="510" height="132" alt="image" src="https://github.com/user-attachments/assets/10df00bd-4a48-45b2-b444-447fac3e24af" />

This gives the user the option to continue importing the measurements or aborting rather than throwing a misleading critical messagebox. 

closes issue #1463 