### PR TITLE
Feature: Increase max visible node items

### DIFF
--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
@@ -325,7 +325,7 @@ QListWidget::item:selected {
         <enum>QFrame::Sunken</enum>
        </property>
        <property name="currentIndex">
-        <number>5</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="properties_Page">
         <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -1668,6 +1668,9 @@ QListWidget::item:selected {
                       <pointsize>9</pointsize>
                       <bold>false</bold>
                      </font>
+                    </property>
+                    <property name="maxVisibleItems">
+                     <number>30</number>
                     </property>
                    </widget>
                   </item>
@@ -4942,8 +4945,8 @@ QListWidget::item:selected {
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>264</width>
-              <height>486</height>
+              <width>362</width>
+              <height>558</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -5872,8 +5875,8 @@ QListWidget::item:selected {
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../../../../vmisc/share/resources/theme.qrc"/>
   <include location="../../../../vmisc/share/resources/icon.qrc"/>
+  <include location="../../../../vmisc/share/resources/theme.qrc"/>
  </resources>
  <connections>
   <connection>
@@ -5910,7 +5913,7 @@ QListWidget::item:selected {
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="notchType_ButtonGroup"/>
   <buttongroup name="notchSubType_ButtonGroup"/>
+  <buttongroup name="notchType_ButtonGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
This PR Increases the number of visible items in the Pattern Piece -> Seam Allowance Nodes comboBox from 10 to 30. 

The combobox will display upto 30 items below the box if there is enough space beteen the box and the botton of the sceen:

<img width="565" height="615" alt="Screenshot 2026-01-29 074009" src="https://github.com/user-attachments/assets/2f34563a-164a-4039-b835-88e46e8b8c81" />

Otherwise if there is not enough space betwen the combobox and the bottom of the screem the items are displayed above:

<img width="661" height="436" alt="Screenshot 2026-01-29 074031" src="https://github.com/user-attachments/assets/d9eb112f-17f1-4f7c-b6d9-17ca22e3e31d" />

Closes issue #1468 
