### PR TITLE
feature: Autoclear fx editor formula

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -9149,6 +9149,14 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
         <source>Background:</source>
         <translation>Pozadí:</translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation>Editor vzorců</translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation>Automatické vymazání vzorce</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -9135,6 +9135,14 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <source>Background:</source>
         <translation>Hintergrund:</translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation>Formeleditor</translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation>Formel automatisch löschen</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -9153,6 +9153,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Background:</source>
         <translation>Φόντο:</translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation>Επεξεργαστής Φόρμουλας</translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation>Φόρμουλα αυτόματης διαγραφής</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -9119,6 +9119,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Background:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -9119,6 +9119,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Background:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -9119,6 +9119,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Background:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -9119,6 +9119,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Background:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -9189,6 +9189,14 @@ actualización:</translation>
         <source>Background:</source>
         <translation>Fondo:</translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation>Editor de fórmulas</translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation>Fórmula de borrado automático</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -9151,6 +9151,14 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
         <source>Background:</source>
         <translation>Tausta:</translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation>Kaavaeditori</translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation>Automaattinen kirkas kaava</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -9177,6 +9177,14 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
         <source>Background:</source>
         <translation>Arrière-plan :</translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation>Éditeur de formules</translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation>Formule de suppression automatique</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -9115,6 +9115,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Background:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -9151,6 +9151,14 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
         <source>Background:</source>
         <translation>Latar belakang:</translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation>Editor Rumus</translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation>Rumus pembersihan otomatis</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -9139,6 +9139,14 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
         <source>Background:</source>
         <translation>Sfondo:</translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation>Editor di formule</translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation>Formula di pulizia automatica</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -9134,6 +9134,14 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
         <source>Background:</source>
         <translation>Achtergrond:</translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation>Formule-editor</translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation>Formule automatisch wissen</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -9138,6 +9138,14 @@ Prima enter para o adicionar temporariamente à lista.</translation>
         <source>Background:</source>
         <translation>Fundo:</translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation>Editor de fórmulas</translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation>Fórmula de limpeza automática</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -9153,6 +9153,14 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
         <source>Background:</source>
         <translation>Fundal:</translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation>Editor de formule</translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation>Formula cu auto-claritate</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -9158,6 +9158,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Background:</source>
         <translation>Фон:</translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation>Редактор формул</translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation>Автоматическое удаление формулы</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -9151,6 +9151,14 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
         <source>Background:</source>
         <translation>Arka plan:</translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation>Formül Düzenleyici</translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation>Otomatik temizleme formülü</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -9152,6 +9152,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Background:</source>
         <translation>Передумова:</translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation>Редактор формул</translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation>Автоматичне очищення формули</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -9115,6 +9115,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Background:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Formula Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto clear formula</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.cpp
@@ -148,6 +148,9 @@ PreferencesGraphicsViewPage::PreferencesGraphicsViewPage (QWidget *parent)
     ui->useCurrentPen_checkBox->setChecked(qApp->Seamly2DSettings()->useCurrentPen());
     ui->showOnlyIso_CheckBox->setChecked(qApp->Seamly2DSettings()->showOnlyIso());
 
+    // Autoclear FX formula
+    ui->autoClearFx_CheckBox->setChecked(qApp->Seamly2DSettings()->autoClearFx());
+
     // Font preferences
     // Pattern piece labels font
     QFont labelFont = qApp->Seamly2DSettings()->getLabelFont();
@@ -335,6 +338,9 @@ void PreferencesGraphicsViewPage::Apply()
     // Pen
     settings->setUseCurrentPen(ui->useCurrentPen_checkBox->isChecked());
     settings->setShowIsoOnly(ui->showOnlyIso_CheckBox->isChecked());
+
+    // Formula Editor
+    settings->setAutoClearFx(ui->autoClearFx_CheckBox->isChecked());
 
     //Fonts
     settings->setLabelFont(ui->labelFont_ComboBox->currentFont());

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
@@ -75,7 +75,7 @@
       <enum>QTabWidget::West</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>4</number>
      </property>
      <widget class="QWidget" name="appearanceTab">
       <attribute name="title">
@@ -123,6 +123,7 @@
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>true</bold>
              </font>
             </property>
             <property name="text">
@@ -174,6 +175,7 @@
                <property name="font">
                 <font>
                  <pointsize>9</pointsize>
+                 <bold>true</bold>
                 </font>
                </property>
                <property name="text">
@@ -198,6 +200,7 @@
                <property name="font">
                 <font>
                  <pointsize>9</pointsize>
+                 <bold>true</bold>
                 </font>
                </property>
                <property name="text">
@@ -222,6 +225,7 @@
                <property name="font">
                 <font>
                  <pointsize>9</pointsize>
+                 <bold>true</bold>
                 </font>
                </property>
                <property name="text">
@@ -246,6 +250,7 @@
                <property name="font">
                 <font>
                  <pointsize>9</pointsize>
+                 <bold>true</bold>
                 </font>
                </property>
                <property name="text">
@@ -270,6 +275,7 @@
                <property name="font">
                 <font>
                  <pointsize>9</pointsize>
+                 <bold>true</bold>
                 </font>
                </property>
                <property name="text">
@@ -294,6 +300,7 @@
                <property name="font">
                 <font>
                  <pointsize>9</pointsize>
+                 <bold>true</bold>
                 </font>
                </property>
                <property name="text">
@@ -318,6 +325,7 @@
                <property name="font">
                 <font>
                  <pointsize>9</pointsize>
+                 <bold>true</bold>
                 </font>
                </property>
                <property name="text">
@@ -342,6 +350,7 @@
                <property name="font">
                 <font>
                  <pointsize>9</pointsize>
+                 <bold>true</bold>
                 </font>
                </property>
                <property name="text">
@@ -366,6 +375,7 @@
                <property name="font">
                 <font>
                  <pointsize>9</pointsize>
+                 <bold>true</bold>
                 </font>
                </property>
                <property name="text">
@@ -395,6 +405,7 @@
          </property>
          <property name="font">
           <font>
+           <pointsize>9</pointsize>
            <bold>true</bold>
           </font>
          </property>
@@ -433,6 +444,7 @@
               </property>
               <property name="font">
                <font>
+                <pointsize>9</pointsize>
                 <bold>true</bold>
                </font>
               </property>
@@ -706,6 +718,7 @@
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>true</bold>
              </font>
             </property>
             <property name="text">
@@ -755,6 +768,7 @@
          </property>
          <property name="font">
           <font>
+           <pointsize>9</pointsize>
            <bold>true</bold>
           </font>
          </property>
@@ -781,6 +795,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -823,6 +838,7 @@
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>true</bold>
              </font>
             </property>
             <property name="text">
@@ -849,6 +865,7 @@
          </property>
          <property name="font">
           <font>
+           <pointsize>9</pointsize>
            <bold>true</bold>
           </font>
          </property>
@@ -875,6 +892,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -900,7 +918,10 @@
                </size>
               </property>
               <property name="font">
-               <font/>
+               <font>
+                <pointsize>9</pointsize>
+                <bold>true</bold>
+               </font>
               </property>
               <property name="styleSheet">
                <string notr="true"/>
@@ -924,6 +945,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -957,6 +979,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="currentText">
@@ -1125,6 +1148,7 @@
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>true</bold>
              </font>
             </property>
             <property name="text">
@@ -1151,6 +1175,7 @@
          </property>
          <property name="font">
           <font>
+           <pointsize>9</pointsize>
            <bold>true</bold>
           </font>
          </property>
@@ -1177,6 +1202,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -1202,7 +1228,10 @@
                </size>
               </property>
               <property name="font">
-               <font/>
+               <font>
+                <pointsize>9</pointsize>
+                <bold>true</bold>
+               </font>
               </property>
               <property name="styleSheet">
                <string notr="true"/>
@@ -1226,6 +1255,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -1259,6 +1289,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="currentText">
@@ -1427,6 +1458,7 @@
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>true</bold>
              </font>
             </property>
             <property name="text">
@@ -1473,6 +1505,7 @@
          </property>
          <property name="font">
           <font>
+           <pointsize>9</pointsize>
            <bold>true</bold>
           </font>
          </property>
@@ -1598,6 +1631,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -1665,6 +1699,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -1757,6 +1792,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -1818,6 +1854,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -1910,6 +1947,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -1969,6 +2007,7 @@
          </property>
          <property name="font">
           <font>
+           <pointsize>9</pointsize>
            <bold>true</bold>
           </font>
          </property>
@@ -1995,6 +2034,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -2056,6 +2096,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -2117,6 +2158,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -2230,6 +2272,7 @@
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>true</bold>
              </font>
             </property>
             <property name="text">
@@ -2259,6 +2302,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -2280,6 +2324,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="styleSheet">
@@ -2313,6 +2358,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -2334,6 +2380,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="toolTip">
@@ -2370,6 +2417,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -2391,6 +2439,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="toolTip">
@@ -2427,6 +2476,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -2450,6 +2500,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -2560,6 +2611,7 @@ border-radius: 4px;
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -2624,6 +2676,7 @@ border-radius: 4px;
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>true</bold>
              </font>
             </property>
             <property name="text">
@@ -2647,6 +2700,7 @@ border-radius: 4px;
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -2670,6 +2724,7 @@ border-radius: 4px;
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -2783,6 +2838,7 @@ border-radius: 4px;
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -2876,6 +2932,7 @@ border-radius: 4px;
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>true</bold>
              </font>
             </property>
             <property name="text">
@@ -2905,6 +2962,7 @@ border-radius: 4px;
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -2926,6 +2984,7 @@ border-radius: 4px;
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="styleSheet">
@@ -3004,6 +3063,7 @@ border-radius: 4px;
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>true</bold>
              </font>
             </property>
             <property name="text">
@@ -3019,6 +3079,7 @@ border-radius: 4px;
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>true</bold>
              </font>
             </property>
             <property name="text">
@@ -3066,6 +3127,7 @@ border-radius: 4px;
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -3089,6 +3151,7 @@ border-radius: 4px;
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -3205,6 +3268,7 @@ border-radius: 4px;
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -3232,6 +3296,7 @@ border-radius: 4px;
          </property>
          <property name="font">
           <font>
+           <pointsize>9</pointsize>
            <bold>true</bold>
           </font>
          </property>
@@ -3250,6 +3315,34 @@ border-radius: 4px;
            <widget class="QCheckBox" name="showOnlyIso_CheckBox">
             <property name="text">
              <string>Show only ISO line weights in drop down boxes</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_3">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>9</pointsize>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="title">
+          <string>Formula Editor</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_27">
+          <item>
+           <widget class="QCheckBox" name="autoClearFx_CheckBox">
+            <property name="text">
+             <string>Auto clear formula</string>
             </property>
            </widget>
           </item>

--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -123,6 +123,7 @@ const QString settingGraphicsViewShowOpsToolBar          = QStringLiteral("graph
 const QString settingGraphicsViewShowPieceToolBar        = QStringLiteral("graphicsview/showPieceToolbar");
 const QString settingGraphicsViewShowDetailsToolBar      = QStringLiteral("graphicsview/showDetailsToolbar");
 const QString settingGraphicsViewShowLayoutToolBar       = QStringLiteral("graphicsview/showLayoutToolbar");
+const QString settingGraphicsAutoClearFx                 = QStringLiteral("graphicsview/autoClearFx");
 
 const QString settingGraphicsViewDialogPosition          = QStringLiteral("graphicsview/dialogPosition");
 const QString settingGraphicsUseSecondMonitor            = QStringLiteral("graphicsview/useSecondMonitor");
@@ -2435,4 +2436,14 @@ QString VCommonSettings::getStr(QString key, const QString &defaultString) const
         return string;
     }
     return defaultString;
+}
+
+bool VCommonSettings::autoClearFx() const
+{
+    return value(settingGraphicsAutoClearFx, false).toBool();
+}
+
+void VCommonSettings::setAutoClearFx(bool value)
+{
+    setValue(settingGraphicsAutoClearFx, value);
 }

--- a/src/libs/vmisc/vcommonsettings.h
+++ b/src/libs/vmisc/vcommonsettings.h
@@ -531,6 +531,9 @@ public:
 
     QString              getStr(QString key, const QString &defaultString) const;
 
+    bool                 autoClearFx() const;
+    void                 setAutoClearFx(bool value);
+
 private:
     Q_DISABLE_COPY(VCommonSettings)
 };

--- a/src/libs/vtools/dialogs/support/edit_formula_dialog.cpp
+++ b/src/libs/vtools/dialogs/support/edit_formula_dialog.cpp
@@ -64,6 +64,7 @@
 #include <QLabel>
 #include <QListWidget>
 #include <QMapIterator>
+#include <QMouseEvent>
 #include <QPlainTextEdit>
 #include <QPushButton>
 #include <QSharedPointer>
@@ -544,6 +545,20 @@ void EditFormulaDialog::SetFormula(const QString &value)
 {
     m_formula = qApp->translateVariables()->FormulaToUser(value, qApp->Settings()->getOsSeparator());
     m_undoFormula = m_formula;
+
+    if (qApp->Settings()->autoClearFx())
+    {
+        bool isInt;
+        int intValue = m_formula.toInt(&isInt);
+
+        bool isDouble;
+        double doubleValue = m_formula.toDouble(&isDouble);
+
+        if(isInt || isDouble)
+        {
+            m_formula = QString();
+        }
+    }
     ui->plainTextEditFormula->setPlainText(m_formula);
     MoveCursorToEnd(ui->plainTextEditFormula);
 }


### PR DESCRIPTION
This PR addresses issue #1467. 

- Instead of clearing the fx formula with a ctrl + mouse click, which was not possible to override the key or mouse events using normal methods - it clears the formula if the formula contains only an int or real number value. 

- Adds a preference whether the user wants to auto clear the fx formula or not. 
  
    <img width="298" height="64" alt="image" src="https://github.com/user-attachments/assets/bc13b2c8-15df-4ea2-a032-ac86acf11776" />

- If a user wishes to keep the numerical value they can always click the "Reset" tool button:

    <img width="175" height="65" alt="image" src="https://github.com/user-attachments/assets/37d40cd1-27cc-4ba4-b23f-b1ece4ba2711" />

- lupdate

closes issue #1467 