### PR TITLE
task: fix typo

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -2913,8 +2913,8 @@ p, li { white-space: pre-wrap; }
         <translation>podle délky</translation>
     </message>
     <message>
-        <source>by points intersetions</source>
-        <translation>křižovatkami bodů</translation>
+        <source>by intersection</source>
+        <translation>podle křižovatkou</translation>
     </message>
     <message>
         <source>by first edge symmetry</source>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -2898,8 +2898,8 @@ p, li { white-space: pre-wrap; }
         <translation>nach Länge</translation>
     </message>
     <message>
-        <source>by points intersetions</source>
-        <translation>nach Schnittpunkten</translation>
+        <source>by intersection</source>
+        <translation>nach Überschneidung</translation>
     </message>
     <message>
         <source>by first edge symmetry</source>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -2913,8 +2913,8 @@ p, li { white-space: pre-wrap; }
         <translation>κατά μήκος</translation>
     </message>
     <message>
-        <source>by points intersetions</source>
-        <translation>από σημεία τομής</translation>
+        <source>by intersection</source>
+        <translation>κατά διασταύρωσης</translation>
     </message>
     <message>
         <source>by first edge symmetry</source>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -2898,8 +2898,8 @@ p, li { white-space: pre-wrap; }
         <translation>by length</translation>
     </message>
     <message>
-        <source>by points intersetions</source>
-        <translation>by points intersetions</translation>
+        <source>by intersection</source>
+        <translation>by intersection</translation>
     </message>
     <message>
         <source>by first edge symmetry</source>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -2898,7 +2898,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>by points intersetions</source>
+        <source>by intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -2898,8 +2898,8 @@ p, li { white-space: pre-wrap; }
         <translation>by length</translation>
     </message>
     <message>
-        <source>by points intersetions</source>
-        <translation>by points intersetions</translation>
+        <source>by intersection</source>
+        <translation>by intersection</translation>
     </message>
     <message>
         <source>by first edge symmetry</source>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -2898,7 +2898,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>by points intersetions</source>
+        <source>by intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -2931,8 +2931,8 @@ p, li { white-space: pre-wrap; }
         <translation>Por longitud</translation>
     </message>
     <message>
-        <source>by points intersetions</source>
-        <translation>por intersecciones de puntos</translation>
+        <source>by intersection</source>
+        <translation>por intersección</translation>
     </message>
     <message>
         <source>by first edge symmetry</source>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -2913,8 +2913,8 @@ p, li { white-space: pre-wrap; }
         <translation>pituuden mukaan</translation>
     </message>
     <message>
-        <source>by points intersetions</source>
-        <translation>pisteiden risteyksillä</translation>
+        <source>by intersection</source>
+        <translation>risteyksen mukaan</translation>
     </message>
     <message>
         <source>by first edge symmetry</source>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -2927,8 +2927,8 @@ p, li { white-space: pre-wrap; }
         <translation>par longueur</translation>
     </message>
     <message>
-        <source>by points intersetions</source>
-        <translation>par point d&apos;intersection</translation>
+        <source>by intersection</source>
+        <translation>par intersection</translation>
     </message>
     <message>
         <source>by first edge symmetry</source>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -2913,8 +2913,8 @@ p, li { spasi: pra-bungkus; }
         <translation>berdasarkan panjang</translation>
     </message>
     <message>
-        <source>by points intersetions</source>
-        <translation>dengan titik persimpangan</translation>
+        <source>by intersection</source>
+        <translation>berdasarkan persimpangan</translation>
     </message>
     <message>
         <source>by first edge symmetry</source>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -2898,8 +2898,8 @@ p, li { white-space: pre-wrap; }
         <translation>per lunghezza</translation>
     </message>
     <message>
-        <source>by points intersetions</source>
-        <translation>per punti intersezioni</translation>
+        <source>by intersection</source>
+        <translation>per intersezione</translation>
     </message>
     <message>
         <source>by first edge symmetry</source>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -2899,7 +2899,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>by intersection</source>
-        <translationop kruispunt</translation>
+        <translation>op kruispunt</translation>
     </message>
     <message>
         <source>by first edge symmetry</source>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -2898,8 +2898,8 @@ p, li { white-space: pre-wrap; }
         <translation>op lengte</translation>
     </message>
     <message>
-        <source>by points intersetions</source>
-        <translation>op snijpunten</translation>
+        <source>by intersection</source>
+        <translationop kruispunt</translation>
     </message>
     <message>
         <source>by first edge symmetry</source>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -2898,8 +2898,8 @@ p, li { white-space: pre-wrap; }
         <translation>por comprimento</translation>
     </message>
     <message>
-        <source>by points intersetions</source>
-        <translation>por pontos de intersecção</translation>
+        <source>by intersection</source>
+        <translation>por interseção</translation>
     </message>
     <message>
         <source>by first edge symmetry</source>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -2913,8 +2913,8 @@ p, li { white-space: pre-wrap; }
         <translation>după lungime</translation>
     </message>
     <message>
-        <source>by points intersetions</source>
-        <translation>prin intersecții de puncte</translation>
+        <source>by intersection</source>
+        <translation>prin intersectie</translation>
     </message>
     <message>
         <source>by first edge symmetry</source>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -2913,8 +2913,8 @@ p, li { white-space: pre-wrap; }
         <translation>по длине</translation>
     </message>
     <message>
-        <source>by points intersetions</source>
-        <translation>по точкам пересечения</translation>
+        <source>by intersection</source>
+        <translation>по пересечению</translation>
     </message>
     <message>
         <source>by first edge symmetry</source>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -2913,8 +2913,8 @@ p, li { boşluk: ön sarma; }
         <translation>uzunluğa göre</translation>
     </message>
     <message>
-        <source>by points intersetions</source>
-        <translation>nokta kesişimlerine göre</translation>
+        <source>by intersection</source>
+        <translation>kesişim noktasına göre</translation>
     </message>
     <message>
         <source>by first edge symmetry</source>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -2913,8 +2913,8 @@ p, li { white-space: pre-wrap; }
         <translation>за довжиною</translation>
     </message>
     <message>
-        <source>by points intersetions</source>
-        <translation>за точками перетину</translation>
+        <source>by intersection</source>
+        <translation>шляхом перетину</translation>
     </message>
     <message>
         <source>by first edge symmetry</source>

--- a/src/libs/vtools/dialogs/tools/dialogtool.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogtool.cpp
@@ -731,7 +731,7 @@ void DialogTool::initializeNodeAngles(QComboBox *box)
     box->clear();
 
     box->addItem(tr("by length"), static_cast<unsigned char>(PieceNodeAngle::ByLength));
-    box->addItem(tr("by points intersetions"), static_cast<unsigned char>(PieceNodeAngle::ByPointsIntersection));
+    box->addItem(tr("by intersection"), static_cast<unsigned char>(PieceNodeAngle::ByPointsIntersection));
     box->addItem(tr("by first edge symmetry"), static_cast<unsigned char>(PieceNodeAngle::ByFirstEdgeSymmetry));
     box->addItem(tr("by second edge symmetry"), static_cast<unsigned char>(PieceNodeAngle::BySecondEdgeSymmetry));
     box->addItem(tr("by first edge right angle"), static_cast<unsigned char>(PieceNodeAngle::ByFirstEdgeRightAngle));


### PR DESCRIPTION
This PR fixes the typo by changing "by points intersetion" to "by intersection" and updating the translations. 

Issue #674 should remain open. 