### PR TITLE
FEATURE: Improve history dialog

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -4184,10 +4184,6 @@ Chcete si ji stáhnout?</translation>
         <translation>Protíná čáry %1_%2 a %3_%4</translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation>Křivka_</translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation>Interaktivní křivka</translation>
     </message>
@@ -4196,20 +4192,8 @@ Chcete si ji stáhnout?</translation>
         <translation>Křivka opravena</translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation>Oblouková_</translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
         <translation>Poloměr a úhly oblouku</translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation>Poloměr a délka oblouku %1</translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
-        <translation>SplPath_</translation>
     </message>
     <message>
         <source>Spline Interactive</source>
@@ -4334,6 +4318,30 @@ Chcete si ji stáhnout?</translation>
     <message>
         <source>Seach by regular expression</source>
         <translation>vyhledávání podle regulárního výrazu</translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation>Blok konceptu:</translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation>blok</translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation>Poloměr / Délka</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Úhel</translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation>Oblouk s poloměrem, délkou a úhlem</translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation>Středový bod</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -4185,10 +4185,6 @@ Möchten Sie sie herunterladen?</translation>
         <translation>Bogen Radius &amp; Winkel</translation>
     </message>
     <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation>Bogen Radius &amp; Länge %1</translation>
-    </message>
-    <message>
         <source>Spline Interactive</source>
         <translation>Spline interaktiv</translation>
     </message>
@@ -4285,18 +4281,6 @@ Möchten Sie sie herunterladen?</translation>
         <translation>Kann keinen Datensatz erstellen.</translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation>Spl_</translation>
-    </message>
-    <message>
-        <source>Arc_</source>
-        <translation>Bogen_</translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
-        <translation>SplPfad_</translation>
-    </message>
-    <message>
         <source>ElArc_</source>
         <translation>ElBogen_</translation>
     </message>
@@ -4319,6 +4303,30 @@ Möchten Sie sie herunterladen?</translation>
     <message>
         <source>Seach by regular expression</source>
         <translation>Suche nach regulären Ausdrücken</translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation>Entwurfsblock:</translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation>block</translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation>Radius / Länge</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Winkel</translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation>Bogen mit Radius, Länge und Winkel</translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation>Mittelpunkt</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -4188,10 +4188,6 @@ Do you want to download it?</source>
         <translation>Σημεία που τέμνουν τις ευθείες %1_%2 και %3_%4</translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation>Σπλ_</translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation>Διαδραστικό Curve</translation>
     </message>
@@ -4200,20 +4196,8 @@ Do you want to download it?</source>
         <translation>Καμπύλη Σταθερή</translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation>Τόξο_</translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
         <translation>Ακτίνα και γωνίες τόξου</translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation>Ακτίνα και μήκος τόξου %1</translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
-        <translation>ΣπλΔιαδρομ_</translation>
     </message>
     <message>
         <source>Spline Interactive</source>
@@ -4338,6 +4322,31 @@ Do you want to download it?</source>
     <message>
         <source>Seach by regular expression</source>
         <translation>Αναζήτηση με κανονική έκφραση</translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation>Μπλοκ προσχέδιου:</translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation>φραγμός</translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation>Ακτίνα / Μήκος</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Γωνία</translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation>Τόξο με ακτίνα, μήκος και γωνία
+</translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation>Κεντρικό σημείο</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -4341,8 +4341,7 @@ Do you want to download it?</source>
     </message>
     <message>
         <source>Arc with Radius, Length, and Angle</source>
-        <translation>Τόξο με ακτίνα, μήκος και γωνία
-</translation>
+        <translation>Τόξο με ακτίνα, μήκος και γωνία</translation>
     </message>
     <message>
         <source>Center point</source>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -4165,10 +4165,6 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation type="unfinished">Spl_</translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4177,19 +4173,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation type="unfinished">Arc_</translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4315,6 +4299,30 @@ Do you want to download it?</source>
     <message>
         <source>Seach by regular expression</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Angle</translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation type="unfinished">Center point</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -4165,10 +4165,6 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation type="unfinished">Spl_</translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4177,19 +4173,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation type="unfinished">Arc_</translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4315,6 +4299,30 @@ Do you want to download it?</source>
     <message>
         <source>Seach by regular expression</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Angle</translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation type="unfinished">Center point</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -4165,10 +4165,6 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation type="unfinished">Spl_</translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4177,19 +4173,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation type="unfinished">Arc_</translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4315,6 +4299,30 @@ Do you want to download it?</source>
     <message>
         <source>Seach by regular expression</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Angle</translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation type="unfinished">Center point</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -4165,10 +4165,6 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation type="unfinished">Spl_</translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4177,19 +4173,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation type="unfinished">Arc_</translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4315,6 +4299,30 @@ Do you want to download it?</source>
     <message>
         <source>Seach by regular expression</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Angle</translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation type="unfinished">Center point</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -4206,10 +4206,6 @@ Do you want to download it?</source>
         <translation>Punto Intersección de las Líneas %1_%2 y %3_%4</translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation>Spl_</translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation>Curva Interactiva</translation>
     </message>
@@ -4218,20 +4214,8 @@ Do you want to download it?</source>
         <translation>Curva Fija</translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation>Arco_</translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
         <translation>Radio y Ángulos del Arco</translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation>Radio y Longitud del Arco %1</translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
-        <translation>SplPath_</translation>
     </message>
     <message>
         <source>Spline Interactive</source>
@@ -4356,6 +4340,30 @@ Do you want to download it?</source>
     <message>
         <source>Seach by regular expression</source>
         <translation>Búsqueda por expresión regular</translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation>Bolque de borrador:</translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation>bloquear</translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation>Radio / Longitud</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Ángulo</translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation>Arco con radio, longitud y ángulo</translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation>Punto central</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -4186,10 +4186,6 @@ Haluatko ladata sen?</translation>
         <translation>Piste leikkaa viivoja %1_%2 ja %3_%4</translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation>Spl_</translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation>Käyräinteraktiivinen</translation>
     </message>
@@ -4198,20 +4194,8 @@ Haluatko ladata sen?</translation>
         <translation>Käyrä korjattu</translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation>Kaari_</translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
         <translation>Kaaren säde ja kulmat</translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation>Kaaren säde ja pituus %1</translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
-        <translation>Osapolku_</translation>
     </message>
     <message>
         <source>Spline Interactive</source>
@@ -4336,6 +4320,30 @@ Haluatko ladata sen?</translation>
     <message>
         <source>Seach by regular expression</source>
         <translation>Hae säännöllisen lausekkeen avulla</translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation>Luonnoslohko:</translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation>lohko</translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation>Säde / Pituus</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Kulma</translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation>Kaari säteellä, pituudella ja kulmalla</translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation>Keskipiste</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -4209,10 +4209,6 @@ Voulez-vous la télécharger ?</translation>
         <translation>Point Intersection Lignes %1_%2 et %3_%4</translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation>Spl_</translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation>Courbe Interactive</translation>
     </message>
@@ -4221,20 +4217,8 @@ Voulez-vous la télécharger ?</translation>
         <translation>Courbe Fixe</translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation>Arc_</translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
         <translation>Arc Rayon et Angles</translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation>Arc Rayon et Longueur %1</translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
-        <translation>SplPath_</translation>
     </message>
     <message>
         <source>Spline Interactive</source>
@@ -4359,6 +4343,30 @@ Voulez-vous la télécharger ?</translation>
     <message>
         <source>Seach by regular expression</source>
         <translation>Recherche par expression</translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation>Bloc de brouillon :</translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation>bloc</translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation>Rayon / Longueur</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Angle</translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation>Arc avec rayon, longueur et angle</translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation>Point central</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -4165,10 +4165,6 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4177,19 +4173,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4315,6 +4299,30 @@ Do you want to download it?</source>
     <message>
         <source>Seach by regular expression</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation type="unfinished">נקודת מרכז</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -4186,10 +4186,6 @@ Apakah Anda ingin mengunduhnya?</translation>
         <translation>Titik Perpotongan Garis %1_%2 dan %3_%4</translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation>Spl_</translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation>Kurva Interaktif</translation>
     </message>
@@ -4198,20 +4194,8 @@ Apakah Anda ingin mengunduhnya?</translation>
         <translation>Kurva Tetap</translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation>Busur_</translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
         <translation>Jari-jari Busur dan Sudut</translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation>Jari-jari Busur &amp; Panjang %1</translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
-        <translation>JalurSpl_</translation>
     </message>
     <message>
         <source>Spline Interactive</source>
@@ -4336,6 +4320,30 @@ Apakah Anda ingin mengunduhnya?</translation>
     <message>
         <source>Seach by regular expression</source>
         <translation>Pencarian dengan ekspresi reguler</translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation>Blok Draf:</translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation>memblokir</translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation>Jari-jari / Panjang</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Sudut</translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation>Busur dengan Jari-jari, Panjang, dan Sudut</translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation>Titik tengah</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -4173,10 +4173,6 @@ Volete scaricarla?</translation>
         <translation>Punto interseca le linee %1_%2 e %3_%4</translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation>Spl_</translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation>Curva interattiva</translation>
     </message>
@@ -4185,20 +4181,8 @@ Volete scaricarla?</translation>
         <translation>Curva fissa</translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation>Arco_</translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
         <translation>Raggio e angoli dell&apos;arco</translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation>Raggio e lunghezza dell&apos;arco %1</translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
-        <translation>Percorso Spl_</translation>
     </message>
     <message>
         <source>Spline Interactive</source>
@@ -4323,6 +4307,30 @@ Volete scaricarla?</translation>
     <message>
         <source>Seach by regular expression</source>
         <translation>Ricerca tramite espressione regolare</translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation>Blocco bozza:</translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation>blocco</translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation>Raggio / Lunghezza</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Angolo</translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation>Arco con Raggio, Lunghezza e Angolo</translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation>Punto centrale</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -4169,10 +4169,6 @@ Wilt u deze downloaden?</translation>
         <translation>Snijpunt Lijnen %1_%2 en %3_%4</translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation>Spl_</translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation>Kromme Interactief</translation>
     </message>
@@ -4181,20 +4177,8 @@ Wilt u deze downloaden?</translation>
         <translation>Kromme Vast</translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation>Boog_</translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
         <translation>Boog Straal &amp; Hoeken</translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation>Boog Straal &amp; Lengte %1</translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
-        <translation>Splinepad_</translation>
     </message>
     <message>
         <source>Spline Interactive</source>
@@ -4319,6 +4303,30 @@ Wilt u deze downloaden?</translation>
     <message>
         <source>Seach by regular expression</source>
         <translation>Zoeken op reguliere expressie</translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation>Tekenblok:</translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation>Blocco</translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation>Straal / Lengte</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Hoek</translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation>Boog met Straal, Lengte, en Hoek</translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation>Middelste punt</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -4172,10 +4172,6 @@ Deseja descarregá-la?</translation>
         <translation>Pontos que interceptam linhas %1_%2 e %3_%4</translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation>Spl_</translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation>Curva Interativa</translation>
     </message>
@@ -4184,20 +4180,8 @@ Deseja descarregá-la?</translation>
         <translation>Curva Fixa</translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation>Arco_</translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
         <translation>Raio e ângulos do arco</translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation>Raio e comprimento do arco %1</translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
-        <translation>Caminho Spl_</translation>
     </message>
     <message>
         <source>Spline Interactive</source>
@@ -4322,6 +4306,30 @@ Deseja descarregá-la?</translation>
     <message>
         <source>Seach by regular expression</source>
         <translation>Pesquisar por expressão regular</translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation>Bloco de Rascunho:</translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation>bloco</translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation>Raio / Comprimento</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Ângulo</translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation>Arco com Raio, Comprimento, e Ângulo</translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation>Ponto central</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -4188,10 +4188,6 @@ Doriți să o descărcați?</translation>
         <translation>Punct care intersectează liniile %1_%2 și %3_%4</translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation>Spl_</translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation>Curve Interactive</translation>
     </message>
@@ -4200,20 +4196,8 @@ Doriți să o descărcați?</translation>
         <translation>Curbă fixă</translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation>Arc_</translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
         <translation>Raza și unghiurile arcului</translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation>Raza și lungimea arcului %1</translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
-        <translation>CaleaSpl_</translation>
     </message>
     <message>
         <source>Spline Interactive</source>
@@ -4338,6 +4322,30 @@ Doriți să o descărcați?</translation>
     <message>
         <source>Seach by regular expression</source>
         <translation>Căutare prin expresie regulată</translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation>Bloc de schițe:</translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation>bloc</translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation>Rază / Lungime</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Unghi</translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation>Arc cu Rază, Lungime și Unghi</translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation>Punct central</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -4190,10 +4190,6 @@ Do you want to download it?</source>
         <translation>Точка Пересечения Линий %1_%2 и %3_%4</translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation>Спл_</translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation>Интерактивная Кривая</translation>
     </message>
@@ -4202,20 +4198,8 @@ Do you want to download it?</source>
         <translation>Фиксированная Кривая</translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation>Дуга_</translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
         <translation>Дуга Радиус и Углы</translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation>Дуга Радиус и Длина %1</translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
-        <translation>СплКонтур_</translation>
     </message>
     <message>
         <source>Spline Interactive</source>
@@ -4340,6 +4324,30 @@ Do you want to download it?</source>
     <message>
         <source>Seach by regular expression</source>
         <translation>Поиск по регулярному выражению</translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation>Блок Чертежа:</translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation>блокировать</translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation>Радиус / Длина</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Угол</translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation>Дуга с Радиус, Длина, и Угол.</translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation>Центральная точка</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -4343,7 +4343,7 @@ Do you want to download it?</source>
     </message>
     <message>
         <source>Arc with Radius, Length, and Angle</source>
-        <translation>Дуга с Радиус, Длина, и Угол.</translation>
+        <translation>Дуга с Радиус, Длина, и Угол</translation>
     </message>
     <message>
         <source>Center point</source>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -4186,10 +4186,6 @@ Do you want to download it?</source>
         <translation>Nokta Kesişim Çizgileri %1_%2 ve %3_%4</translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation>Ayrıca_</translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation>Eğri Etkileşimli</translation>
     </message>
@@ -4198,20 +4194,8 @@ Do you want to download it?</source>
         <translation>Eğri Sabitlendi</translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation>Yay_</translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
         <translation>Yay Yarıçapı ve Açıları</translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation>Yay Yarıçapı ve Uzunluğu %1</translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
-        <translation>EkYol_</translation>
     </message>
     <message>
         <source>Spline Interactive</source>
@@ -4336,6 +4320,30 @@ Do you want to download it?</source>
     <message>
         <source>Seach by regular expression</source>
         <translation>Düzenli ifadeye göre ara</translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation>Taslak Bloğu:</translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation>bloğu</translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation>Yarıçap / Uzunluk</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Açı</translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation>Yarıçapı, Uzunluğu ve Açısı bilinen Yay</translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation>Merkez noktası</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -4188,10 +4188,6 @@ Do you want to download it?</source>
         <translation>Σημεία που τέμνουν τις ευθείες %1_%2 και %3_%4</translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation>Спл_</translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation>Διαδραστικό Curve</translation>
     </message>
@@ -4200,20 +4196,8 @@ Do you want to download it?</source>
         <translation>Καμπύλη Σταθερή</translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation>Ντούγκα_</translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
         <translation>Ακτίνα και γωνίες τόξου</translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation>Ακτίνα και μήκος τόξου %1</translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
-        <translation>Διαδρομή____</translation>
     </message>
     <message>
         <source>Spline Interactive</source>
@@ -4338,6 +4322,30 @@ Do you want to download it?</source>
     <message>
         <source>Seach by regular expression</source>
         <translation>Пошук за регулярним виразом</translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation>Μπλοκ προσχέδιου:</translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation>mπλοκ</translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation>Радіус / Довжина</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Κουτ</translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation>Дуга з Радіус, Довжина, та Κουτ</translation>
+    </message>
+    <message>
+        <source>Center point</source>
+        <translation>Точка центру</translation>
     </message>
 </context>
 <context>
@@ -4946,7 +4954,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
     </message>
     <message>
         <source>Radius:</source>
-        <translation>Ραδιους:</translation>
+        <translation>Радіус:</translation>
     </message>
     <message>
         <source>Value</source>
@@ -4974,7 +4982,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
     </message>
     <message>
         <source>Radius can&apos;t be negative</source>
-        <translation>Ραδιους δεν μπορει να ματι σημαινει</translation>
+        <translation>Радіус δεν μπορει να ματι σημαινει</translation>
     </message>
     <message>
         <source>Point - Intersect Circle and Tangent</source>
@@ -5028,7 +5036,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
     </message>
     <message>
         <source>Radius:</source>
-        <translation>Ραδιους:</translation>
+        <translation>Радіус:</translation>
     </message>
     <message>
         <source>Value</source>
@@ -5068,7 +5076,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
     </message>
     <message>
         <source>Radius can&apos;t be negative</source>
-        <translation>Ραδιους δεν μπορει να ματι σημαινει</translation>
+        <translation>Радіус δεν μπορει να ματι σημαινει</translation>
     </message>
     <message>
         <source>Point - Intersect Circles</source>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -4165,10 +4165,6 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4177,19 +4173,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Arc Radius &amp; Length %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4314,6 +4298,30 @@ Do you want to download it?</source>
     </message>
     <message>
         <source>Seach by regular expression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Draft Block:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Radius / Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Arc with Radius, Length, and Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Center point</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/app/seamly2d/dialogs/history_dialog.cpp
+++ b/src/app/seamly2d/dialogs/history_dialog.cpp
@@ -63,6 +63,7 @@
 #include "../vmisc/vabstractapplication.h"
 #include "../vmisc/vtablesearch.h"
 #include "../vtools/tools/vabstracttool.h"
+#include "../vtools/tools/drawTools/operation/vabstractoperation.h"
 #include "../vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.h"
 #include "../vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.h"
 #include "../vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.h"
@@ -74,6 +75,10 @@
 #include <QDebug>
 #include <QGuiApplication>
 #include <QScreen>
+#include <QScrollBar>
+
+// We need this enum in case we will add or delete a column. It also makes code more readable.
+enum {CursorColumn = 0, IdColumn, NameColumn, DescColumn, LengthColumn, AngleColumn};
 
 //---------------------------------------------------------------------------------------------------------------------
 /// @brief HistoryDialog create dialog
@@ -92,9 +97,13 @@ HistoryDialog::HistoryDialog(VContainer *data, VPattern *doc, QWidget *parent)
     setWindowFlags(Qt::Window);
     setWindowFlags(windowFlags() & ~Qt::WindowStaysOnTopHint & ~Qt::WindowContextHelpButtonHint);
 
-    // Limit dialog height to 80% of screen size
+    // Set the position that the dialog opens based on user preference.
+    setDialogPosition();
+
+    // Limit dialog height to 80% of screen size.
     setMaximumHeight(qRound(QGuiApplication::primaryScreen()->availableGeometry().height() * .8));
 
+    /// Install event filter to handle key presses and mouse events for the search line edit field.
     ui->find_LineEdit->installEventFilter(this);
 
     qApp->Settings()->getOsSeparator() ? setLocale(QLocale()) : setLocale(QLocale::c());
@@ -102,34 +111,38 @@ HistoryDialog::HistoryDialog(VContainer *data, VPattern *doc, QWidget *parent)
     fillTable();
     initializeTable();
 
-    ok_Button = ui->buttonBox->button(QDialogButtonBox::Ok);
-    connect(ok_Button,                &QPushButton::clicked, this,  &HistoryDialog::DialogAccepted);
-    connect(ui->clipboard_ToolButton, &QToolButton::clicked, this,  &HistoryDialog::copyToClipboard);
+    QPushButton *close_Button = ui->buttonBox->button(QDialogButtonBox::Close);
+    close_Button->setDefault(false);
+    close_Button->setAutoDefault(false);
 
-
-    // Set up search
     m_search = QSharedPointer<VTableSearch>(new VTableSearch(ui->tableWidget));
-    connect(ui->find_LineEdit,    &QLineEdit::textEdited,this,  &HistoryDialog::findText);
-    connect(ui->prev_PushButton,  &QToolButton::clicked, this,  &HistoryDialog::searchPrev);
-    connect(ui->next_PushButton,  &QToolButton::clicked, this,  &HistoryDialog::searchNext);
-    connect(ui->regex_ToolButton, &QToolButton::toggled, this,  &HistoryDialog::regexToggled);
-    connect(ui->case_ToolButton,  &QToolButton::toggled, this,  &HistoryDialog::caseToggled);
-    connect(ui->word_ToolButton,  &QToolButton::toggled, this,  &HistoryDialog::wordToggled);
-    connect(m_search.data(), &VTableSearch::hasResult, this, [this] (bool state)
+
+    connect(ui->clipboard_ToolButton,    &QToolButton::clicked,       this,  &HistoryDialog::copyToClipboard);
+    connect(ui->find_LineEdit,           &QLineEdit::textEdited,      this,  &HistoryDialog::findText);
+    connect(ui->prev_PushButton,         &QToolButton::clicked,       this,  &HistoryDialog::searchPrev);
+    connect(ui->next_PushButton,         &QToolButton::clicked,       this,  &HistoryDialog::searchNext);
+    connect(ui->regex_ToolButton,        &QToolButton::toggled,       this,  &HistoryDialog::regexToggled);
+    connect(ui->case_ToolButton,         &QToolButton::toggled,       this,  &HistoryDialog::caseToggled);
+    connect(ui->word_ToolButton,         &QToolButton::toggled,       this,  &HistoryDialog::wordToggled);
+    connect(ui->moveToTop_ToolButton,    &QToolButton::clicked,       this,  &HistoryDialog::moveToTop);
+    connect(ui->moveToCursor_ToolButton, &QToolButton::clicked,       this,  &HistoryDialog::moveToCursor);
+    connect(ui->moveToBottom_ToolButton, &QToolButton::clicked,       this,  &HistoryDialog::moveToBottom);
+    connect(ui->tableWidget,             &QTableWidget::cellClicked,  this,  &HistoryDialog::cellClicked);
+    connect(close_Button,                &QPushButton::clicked,       this,  &HistoryDialog::DialogAccepted);
+    connect(m_doc,                       &VPattern::ChangedCursor,    this,  &HistoryDialog::cursorChanged);
+    connect(m_doc,                       &VPattern::patternChanged,   this,  &HistoryDialog::updateHistory);
+
+    connect(this, &HistoryDialog::showHistoryTool, m_doc, [doc](quint32 id, bool enable)
+    {
+        emit doc->ShowTool(id, enable);
+    });
+    connect(m_search.data(), &VTableSearch::hasResult,  this,  [this] (bool state)
     {
         ui->prev_PushButton->setEnabled(state);
     });
     connect(m_search.data(), &VTableSearch::hasResult, this, [this] (bool state)
     {
         ui->next_PushButton->setEnabled(state);
-    });
-
-    connect(ui->tableWidget, &QTableWidget::cellClicked,      this,  &HistoryDialog::cellClicked);
-    connect(m_doc,           &VPattern::ChangedCursor,        this,  &HistoryDialog::changedCursor);
-    connect(m_doc,           &VPattern::patternChanged,       this,  &HistoryDialog::updateHistory);
-    connect(this,            &HistoryDialog::showHistoryTool, m_doc, [doc](quint32 id, bool enable)
-    {
-        emit doc->ShowTool(id, enable);
     });
 
     showTool();
@@ -146,9 +159,13 @@ HistoryDialog::~HistoryDialog()
 //---------------------------------------------------------------------------------------------------------------------
 void HistoryDialog::DialogAccepted()
 {
-    QTableWidgetItem *item = ui->tableWidget->item(m_cursorToolRecordRow, 0);
+    QTableWidgetItem *item = ui->tableWidget->item(m_cursorToolRecordRow, IdColumn);
     quint32 id = qvariant_cast<quint32>(item->data(Qt::UserRole));
     emit showHistoryTool(id, false);
+
+    // Reset cursor to bottom of table before closing
+    m_doc->setCursorId(NULL_ID);
+
     emit DialogClosed(QDialog::Accepted);
 }
 
@@ -159,48 +176,59 @@ void HistoryDialog::DialogAccepted()
 //---------------------------------------------------------------------------------------------------------------------
 void HistoryDialog::cellClicked(int row, int column)
 {
-    if (column == 0)
+    if (column == CursorColumn)
     {
-        QTableWidgetItem *item = ui->tableWidget->item(m_cursorRow, 0);
+        // clear current cursor row icon
+        QTableWidgetItem *item = ui->tableWidget->item(m_cursorRow, CursorColumn);
         item->setIcon(QIcon());
 
-        item = ui->tableWidget->item(row, 0);
+        // set new cursor row icon
         m_cursorRow = row;
+        item = ui->tableWidget->item(m_cursorRow, CursorColumn);
         item->setIcon(QIcon("://icon/24x24/left_to_right_arrow.png"));
+
+        // set new cursor position in pattern.
+        // if cursor is at last row set id to 0, else use tool id in row.
+        item = ui->tableWidget->item(m_cursorRow, IdColumn);
         const quint32 id = qvariant_cast<quint32>(item->data(Qt::UserRole));
         m_doc->blockSignals(true);
-        row == ui->tableWidget->rowCount()-1 ? m_doc->setCursor(0) : m_doc->setCursor(id);
+        row == ui->tableWidget->rowCount()-1 ? m_doc->setCursorId(NULL_ID) : m_doc->setCursorId(id);
         m_doc->blockSignals(false);
     }
     else
     {
-        QTableWidgetItem *item = ui->tableWidget->item(m_cursorToolRecordRow, 0);
+        // Un Highlight old selected tool in draft block
+        QTableWidgetItem *item = ui->tableWidget->item(m_cursorToolRecordRow, IdColumn);
         quint32 id = qvariant_cast<quint32>(item->data(Qt::UserRole));
         emit showHistoryTool(id, false);
 
+        // Highlight new selected tool in draft block
         m_cursorToolRecordRow = row;
-        item = ui->tableWidget->item(m_cursorToolRecordRow, 0);
+        item = ui->tableWidget->item(m_cursorToolRecordRow, IdColumn);
         id = qvariant_cast<quint32>(item->data(Qt::UserRole));
         emit showHistoryTool(id, true);
     }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/// @brief changedCursor changed cursor of input. Cursor show after which record we will insert new object
+/// @brief cursorChanged changed cursor of input. Cursor show after which record we will insert new object
 /// @param id id of object
 //---------------------------------------------------------------------------------------------------------------------
-void HistoryDialog::changedCursor(quint32 id)
+void HistoryDialog::cursorChanged(quint32 id)
 {
-    for (qint32 i = 0; i< ui->tableWidget->rowCount(); ++i)
+    for (qint32 row = 0; row < ui->tableWidget->rowCount(); ++row)
     {
-        QTableWidgetItem *item = ui->tableWidget->item(i, 0);
-        quint32 rId = qvariant_cast<quint32>(item->data(Qt::UserRole));
-        if (rId == id)
+        QTableWidgetItem *item = ui->tableWidget->item(row, IdColumn);
+        quint32 rowId = qvariant_cast<quint32>(item->data(Qt::UserRole));
+        if (rowId == id)
         {
-            QTableWidgetItem *oldCursorItem = ui->tableWidget->item(m_cursorRow, 0);
+            QTableWidgetItem *oldCursorItem = ui->tableWidget->item(m_cursorRow, CursorColumn);
             oldCursorItem->setIcon(QIcon());
-            m_cursorRow = i;
+            m_cursorRow = row;
             item->setIcon(QIcon("://icon/24x24/left_to_right_arrow.png"));
+
+            QScrollBar *verScrollBar = ui->tableWidget->verticalScrollBar();
+            verScrollBar->setSliderPosition(verScrollBar->maximum());
         }
     }
 }
@@ -208,10 +236,13 @@ void HistoryDialog::changedCursor(quint32 id)
 //---------------------------------------------------------------------------------------------------------------------
 /// @brief updateHistory update history table
 //---------------------------------------------------------------------------------------------------------------------
-void HistoryDialog::updateHistory()
+void HistoryDialog::updateHistory(bool saved)
 {
-    fillTable();
-    initializeTable();
+    if (saved)
+    {
+        fillTable();
+        initializeTable();
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -219,7 +250,13 @@ void HistoryDialog::updateHistory()
 //---------------------------------------------------------------------------------------------------------------------
 void HistoryDialog::fillTable()
 {
+    ui->draftblockName_Label->setText(m_doc->getActiveDraftBlockName());
     ui->tableWidget->clear();
+
+    // Set the description column to stretch
+    QHeaderView *header = ui->tableWidget->horizontalHeader();
+    header->setSectionResizeMode(DescColumn, QHeaderView::Stretch);
+
     QVector<VToolRecord> history = m_doc->getBlockHistory();
     qint32 currentRow = -1;
     qint32 count = 0;
@@ -235,42 +272,66 @@ void HistoryDialog::fillTable()
             currentRow++;
 
             {
+                QTableWidgetItem *item = new QTableWidgetItem(QString(""));
+                item->setTextAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+                ui->tableWidget->setItem(currentRow, CursorColumn, item); //1st column is Cursor position
+            }
+
+            {
                 QTableWidgetItem *item = new QTableWidgetItem(QString().setNum(rowData.id));
-                item->setTextAlignment(Qt::AlignHCenter);
-                item->setSizeHint(QSize(80, 24));
+                item->setTextAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
                 item->setData(Qt::UserRole, rowData.id);
                 item->setFlags(item->flags() ^ Qt::ItemIsEditable);
-                ui->tableWidget->setItem(currentRow, 0, item);//2nd column is Tool id
+                ui->tableWidget->setItem(currentRow, IdColumn, item); //2nd column is Tool id
             }
 
             {
                 QTableWidgetItem *item = new QTableWidgetItem(QString(rowData.name));
-                item->setTextAlignment(Qt::AlignHCenter);
-                item->setSizeHint(QSize(100, 24));
+                item->setTextAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
                 item->setFlags(item->flags() ^ Qt::ItemIsEditable);
-                ui->tableWidget->setItem(currentRow, 1, item);//3rd column is Tool name
+                ui->tableWidget->setColumnWidth(NameColumn, 150);
+                ui->tableWidget->setItem(currentRow, NameColumn, item); //3rd column is Tool name or Obj names
+                ui->tableWidget->resizeRowToContents(currentRow);
             }
 
-            QTableWidgetItem *item = new QTableWidgetItem(rowData.tool);
-            item->setTextAlignment(Qt::AlignLeft);
-            item->setFlags(item->flags() ^ Qt::ItemIsEditable);
-            item->setIcon(QIcon(rowData.icon));
-            ui->tableWidget->setItem(currentRow, 2, item);//4th column is Tool description
+                QTableWidgetItem *item = new QTableWidgetItem(rowData.tool);
+                item->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+                item->setFlags(item->flags() ^ Qt::ItemIsEditable);
+                ui->tableWidget->setColumnWidth(DescColumn, 400);
+                item->setIcon(QIcon(rowData.icon));
+                ui->tableWidget->setItem(currentRow, DescColumn, item); //4th column is Tool description
+
+            {
+                QTableWidgetItem *item = new QTableWidgetItem(QString(rowData.length));
+                item->setTextAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+                item->setFlags(item->flags() ^ Qt::ItemIsEditable);
+                ui->tableWidget->setColumnWidth(LengthColumn, 120);
+                ui->tableWidget->setItem(currentRow, LengthColumn, item); //5th column is Tool length formula
+                ui->tableWidget->resizeRowToContents(currentRow);
+            }
+
+            {
+                QTableWidgetItem *item = new QTableWidgetItem(QString(rowData.angle));
+                item->setTextAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+                item->setFlags(item->flags() ^ Qt::ItemIsEditable);
+                ui->tableWidget->setColumnWidth(AngleColumn, 120);
+                ui->tableWidget->setItem(currentRow, AngleColumn, item); //6th column is Tool angle formula
+                ui->tableWidget->resizeRowToContents(currentRow);
+            }
             ++count;
         }
     }
+
     ui->tableWidget->setRowCount(count);//Current history records count
+
     if (count>0)
     {
         m_cursorRow = cursorRow();
-        QTableWidgetItem *item = ui->tableWidget->item(m_cursorRow, 0);
+        QTableWidgetItem *item = ui->tableWidget->item(m_cursorRow, CursorColumn);
         SCASSERT(item != nullptr)
         item->setIcon(QIcon("://icon/24x24/left_to_right_arrow.png"));//place arrow in 1st column of most recent history record
     }
 
-    ui->tableWidget->resizeColumnsToContents();
-    ui->tableWidget->resizeRowsToContents();
-    ui->tableWidget->verticalHeader()->setDefaultSectionSize(24);//Set all row heights to 20px
 }
 
 
@@ -317,250 +378,251 @@ RowData HistoryDialog::record(const VToolRecord &tool)
 
             case Tool::BasePoint:
                 rowData.icon = ":/toolicon/32x32/point_basepoint_icon.png";
-                rowData.name = getPointName(toolId);
+                rowData.name = getName(toolId);
                 rowData.tool = tr("Base Point");
                 break;
 
             case Tool::EndLine:
-                rowData.icon = ":/toolicon/32x32/segment.png";
-                rowData.name = getPointName(toolId);
-                rowData.tool = tr("Point Length and Angle from point %1")
-                                  .arg(getPointName(attrUInt(domElement, AttrBasePoint)));
-                break;
+                rowData.icon   = ":/toolicon/32x32/segment.png";
+                rowData.name   = getName(toolId);
+                rowData.length = m_doc->GetParametrString(domElement, AttrLength, QString());
+                rowData.angle  = m_doc->GetParametrString(domElement, AttrAngle, QString());
+                rowData.tool   = tr("Point Length and Angle from point %1")
+                                    .arg(getName(attrUInt(domElement, AttrBasePoint)));
+                                break;
 
             case Tool::Line:
                 rowData.icon = ":/toolicon/32x32/line.png";
                 rowData.name = tr("Line_%1_%2")
-                                  .arg(getPointName(attrUInt(domElement, AttrFirstPoint)))
-                                  .arg(getPointName(attrUInt(domElement, AttrSecondPoint)));
+                                  .arg(getName(attrUInt(domElement, AttrFirstPoint)))
+                                  .arg(getName(attrUInt(domElement, AttrSecondPoint)));
                 rowData.tool = tr("Line from %1 to %2")
-                                  .arg(getPointName(attrUInt(domElement, AttrFirstPoint)))
-                                  .arg(getPointName(attrUInt(domElement, AttrSecondPoint)));
+                                  .arg(getName(attrUInt(domElement, AttrFirstPoint)))
+                                  .arg(getName(attrUInt(domElement, AttrSecondPoint)));
                 break;
 
             case Tool::AlongLine:
                 rowData.icon = ":/toolicon/32x32/along_line.png";
-                rowData.name = getPointName(toolId);
+                rowData.name = getName(toolId);
                 rowData.tool = tr("Point On Line %1_%2")
-                                  .arg(getPointName(attrUInt(domElement, AttrFirstPoint)))
-                                  .arg(getPointName(attrUInt(domElement, AttrSecondPoint)));
+                                  .arg(getName(attrUInt(domElement, AttrFirstPoint)))
+                                  .arg(getName(attrUInt(domElement, AttrSecondPoint)));
                 break;
 
             case Tool::ShoulderPoint:
                 rowData.icon = ":/toolicon/32x32/shoulder.png";
-                rowData.name = getPointName(toolId);
+                rowData.name = getName(toolId);
                 rowData.tool = tr("Point Length to Line");
                 break;
 
             case Tool::Normal:
-                rowData.icon = ":/toolicon/32x32/normal.png";
-                rowData.name = getPointName(toolId);
-                rowData.tool = tr("Point On Perpendicular %1_%2")
-                                 .arg(getPointName(attrUInt(domElement, AttrFirstPoint)))
-                                 .arg(getPointName(attrUInt(domElement, AttrSecondPoint)));
+                rowData.icon   = ":/toolicon/32x32/normal.png";
+                rowData.name   = getName(toolId);
+                rowData.length = m_doc->GetParametrString(domElement, AttrLength, QString());
+                rowData.angle  = m_doc->GetParametrString(domElement, AttrAngle, QString());
+                rowData.tool   = tr("Point On Perpendicular %1_%2")
+                                .arg(getName(attrUInt(domElement, AttrFirstPoint)))
+                                .arg(getName(attrUInt(domElement, AttrSecondPoint)));
                 break;
 
             case Tool::Bisector:
                 rowData.icon = ":/toolicon/32x32/bisector.png";
-                rowData.name = getPointName(toolId);
+                rowData.name = getName(toolId);
                 rowData.tool = tr("Point On Bisector %1_%2_%3")
-                                 .arg(getPointName(attrUInt(domElement, AttrFirstPoint)))
-                                 .arg(getPointName(attrUInt(domElement, AttrSecondPoint)))
-                                 .arg(getPointName(attrUInt(domElement, AttrThirdPoint)));
+                                 .arg(getName(attrUInt(domElement, AttrFirstPoint)))
+                                 .arg(getName(attrUInt(domElement, AttrSecondPoint)))
+                                 .arg(getName(attrUInt(domElement, AttrThirdPoint)));
                 break;
 
             case Tool::LineIntersect:
                 rowData.icon = ":/toolicon/32x32/intersect.png";
-                rowData.name = getPointName(toolId);
+                rowData.name = getName(toolId);
                 rowData.tool = tr("Point Intersect Lines %1_%2 and %3_%4")
-                                 .arg(getPointName(attrUInt(domElement, AttrP1Line1)))
-                                 .arg(getPointName(attrUInt(domElement, AttrP2Line1)))
-                                 .arg(getPointName(attrUInt(domElement, AttrP1Line2)))
-                                 .arg(getPointName(attrUInt(domElement, AttrP2Line2)));
+                                 .arg(getName(attrUInt(domElement, AttrP1Line1)))
+                                 .arg(getName(attrUInt(domElement, AttrP2Line1)))
+                                 .arg(getName(attrUInt(domElement, AttrP1Line2)))
+                                 .arg(getName(attrUInt(domElement, AttrP2Line2)));
                 break;
 
             case Tool::Spline:
             {
-                const QSharedPointer<VSpline> spl = data->GeometricObject<VSpline>(toolId);
-                SCASSERT(!spl.isNull())
-                rowData.icon = ":/toolicon/32x32/spline.png";
-                rowData.name = spl->NameForHistory(tr("Spl_"));
-                rowData.tool = tr("Curve Interactive");
+                rowData.icon   = ":/toolicon/32x32/spline.png";
+                rowData.name   = getName(toolId);
+                rowData.length = tr("%1\n%2")
+                                   .arg(m_doc->GetParametrString(domElement, AttrLength1, QString()))
+                                   .arg(m_doc->GetParametrString(domElement, AttrLength2, QString()));
+                rowData.angle  = tr("%1\n%2")
+                                   .arg(m_doc->GetParametrString(domElement, AttrAngle1, QString()))
+                                   .arg(m_doc->GetParametrString(domElement, AttrAngle2, QString()));
+                rowData.tool   = tr("Curve Interactive");
                 break;
             }
 
             case Tool::CubicBezier:
             {
-                const QSharedPointer<VCubicBezier> spl = data->GeometricObject<VCubicBezier>(toolId);
-                SCASSERT(!spl.isNull())
                 rowData.icon = ":/toolicon/32x32/cubic_bezier.png";
-                rowData.name = spl->NameForHistory(tr("Spl_"));
+                rowData.name = getName(toolId);
                 rowData.tool = tr("Curve Fixed");
                 break;
             }
 
             case Tool::Arc:
             {
-                const QSharedPointer<VArc> arc = data->GeometricObject<VArc>(toolId);
-                SCASSERT(!arc.isNull())
-                rowData.icon = ":/toolicon/32x32/arc.png";
-                rowData.name = arc->NameForHistory(tr("Arc_"));
-                rowData.tool = tr("Arc Radius & Angles");
+                rowData.icon   = ":/toolicon/32x32/arc.png";
+                rowData.name   = getName(toolId);
+                rowData.length = m_doc->GetParametrString(domElement, AttrRadius, QString());
+                rowData.angle  = QString("%1\n %2")
+                                 .arg(m_doc->GetParametrString(domElement, AttrAngle1, QString()))
+                                 .arg(m_doc->GetParametrString(domElement, AttrAngle2, QString()));
+                rowData.tool   = tr("Arc Radius & Angles");
                 break;
             }
 
             case Tool::ArcWithLength:
             {
-                const QSharedPointer<VArc> arc = data->GeometricObject<VArc>(toolId);
-                SCASSERT(!arc.isNull())
-                rowData.icon = ":/toolicon/32x32/arc_with_length.png";
-                rowData.name = arc->NameForHistory(tr("Arc_"));
-                rowData.tool = tr("Arc Radius & Length %1") .arg(arc->NameForHistory(tr("Arc_")));
+                rowData.icon   = ":/toolicon/32x32/arc_with_length.png";
+                rowData.name   = getName(toolId);
+                rowData.length = QString("%1\n %2").arg(m_doc->GetParametrString(domElement, AttrRadius, ""))
+                                                   .arg(m_doc->GetParametrString(domElement, AttrLength, ""));
+                rowData.angle  = m_doc->GetParametrString(domElement, AttrAngle1, QString());
+                rowData.tool   = tr("Arc with Radius, Length, and Angle");
                 break;
             }
 
             case Tool::SplinePath:
             {
-                const QSharedPointer<VSplinePath> splPath = data->GeometricObject<VSplinePath>(toolId);
-                SCASSERT(!splPath.isNull())
                 rowData.icon = ":/toolicon/32x32/splinePath.png";
-                rowData.name = splPath->NameForHistory(tr("SplPath_"));
+                rowData.name = getName(toolId);
                 rowData.tool = tr("Spline Interactive");
                 break;
             }
 
             case Tool::CubicBezierPath:
             {
-                const QSharedPointer<VCubicBezierPath> splPath = data->GeometricObject<VCubicBezierPath>(toolId);
-                SCASSERT(!splPath.isNull())
                 rowData.icon = ":/toolicon/32x32/cubic_bezier_path.png";
-                rowData.name = splPath->NameForHistory(tr("SplPath_"));
+                rowData.name = getName(toolId);
                 rowData.tool = tr("Spline Fixed");
                 break;
             }
 
             case Tool::PointOfContact:
                 rowData.icon = ":/toolicon/32x32/point_intersect_arc_line.png";
-                rowData.name = getPointName(toolId);
+                rowData.name = getName(toolId);
                 rowData.tool = tr("Point Intersect Arc with center %1 & Line %2_%3")
-                                  .arg(getPointName(attrUInt(domElement, AttrCenter)))
-                                  .arg(getPointName(attrUInt(domElement, AttrFirstPoint)))
-                                  .arg(getPointName(attrUInt(domElement, AttrSecondPoint)));
+                                  .arg(getName(attrUInt(domElement, AttrCenter)))
+                                  .arg(getName(attrUInt(domElement, AttrFirstPoint)))
+                                  .arg(getName(attrUInt(domElement, AttrSecondPoint)));
                 break;
 
             case Tool::Height:
                 rowData.icon = ":/toolicon/32x32/height.png";
-                rowData.name = getPointName(toolId);
+                rowData.name = getName(toolId);
                 rowData.tool = tr("Point Intersect Line %1_%2 & Perpendicular %3")
-                                  .arg(getPointName(attrUInt(domElement, AttrP1Line)))
-                                  .arg(getPointName(attrUInt(domElement, AttrP2Line)))
-                                  .arg(getPointName(attrUInt(domElement, AttrBasePoint)));
+                                  .arg(getName(attrUInt(domElement, AttrP1Line)))
+                                  .arg(getName(attrUInt(domElement, AttrP2Line)))
+                                  .arg(getName(attrUInt(domElement, AttrBasePoint)));
                 break;
 
             case Tool::Triangle:
                 rowData.icon = ":/toolicon/32x32/triangle.png";
-                rowData.name = getPointName(toolId);
+                rowData.name = getName(toolId);
                 rowData.tool = tr("Point Intersect Axis %1_%2 & Triangle points %3 and %4")
-                                  .arg(getPointName(attrUInt(domElement, AttrAxisP1)))
-                                  .arg(getPointName(attrUInt(domElement, AttrAxisP2)))
-                                  .arg(getPointName(attrUInt(domElement, AttrFirstPoint)))
-                                  .arg(getPointName(attrUInt(domElement, AttrSecondPoint)));
+                                  .arg(getName(attrUInt(domElement, AttrAxisP1)))
+                                  .arg(getName(attrUInt(domElement, AttrAxisP2)))
+                                  .arg(getName(attrUInt(domElement, AttrFirstPoint)))
+                                  .arg(getName(attrUInt(domElement, AttrSecondPoint)));
                 break;
 
             case Tool::PointOfIntersection:
                 rowData.icon = ":/toolicon/32x32/point_intersectxy_icon.png";
-                rowData.name = getPointName(toolId);
+                rowData.name = getName(toolId);
                 rowData.tool = tr("Point Intersect XY of points %1 and %2")
-                                  .arg(getPointName(attrUInt(domElement, AttrFirstPoint)))
-                                  .arg(getPointName(attrUInt(domElement, AttrSecondPoint)));
+                                  .arg(getName(attrUInt(domElement, AttrFirstPoint)))
+                                  .arg(getName(attrUInt(domElement, AttrSecondPoint)));
                 break;
 
             case Tool::CutArc:
             {
-                const QSharedPointer<VArc> arc = data->GeometricObject<VArc>(attrUInt(domElement, AttrArc));
-                SCASSERT(!arc.isNull())
-                rowData.icon = ":/toolicon/32x32/arc_cut.png";
-                rowData.name = getPointName(toolId);
-                rowData.tool = tr("Point On Arc");
+                rowData.icon   = ":/toolicon/32x32/arc_cut.png";
+                rowData.name   = getName(toolId);
+                rowData.length = m_doc->GetParametrString(domElement, AttrLength, QString());
+                rowData.tool   = tr("Point On Arc");
                 break;
             }
 
             case Tool::CutSpline:
             {
-                const quint32 splineId = attrUInt(domElement, VToolCutSpline::AttrSpline);
-                const QSharedPointer<VAbstractCubicBezier> spl = data->GeometricObject<VAbstractCubicBezier>(splineId);
-                SCASSERT(!spl.isNull())
-                rowData.icon = ":/toolicon/32x32/spline_cut_point.png";
-                rowData.name = getPointName(toolId);
-                rowData.tool = tr("Point On Curve");
+                rowData.icon   = ":/toolicon/32x32/spline_cut_point.png";
+                rowData.name   = getName(toolId);
+                rowData.length = m_doc->GetParametrString(domElement, AttrLength, QString());
+                rowData.tool   = tr("Point On Curve");
                 break;
             }
 
             case Tool::CutSplinePath:
             {
-                const quint32 splinePathId = attrUInt(domElement, VToolCutSplinePath::AttrSplinePath);
-                const QSharedPointer<VAbstractCubicBezierPath> splPath =
-                data->GeometricObject<VAbstractCubicBezierPath>(splinePathId);
-                SCASSERT(!splPath.isNull())
-                rowData.icon = ":/toolicon/32x32/splinePath_cut_point.png";
-                rowData.name = getPointName(toolId);
-                rowData.tool = tr("Point On Spline");
+                rowData.icon   = ":/toolicon/32x32/splinePath_cut_point.png";
+                rowData.name   = getName(toolId);
+                rowData.length = m_doc->GetParametrString(domElement, AttrLength, QString());
+                rowData.tool   = tr("Point On Spline");
                 break;
             }
 
             case Tool::LineIntersectAxis:
                 rowData.icon = ":/toolicon/32x32/line_intersect_axis.png";
-                rowData.name = getPointName(toolId);
+                rowData.name = getName(toolId);
                 rowData.tool = tr("%Point Intersect Line & %1_%2 and Axis through point %3")
-                                 .arg(getPointName(attrUInt(domElement, AttrP1Line)))
-                                 .arg(getPointName(attrUInt(domElement, AttrP2Line)))
-                                 .arg(getPointName(attrUInt(domElement, AttrBasePoint)));
+                                 .arg(getName(attrUInt(domElement, AttrP1Line)))
+                                 .arg(getName(attrUInt(domElement, AttrP2Line)))
+                                 .arg(getName(attrUInt(domElement, AttrBasePoint)));
                 break;
 
             case Tool::CurveIntersectAxis:
-                rowData.icon = ":/toolicon/32x32/arc_intersect_axis.png";
-                rowData.name = getPointName(toolId);
-                rowData.tool = tr("Point Intersect Curve & Axis through point %1")
-                                  .arg(getPointName(attrUInt(domElement, AttrBasePoint)));
-                break;
+            rowData.icon   = ":/toolicon/32x32/arc_intersect_axis.png";
+            rowData.name   = getName(toolId);
+            rowData.angle  = m_doc->GetParametrString(domElement, AttrAngle, QString());
+            rowData.tool   = tr("Point Intersect Curve & Axis through point %1")
+                                .arg(getName(attrUInt(domElement, AttrBasePoint)));
+            break;
 
             case Tool::PointOfIntersectionArcs:
                 rowData.icon = ":/toolicon/32x32/point_of_intersection_arcs.png";
-                rowData.name = getPointName(toolId);
+                rowData.name = getName(toolId);
                 rowData.tool = tr("Point Intersect Arcs");
                 break;
 
             case Tool::PointOfIntersectionCircles:
                 rowData.icon = ":/toolicon/32x32/point_of_intersection_circles.png";
-                rowData.name = getPointName(toolId);
+                rowData.name = getName(toolId);
                 rowData.tool = tr("%1 - Point Intersect Circles");
                 break;
 
             case Tool::PointOfIntersectionCurves:
                 rowData.icon = ":/toolicon/32x32/intersection_curves.png";
-                rowData.name = getPointName(toolId);
+                rowData.name = getName(toolId);
                 rowData.tool = tr("Point Intersect Curves");
                 break;
 
             case Tool::PointFromCircleAndTangent:
                 rowData.icon = ":/toolicon/32x32/point_from_circle_and_tangent.png";
-                rowData.name = getPointName(toolId);
+                rowData.name = getName(toolId);
                 rowData.tool = tr("Point Intersect Circle & Tangent");
                 break;
 
             case Tool::PointFromArcAndTangent:
                 rowData.icon = ":/toolicon/32x32/point_from_arc_and_tangent.png";
-                rowData.name = getPointName(toolId);
+                rowData.name = getName(toolId);
                 rowData.tool = tr("Point Intersect Arc & Tangent");
                 break;
 
             case Tool::TrueDarts:
                 rowData.icon = ":/toolicon/32x32/true_darts.png";
-                rowData.name = QString("");
+                rowData.name = getName(attrUInt(domElement, AttrPoint1)) + QStringLiteral("\n") +
+                            getName(attrUInt(domElement, AttrPoint2));
                 rowData.tool = tr("True Dart %1_%2_%3")
-                                 .arg(getPointName(attrUInt(domElement, AttrDartP1)))
-                                 .arg(getPointName(attrUInt(domElement, AttrDartP2)))
-                                 .arg(getPointName(attrUInt(domElement, AttrDartP2)));
+                                .arg(getName(attrUInt(domElement, AttrDartP1)))
+                                .arg(getName(attrUInt(domElement, AttrDartP2)))
+                                .arg(getName(attrUInt(domElement, AttrDartP3)));
                 break;
 
             case Tool::EllipticalArc:
@@ -574,37 +636,52 @@ RowData HistoryDialog::record(const VToolRecord &tool)
 
             }
             case Tool::Rotation:
+            {
+                const QString suffix = m_doc->GetParametrString(domElement, AttrSuffix, QString());
                 rowData.icon = ":/toolicon/32x32/rotation.png";
-                rowData.name = QString("");
+                rowData.name = getDestinationNames(domElement, suffix);
                 rowData.tool = tr("Rotation around point %1. Suffix %2")
-                                  .arg(getPointName(attrUInt(domElement, AttrCenter)),
-                                       m_doc->GetParametrString(domElement, AttrSuffix, QString()));
+                                .arg(getName(attrUInt(domElement, AttrCenter)), suffix);
                 break;
+            }
 
             case Tool::MirrorByLine:
+            {
+                const QString suffix = m_doc->GetParametrString(domElement, AttrSuffix, QString());
                 rowData.icon = ":/toolicon/32x32/mirror_by_line.png";
-                rowData.name = QString("");
+                rowData.name = getDestinationNames(domElement, suffix);
                 rowData.tool = tr("Mirror by Line %1_%2. Suffix %3")
-                                  .arg(getPointName(attrUInt(domElement, AttrP1Line)))
-                                  .arg(getPointName(attrUInt(domElement, AttrP2Line)),
-                                       m_doc->GetParametrString(domElement, AttrSuffix, QString()));
+                                  .arg(getName(attrUInt(domElement, AttrP1Line)))
+                                  .arg(getName(attrUInt(domElement, AttrP2Line)), suffix);
                 break;
+            }
 
             case Tool::MirrorByAxis:
+            {
+                const QString suffix = m_doc->GetParametrString(domElement, AttrSuffix, QString());
                 rowData.icon = ":/toolicon/32x32/mirror_by_axis.png";
-                rowData.name = QString("");
+                rowData.name = getDestinationNames(domElement, suffix);
                 rowData.tool = tr("Mirror by Axis through %1 point. Suffix %2")
-                                  .arg(getPointName(attrUInt(domElement, AttrCenter)),
-                                       m_doc->GetParametrString(domElement, AttrSuffix, QString()));
+                                  .arg(getName(attrUInt(domElement, AttrCenter)), suffix);
                 break;
+            }
 
             case Tool::Move:
+            {
+                const QString suffix = m_doc->GetParametrString(domElement, AttrSuffix, QString());
                 rowData.icon = ":/toolicon/32x32/move.png";
-                rowData.name = QString("");
+                rowData.name = getDestinationNames(domElement, suffix);
+
+                quint32 id = attrUInt(domElement, AttrCenter);
+                QString pointName = tr("Center point");
+                if (id != NULL)
+                {
+                    pointName = getName(id);
+                }
                 rowData.tool = tr("Move - rotate around point %1. Suffix %2")
-                                  .arg(getPointName(attrUInt(domElement, AttrCenter)),
-                                       m_doc->GetParametrString(domElement, AttrSuffix, QString()));
+                                .arg(pointName, suffix);
                 break;
+            }
 
             //Because "history" not only shows history of pattern, but helps restore current data for each pattern's
             //piece, we need add record about details and nodes, but don't show them.
@@ -642,9 +719,12 @@ void HistoryDialog::initializeTable()
     ui->tableWidget->setSortingEnabled(false);
     ui->tableWidget->verticalHeader()->setDefaultAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
     ui->tableWidget->horizontalHeader()->setDefaultAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
-    ui->tableWidget->setHorizontalHeaderItem(0, new QTableWidgetItem("Id"));
-    ui->tableWidget->setHorizontalHeaderItem(1, new QTableWidgetItem(tr("Name")));
-    ui->tableWidget->setHorizontalHeaderItem(2, new QTableWidgetItem(tr("Description")));
+    ui->tableWidget->setHorizontalHeaderItem(CursorColumn, new QTableWidgetItem(""));
+    ui->tableWidget->setHorizontalHeaderItem(IdColumn, new QTableWidgetItem("Id"));
+    ui->tableWidget->setHorizontalHeaderItem(NameColumn, new QTableWidgetItem(tr("Name")));
+    ui->tableWidget->setHorizontalHeaderItem(DescColumn, new QTableWidgetItem(tr("Description")));
+    ui->tableWidget->setHorizontalHeaderItem(LengthColumn, new QTableWidgetItem(tr("Radius / Length")));
+    ui->tableWidget->setHorizontalHeaderItem(AngleColumn, new QTableWidgetItem(tr("Angle")));
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -655,25 +735,49 @@ void HistoryDialog::showTool()
     const QVector<VToolRecord> *history = m_doc->getHistory();
     if (history->size()>0)
     {
-        QTableWidgetItem *item = ui->tableWidget->item(0, 1);
-        item->setSelected(true);
+        // Select 1st tool and highlight it in draftblock
+        QTableWidgetItem *item = ui->tableWidget->item(0, CursorColumn);
         m_cursorToolRecordRow = 0;
-        item = ui->tableWidget->item(0, 0);
+        item = ui->tableWidget->item(0, IdColumn);
         quint32 id = qvariant_cast<quint32>(item->data(Qt::UserRole));
         emit showHistoryTool(id, true);
     }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/// @brief HistoryDialog::PointName return point name by id.
+/// @brief HistoryDialog::getName get object name by id.
 ///
-/// Refacoring what hide ugly string getting point name by id.
-/// @param pointId point if in data.
-/// @return point name.
+/// This method gets the name of the VObject with the given tool id.
+///
+/// @param toolId id of object.
+/// @return name of object.
 //---------------------------------------------------------------------------------------------------------------------
-QString HistoryDialog::getPointName(quint32 pointId)
+QString HistoryDialog::getName(const quint32 &toolId)
 {
-    return data->GeometricObject<VPointF>(pointId)->name();
+    const QSharedPointer<VGObject> object = data->GetGObject(toolId);
+    return object->name();
+}
+
+QString HistoryDialog::getDestinationNames(const QDomElement &domElement, const QString &suffix)
+{
+    QString name = QString("");
+    QVector<SourceItem> source;
+    QVector<DestinationItem> destination;
+    VAbstractOperation::ExtractData(domElement, source, destination);
+
+    for(int i = 0; i < source.size(); i++)
+    {
+        if ((i > 0) && (i != source.size()))
+
+        {
+            name = name + QStringLiteral("\n") + getName(source[i].id) + suffix;
+        }
+        else
+        {
+            name = name + getName(source[i].id) + suffix;
+        }
+    }
+    return name;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -688,9 +792,14 @@ quint32 HistoryDialog::attrUInt(const QDomElement &domElement, const QString &na
 //---------------------------------------------------------------------------------------------------------------------
 void HistoryDialog::closeEvent(QCloseEvent *event)
 {
-    QTableWidgetItem *item = ui->tableWidget->item(m_cursorToolRecordRow,1);
+    // Highlight tool in draft block
+    QTableWidgetItem *item = ui->tableWidget->item(m_cursorToolRecordRow, IdColumn);
     quint32 id = qvariant_cast<quint32>(item->data(Qt::UserRole));
     emit showHistoryTool(id, false);
+
+    // Reset cursor to bottom of table before closing
+    m_doc->setCursorId(NULL_ID);
+
     DialogTool::closeEvent(event);
 }
 
@@ -716,7 +825,12 @@ bool HistoryDialog::eventFilter(QObject *object, QEvent *event)
         if (event->type() == QEvent::KeyPress)
         {
             QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
-            if ((keyEvent->key() == Qt::Key_Period) && (keyEvent->modifiers() & Qt::KeypadModifier))
+            if ((keyEvent->key() == Qt::Key_Enter) || (keyEvent->key() == Qt::Key_Return))
+            {
+                // Ignore Enter key
+                return true;
+            }
+            else if ((keyEvent->key() == Qt::Key_Period) && (keyEvent->modifiers() & Qt::KeypadModifier))
             {
                 QString separator = qApp->Settings()->getOsSeparator()
                                   ? QString(localeDecimalPoint(QLocale()))
@@ -736,43 +850,90 @@ bool HistoryDialog::eventFilter(QObject *object, QEvent *event)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+/// @brief showEvent Reimplement show event.
+///
+/// This method reimplemnts the showevent and resizes the dialog based on the last saved size.
+///
+/// @param event event
+//---------------------------------------------------------------------------------------------------------------------
+
+void HistoryDialog::showEvent(QShowEvent *event)
+{
+    // Skip DialogTool implementation
+    QDialog::showEvent(event);
+    if ( event->spontaneous() )
+    {
+        return;
+    }
+
+    if (isInitialized)
+    {
+        return;
+    }
+
+    const QSize size = qApp->Settings()->getHistoryDialogSize();
+    if (! size.isEmpty())
+    {
+        resize(size);
+    }
+
+    isInitialized = true;//first show windows are held
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief resizeEvent Reimplement rsize event.
+/// @param event event
+//---------------------------------------------------------------------------------------------------------------------
+void HistoryDialog::resizeEvent(QResizeEvent *event)
+{
+    // remember the size for the next time this dialog is opened, but only
+    // if widget was already initialized, which rules out the resize when
+    // dialog is created.
+    if (isInitialized)
+    {
+        qApp->Settings()->setHistoryDialogSize(size());
+    }
+    DialogTool::resizeEvent(event);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 void HistoryDialog::retranslateUi()
 {
     qint32 currentRow = m_cursorRow;
-    updateHistory();
+    updateHistory(true);
 
-    QTableWidgetItem *item = ui->tableWidget->item(m_cursorRow, 0);
+    QTableWidgetItem *item = ui->tableWidget->item(m_cursorRow, CursorColumn);
     SCASSERT(item != nullptr)
     item->setIcon(QIcon(""));
 
     m_cursorRow = currentRow;
-    cellClicked(m_cursorRow, 0);
+    cellClicked(m_cursorRow, CursorColumn);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 int HistoryDialog::cursorRow() const
 {
-    const quint32 cursor = m_doc->getCursor();
-    if (cursor == 0)
+    const quint32 cursorId = m_doc->getCursorId();
+    if (cursorId == NULL_ID)
     {
         return ui->tableWidget->rowCount()-1;
     }
 
-    for (int i = 0; i < ui->tableWidget->rowCount(); ++i)
+    for (int row = 0; row < ui->tableWidget->rowCount(); ++row)
     {
-        QTableWidgetItem *item = ui->tableWidget->item(i, 0);
+        QTableWidgetItem *item = ui->tableWidget->item(row, IdColumn);
         const quint32 id = qvariant_cast<quint32>(item->data(Qt::UserRole));
-        if (cursor == id)
+        if (cursorId == id)
         {
-            return i;
+            return row;
         }
     }
-    return ui->tableWidget->rowCount()-1;
+    return ui->tableWidget->rowCount() - 1;
 }
 
 void HistoryDialog::findText(const QString &text)
 {
-    updateHistory();
+    updateHistory(true);
     m_search->find(text);
 }
 
@@ -874,4 +1035,32 @@ void HistoryDialog::wordToggled(bool checked)
 
     m_search->setMatchWord(checked);
     m_search->find(ui->find_LineEdit->text());
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief moveToTop  Scroll to top of table.
+//---------------------------------------------------------------------------------------------------------------------
+void HistoryDialog::moveToTop()
+{
+    ui->tableWidget->verticalScrollBar()->setValue(ui->tableWidget->verticalScrollBar()->minimum());
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief moveToCursor Scroll to cursor osition in table.
+//---------------------------------------------------------------------------------------------------------------------
+void HistoryDialog::moveToCursor()
+{
+    QTableWidgetItem *item = ui->tableWidget->item(m_cursorRow, CursorColumn);
+    if (item)
+    {
+        ui->tableWidget->scrollToItem(item, QAbstractItemView::PositionAtCenter);
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief moveToBottom Scroll to bottom of table.
+//---------------------------------------------------------------------------------------------------------------------
+void HistoryDialog::moveToBottom()
+{
+    ui->tableWidget->verticalScrollBar()->setValue(ui->tableWidget->verticalScrollBar()->maximum());
 }

--- a/src/app/seamly2d/dialogs/history_dialog.cpp
+++ b/src/app/seamly2d/dialogs/history_dialog.cpp
@@ -448,10 +448,10 @@ RowData HistoryDialog::record(const VToolRecord &tool)
             {
                 rowData.icon   = ":/toolicon/32x32/spline.png";
                 rowData.name   = getName(toolId);
-                rowData.length = tr("%1\n%2")
+                rowData.length = QString("%1\n%2")
                                    .arg(m_doc->GetParametrString(domElement, AttrLength1, QString()))
                                    .arg(m_doc->GetParametrString(domElement, AttrLength2, QString()));
-                rowData.angle  = tr("%1\n%2")
+                rowData.angle  = QString("%1\n%2")
                                    .arg(m_doc->GetParametrString(domElement, AttrAngle1, QString()))
                                    .arg(m_doc->GetParametrString(domElement, AttrAngle2, QString()));
                 rowData.tool   = tr("Curve Interactive");

--- a/src/app/seamly2d/dialogs/history_dialog.h
+++ b/src/app/seamly2d/dialogs/history_dialog.h
@@ -56,6 +56,7 @@
 #include "../vtools/dialogs/tools/dialogtool.h"
 
 #include <QDomElement>
+#include <QTableWidgetItem>
 
 class VPattern;
 class VTableSearch;
@@ -68,9 +69,11 @@ namespace Ui
 struct RowData
 {
      quint32 id{NULL_ID};
-     QString icon{QString()};
-     QString name{QString()};
-     QString tool{QString()};
+     QString icon{QString("")};
+     QString name{QString("")};
+     QString tool{QString("")};
+     QString length{QString("")};
+     QString angle{QString("")};
 };
 
 class HistoryDialog : public DialogTool
@@ -82,25 +85,22 @@ public:
 
 public slots:
     virtual void            DialogAccepted() override;
-
-    // TODO ISSUE 79 : create real function
-    /// @brief DialogApply apply data and emit signal about applied dialog.
-    virtual void            DialogApply() override {}
-
     void                    cellClicked(int row, int column);
-    void                    changedCursor(quint32 id);
-    void                    updateHistory();
+    void                    cursorChanged(quint32 id);
+    void                    updateHistory(bool saved);
 
 signals:
-     /// @brief showHistoryTool signal change color of selected in records tool
-     /// @param id id of tool
-     /// @param enable true enable selection, false disable selection
+    // @brief showHistoryTool signal change to highlight selected tool in history
+    // @param id id of tool
+    // @param enable true enable selection, false disable selection
     void                    showHistoryTool(quint32 id, bool enable);
 
 protected:
-    virtual void            closeEvent ( QCloseEvent *event ) override;
-    virtual void            changeEvent(QEvent *event) override;
+    virtual void            closeEvent ( QCloseEvent * event ) override;
+    virtual void            changeEvent(QEvent* event) override;
     virtual bool            eventFilter(QObject *object, QEvent *event) override;
+    virtual void            showEvent( QShowEvent *event ) override;
+    virtual void            resizeEvent(QResizeEvent *event) override;
 
 private:
     Q_DISABLE_COPY(HistoryDialog)
@@ -113,9 +113,10 @@ private:
 
     void                    fillTable();
     RowData                 record(const VToolRecord &tool);
+    QString                 getName(const quint32 &toolId);
+    QString                 getDestinationNames(const QDomElement &domElement, const QString &suffix);
     void                    initializeTable();
     void                    showTool();
-    QString                 getPointName(quint32 pointId);
     quint32                 attrUInt(const QDomElement &domElement, const QString &name);
     void                    retranslateUi();
     int                     cursorRow() const;
@@ -126,6 +127,9 @@ private:
     void                    regexToggled(bool checked);
     void                    caseToggled(bool checked);
     void                    wordToggled(bool checked);
+    void                    moveToTop();
+    void                    moveToCursor();
+    void                    moveToBottom();
 };
 
 #endif // HISTORY_DIALOG_H

--- a/src/app/seamly2d/dialogs/history_dialog.ui
+++ b/src/app/seamly2d/dialogs/history_dialog.ui
@@ -10,12 +10,12 @@
     <x>0</x>
     <y>0</y>
     <width>801</width>
-    <height>550</height>
+    <height>448</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>0</width>
+    <width>100</width>
     <height>0</height>
    </size>
   </property>
@@ -99,7 +99,7 @@
   </property>
   <property name="windowIcon">
    <iconset resource="../../../libs/vmisc/share/resources/icon.qrc">
-    <normaloff>:/icon/64x64/icon64x64.png</normaloff>:/icon/64x64/icon64x64.png</iconset>
+    <normaloff>:/icon/32x32/history.png</normaloff>:/icon/32x32/history.png</iconset>
   </property>
   <property name="locale">
    <locale language="English" country="UnitedStates"/>
@@ -107,443 +107,542 @@
   <property name="sizeGripEnabled">
    <bool>true</bool>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
-   <property name="rightMargin">
-    <number>9</number>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout">
+    <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QToolButton" name="clipboard_ToolButton">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../../libs/vmisc/share/resources/icon.qrc">
-           <normaloff>:/icon/32x32/clipboard_icon.png</normaloff>:/icon/32x32/clipboard_icon.png</iconset>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>20</width>
-           <height>20</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="findIcon_Label">
-         <property name="maximumSize">
-          <size>
-           <width>16</width>
-           <height>16</height>
-          </size>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="pixmap">
-          <pixmap resource="../../../libs/vmisc/share/resources/icon.qrc">:/icon/32x32/find.png</pixmap>
-         </property>
-         <property name="scaledContents">
-          <bool>true</bool>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="findText_Label">
-         <property name="font">
-          <font>
-           <pointsize>10</pointsize>
-          </font>
-         </property>
-         <property name="text">
-          <string>Find:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLineEdit" name="find_LineEdit">
-         <property name="font">
-          <font>
-           <pointsize>10</pointsize>
-          </font>
-         </property>
-         <property name="mouseTracking">
-          <bool>true</bool>
-         </property>
-         <property name="placeholderText">
-          <string>Search text</string>
-         </property>
-         <property name="clearButtonEnabled">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="prev_PushButton">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>30</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>30</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Find previous</string>
-         </property>
-         <property name="text">
-          <string notr="true"/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../../libs/vmisc/share/resources/theme.qrc">
-           <normaloff>:/icons/win.icon.theme/32x32/actions/go-previous.png</normaloff>:/icons/win.icon.theme/32x32/actions/go-previous.png</iconset>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>24</width>
-           <height>18</height>
-          </size>
-         </property>
-         <property name="flat">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="next_PushButton">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>30</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>30</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Find next</string>
-         </property>
-         <property name="text">
-          <string notr="true"/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../../libs/vmisc/share/resources/theme.qrc">
-           <normaloff>:/icons/win.icon.theme/32x32/actions/go-next.png</normaloff>:/icons/win.icon.theme/32x32/actions/go-next.png</iconset>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>24</width>
-           <height>18</height>
-          </size>
-         </property>
-         <property name="flat">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QToolButton" name="regex_ToolButton">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>30</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>30</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Seach by regular expression</string>
-         </property>
-         <property name="text">
-          <string notr="true"/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../../libs/vmisc/share/resources/icon.qrc">
-           <normaloff>:/icon/svg/regex.svg</normaloff>:/icon/svg/regex.svg</iconset>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>24</width>
-           <height>18</height>
-          </size>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QToolButton" name="case_ToolButton">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>30</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>30</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Case sensitive</string>
-         </property>
-         <property name="text">
-          <string notr="true"/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../../libs/vmisc/share/resources/icon.qrc">
-           <normaloff>:/icon/svg/case.svg</normaloff>:/icon/svg/case.svg</iconset>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>24</width>
-           <height>18</height>
-          </size>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QToolButton" name="word_ToolButton">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>30</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>30</width>
-           <height>24</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Search by full word</string>
-         </property>
-         <property name="text">
-          <string notr="true"/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../../libs/vmisc/share/resources/icon.qrc">
-           <normaloff>:/icon/svg/word.svg</normaloff>:/icon/svg/word.svg</iconset>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>24</width>
-           <height>18</height>
-          </size>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
+      <widget class="QToolButton" name="clipboard_ToolButton">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../libs/vmisc/share/resources/icon.qrc">
+         <normaloff>:/icon/32x32/clipboard_icon.png</normaloff>:/icon/32x32/clipboard_icon.png</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+      </widget>
      </item>
      <item>
-      <widget class="QTableWidget" name="tableWidget">
-       <property name="palette">
-        <palette>
-         <active>
-          <colorrole role="Highlight">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>162</red>
-             <green>188</green>
-             <blue>216</blue>
-            </color>
-           </brush>
-          </colorrole>
-         </active>
-         <inactive>
-          <colorrole role="Highlight">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>162</red>
-             <green>188</green>
-             <blue>216</blue>
-            </color>
-           </brush>
-          </colorrole>
-         </inactive>
-         <disabled>
-          <colorrole role="Highlight">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>0</red>
-             <green>120</green>
-             <blue>215</blue>
-            </color>
-           </brush>
-          </colorrole>
-         </disabled>
-        </palette>
+      <widget class="QLabel" name="findIcon_Label">
+       <property name="maximumSize">
+        <size>
+         <width>16</width>
+         <height>16</height>
+        </size>
        </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="pixmap">
+        <pixmap resource="../../../libs/vmisc/share/resources/icon.qrc">:/icon/32x32/find.png</pixmap>
+       </property>
+       <property name="scaledContents">
+        <bool>true</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="findText_Label">
+       <property name="font">
+        <font>
+         <pointsize>10</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>Find:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="find_LineEdit">
        <property name="font">
         <font>
          <pointsize>10</pointsize>
         </font>
        </property>
        <property name="mouseTracking">
-        <bool>false</bool>
-       </property>
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">QHeaderView::section {
-	background-color: rgb(227, 227, 227);
-    border: 1px solid black;
-}</string>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Sunken</enum>
-       </property>
-       <property name="lineWidth">
-        <number>1</number>
-       </property>
-       <property name="alternatingRowColors">
         <bool>true</bool>
        </property>
-       <property name="selectionBehavior">
-        <enum>QAbstractItemView::SelectRows</enum>
+       <property name="placeholderText">
+        <string>Search text</string>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="prev_PushButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>30</width>
+         <height>24</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>24</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Find previous</string>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../libs/vmisc/share/resources/theme.qrc">
+         <normaloff>:/icons/win.icon.theme/32x32/actions/go-previous.png</normaloff>:/icons/win.icon.theme/32x32/actions/go-previous.png</iconset>
        </property>
        <property name="iconSize">
         <size>
          <width>24</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="flat">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="next_PushButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>30</width>
          <height>24</height>
         </size>
        </property>
-       <property name="wordWrap">
-        <bool>false</bool>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>24</height>
+        </size>
        </property>
-       <property name="cornerButtonEnabled">
+       <property name="toolTip">
+        <string>Find next</string>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../libs/vmisc/share/resources/theme.qrc">
+         <normaloff>:/icons/win.icon.theme/32x32/actions/go-next.png</normaloff>:/icons/win.icon.theme/32x32/actions/go-next.png</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>24</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="flat">
         <bool>true</bool>
        </property>
-       <property name="columnCount">
-        <number>3</number>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="regex_ToolButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <attribute name="horizontalHeaderVisible">
+       <property name="minimumSize">
+        <size>
+         <width>30</width>
+         <height>24</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>24</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Seach by regular expression</string>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../libs/vmisc/share/resources/icon.qrc">
+         <normaloff>:/icon/svg/regex.svg</normaloff>:/icon/svg/regex.svg</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>24</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="checkable">
         <bool>true</bool>
-       </attribute>
-       <attribute name="horizontalHeaderMinimumSectionSize">
-        <number>30</number>
-       </attribute>
-       <attribute name="horizontalHeaderDefaultSectionSize">
-        <number>40</number>
-       </attribute>
-       <attribute name="horizontalHeaderHighlightSections">
-        <bool>false</bool>
-       </attribute>
-       <attribute name="horizontalHeaderStretchLastSection">
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="case_ToolButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>30</width>
+         <height>24</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>24</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Case sensitive</string>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../libs/vmisc/share/resources/icon.qrc">
+         <normaloff>:/icon/svg/case.svg</normaloff>:/icon/svg/case.svg</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>24</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="checkable">
         <bool>true</bool>
-       </attribute>
-       <attribute name="verticalHeaderVisible">
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="word_ToolButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>30</width>
+         <height>24</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>24</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Search by full word</string>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../libs/vmisc/share/resources/icon.qrc">
+         <normaloff>:/icon/svg/word.svg</normaloff>:/icon/svg/word.svg</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>24</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="checkable">
         <bool>true</bool>
-       </attribute>
-       <attribute name="verticalHeaderMinimumSectionSize">
-        <number>24</number>
-       </attribute>
-       <attribute name="verticalHeaderDefaultSectionSize">
-        <number>24</number>
-       </attribute>
-       <attribute name="verticalHeaderHighlightSections">
-        <bool>false</bool>
-       </attribute>
-       <column>
-        <property name="text">
-         <string>Id</string>
-        </property>
-        <property name="font">
-         <font>
-          <pointsize>10</pointsize>
-         </font>
-        </property>
-        <property name="background">
-         <color>
-          <red>255</red>
-          <green>255</green>
-          <blue>255</blue>
-         </color>
-        </property>
-       </column>
-       <column>
-        <property name="text">
-         <string>Name</string>
-        </property>
-        <property name="font">
-         <font>
-          <pointsize>10</pointsize>
-         </font>
-        </property>
-       </column>
-       <column>
-        <property name="text">
-         <string>Description</string>
-        </property>
-        <property name="font">
-         <font>
-          <pointsize>10</pointsize>
-         </font>
-        </property>
-       </column>
+       </property>
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="draftblock_Label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>80</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Draft Block:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="draftblockName_Label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>500</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>block</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QToolButton" name="moveToTop_ToolButton">
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../libs/vmisc/share/resources/theme.qrc">
+         <normaloff>:/icons/win.icon.theme/32x32/actions/go-top.png</normaloff>:/icons/win.icon.theme/32x32/actions/go-top.png</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="moveToCursor_ToolButton">
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../libs/vmisc/share/resources/icon.qrc">
+         <normaloff>:/icon/24x24/fast_forward_left_to_right_arrow.png</normaloff>:/icon/24x24/fast_forward_left_to_right_arrow.png</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="moveToBottom_ToolButton">
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../libs/vmisc/share/resources/theme.qrc">
+         <normaloff>:/icons/win.icon.theme/32x32/actions/go-bottom.png</normaloff>:/icons/win.icon.theme/32x32/actions/go-bottom.png</iconset>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="tableWidget">
+     <property name="palette">
+      <palette>
+       <active>
+        <colorrole role="Highlight">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>162</red>
+           <green>188</green>
+           <blue>216</blue>
+          </color>
+         </brush>
+        </colorrole>
+       </active>
+       <inactive>
+        <colorrole role="Highlight">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>162</red>
+           <green>188</green>
+           <blue>216</blue>
+          </color>
+         </brush>
+        </colorrole>
+       </inactive>
+       <disabled>
+        <colorrole role="Highlight">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>0</red>
+           <green>120</green>
+           <blue>215</blue>
+          </color>
+         </brush>
+        </colorrole>
+       </disabled>
+      </palette>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>10</pointsize>
+      </font>
+     </property>
+     <property name="mouseTracking">
+      <bool>false</bool>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QHeaderView::section {
+	background-color: rgb(227, 227, 227);
+    border: 1px solid black;
+}</string>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
+     <property name="lineWidth">
+      <number>1</number>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>24</width>
+       <height>24</height>
+      </size>
+     </property>
+     <property name="wordWrap">
+      <bool>false</bool>
+     </property>
+     <property name="cornerButtonEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="columnCount">
+      <number>6</number>
+     </property>
+     <attribute name="horizontalHeaderVisible">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="horizontalHeaderMinimumSectionSize">
+      <number>30</number>
+     </attribute>
+     <attribute name="horizontalHeaderDefaultSectionSize">
+      <number>40</number>
+     </attribute>
+     <attribute name="horizontalHeaderHighlightSections">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderMinimumSectionSize">
+      <number>24</number>
+     </attribute>
+     <attribute name="verticalHeaderDefaultSectionSize">
+      <number>24</number>
+     </attribute>
+     <attribute name="verticalHeaderHighlightSections">
+      <bool>false</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string/>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Id</string>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="background">
+       <color>
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Name</string>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Description</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Radius / Length</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Angle</string>
+      </property>
+     </column>
+    </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
@@ -551,7 +650,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Close</set>
      </property>
     </widget>
    </item>

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -868,13 +868,15 @@ void MainWindow::ClosedDialogWithApply(int result, VMainGraphicsScene *scene)
     handleArrowTool(true);
     ui->view->itemClicked(vtool);// Don't check for nullptr here
     // If insert not to the end of file call lite parse
-    if (doc->getCursor() > 0)
+    if (doc->getCursorId() > NULL_ID)
     {
+        const quint32 &toolId = vtool->getId();
         doc->LiteParseTree(Document::LiteParse);
-        if (historyDialog)
-        {
-            historyDialog->updateHistory();
-        }
+        doc->setCursorId(toolId);
+    }
+    if (historyDialog)
+    {
+        historyDialog->updateHistory(true);
     }
 }
 
@@ -7244,7 +7246,7 @@ void MainWindow::changeDraftBlock(int index, bool zoomBestFit)
         QString name = draftBlockComboBox->itemText(index);
         doc->changeActiveDraftBlock(name);
         doc->setCurrentData();
-        emit RefreshHistory();
+        emit RefreshHistory(true);
         if (drawMode)
         {
             handleArrowTool(true);

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -125,7 +125,7 @@ public slots:
     void         addSelectedItemsToGroup();
 
 signals:
-    void RefreshHistory();
+    void RefreshHistory(bool refresh);
     void EnableItemMove(bool move);
     void ItemsSelection(SelectionType type) const;
 

--- a/src/app/seamly2d/xml/vpattern.cpp
+++ b/src/app/seamly2d/xml/vpattern.cpp
@@ -4109,7 +4109,7 @@ void VPattern::PrepareForParse(const Document &parse)
         toolsOnRemove.clear();
 
         tools.clear();
-        cursor = 0;
+        m_cursorId = NULL_ID;
         clearHistory();
     }
     else if (parse == Document::LiteParse)

--- a/src/libs/ifc/xml/vabstractpattern.cpp
+++ b/src/libs/ifc/xml/vabstractpattern.cpp
@@ -289,7 +289,7 @@ VAbstractPattern::VAbstractPattern(QObject *parent)
     , m_DefaultLineType(qApp->Settings()->getDefaultLineType())
     , defaultBasePoint(QString())
     , lastSavedExportFormat(QString())
-    , cursor(0)
+    , m_cursorId(0)
     , toolsOnRemove(QVector<VDataTool*>())
     , m_history(QVector<VToolRecord>())
     , patternPieces(QStringList())
@@ -618,18 +618,18 @@ bool VAbstractPattern::appendDraftBlock(const QString &name)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-quint32 VAbstractPattern::getCursor() const
+quint32 VAbstractPattern::getCursorId() const
 {
-    return cursor;
+    return m_cursorId;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VAbstractPattern::setCursor(const quint32 &value)
+void VAbstractPattern::setCursorId(const quint32 &toolId)
 {
-    if (cursor != value)
+    if (m_cursorId != toolId)
     {
-        cursor = value;
-        emit ChangedCursor(cursor);
+        m_cursorId = toolId;
+        emit ChangedCursor(m_cursorId);
     }
 }
 

--- a/src/libs/ifc/xml/vabstractpattern.h
+++ b/src/libs/ifc/xml/vabstractpattern.h
@@ -134,8 +134,8 @@ public:
 
     bool                           getActiveNodeElement(const QString &name, QDomElement &element) const;
 
-    quint32                        getCursor() const;
-    void                           setCursor(const quint32 &value);
+    quint32                        getCursorId() const;
+    void                           setCursorId(const quint32 &toolId);
 
     void                           setDefaultPen(Pen pen);
     QString                        getDefaultLineColor() const;
@@ -512,7 +512,7 @@ protected:
     QString        m_DefaultLineType;
     QString        defaultBasePoint;
     QString        lastSavedExportFormat;
-    quint32        cursor; /// @brief cursor cursor keep id tool after which we will add new tool in file.
+    quint32        m_cursorId;        /// @brief m_cursorId  keep id tool after which we will add new tool in file.
 
     QVector<VDataTool*>       toolsOnRemove;
     QVector<VToolRecord>      m_history;     /// @brief history history records.

--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -224,7 +224,8 @@ const QString settingGeneralWindowState                  = QStringLiteral("windo
 const QString settingGeneralToolbarsState                = QStringLiteral("toolbarsState");
 const QString settingPreferenceDialogSize                = QStringLiteral("preferenceDialogSize");
 const QString settingToolSeamAllowanceDialogSize         = QStringLiteral("toolSeamAllowanceDialogSize");
-const QString settingVariablesDialogSize                = QStringLiteral("toolVariablesDialogSize");
+const QString settingVariablesDialogSize                 = QStringLiteral("toolVariablesDialogSize");
+const QString settingHistoryDialogSize                   = QStringLiteral("toolHistoryDialogSize");
 const QString settingFormulaWizardDialogSize             = QStringLiteral("formulaWizardDialogSize");
 const QString settingLatestSkippedVersion                = QStringLiteral("lastestSkippedVersion");
 const QString settingDateOfLastRemind                    = QStringLiteral("dateOfLastRemind");
@@ -1569,6 +1570,18 @@ QSize VCommonSettings::getVariablesDialogSize() const
 void VCommonSettings::setVariablesDialogSize(const QSize &sz)
 {
     setValue(settingVariablesDialogSize, sz);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+QSize VCommonSettings::getHistoryDialogSize() const
+{
+    return value(settingHistoryDialogSize, QSize(0, 0)).toSize();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VCommonSettings::setHistoryDialogSize(const QSize &sz)
+{
+    setValue(settingHistoryDialogSize, sz);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vmisc/vcommonsettings.h
+++ b/src/libs/vmisc/vcommonsettings.h
@@ -355,6 +355,9 @@ public:
     QSize                getVariablesDialogSize() const;
     void                 setVariablesDialogSize(const QSize& sz);
 
+    QSize                getHistoryDialogSize() const;
+    void                 setHistoryDialogSize(const QSize& sz);
+
     int                  GetLatestSkippedVersion() const;
     void                 SetLatestSkippedVersion(int value);
 

--- a/src/libs/vtools/tools/vabstracttool.cpp
+++ b/src/libs/vtools/tools/vabstracttool.cpp
@@ -572,7 +572,7 @@ void VAbstractTool::AddRecord(const quint32 id, const Tool &toolType, VAbstractP
         return;
     }
 
-    quint32 cursor = doc->getCursor();
+    quint32 cursor = doc->getCursorId();
     if (cursor == NULL_ID)
     {
         history->append(record);

--- a/src/libs/vtools/undocommands/addtocalc.cpp
+++ b/src/libs/vtools/undocommands/addtocalc.cpp
@@ -63,7 +63,9 @@
 
 //---------------------------------------------------------------------------------------------------------------------
 AddToCalc::AddToCalc(const QDomElement &xml, VAbstractPattern *doc, QUndoCommand *parent)
-    : VUndoCommand(xml, doc, parent), activeBlockName(doc->getActiveDraftBlockName()), cursor(doc->getCursor())
+    : VUndoCommand(xml, doc, parent)
+    , m_activeBlockName(doc->getActiveDraftBlockName())
+    , m_cursorId(doc->getCursorId())
 {
     setText(tr("add object"));
     nodeId = doc->getParameterId(xml);
@@ -74,7 +76,7 @@ void AddToCalc::undo()
 {
     qCDebug(vUndo, "Undo.");
 
-    doc->changeActiveDraftBlock(activeBlockName);//Without this user will not see this change
+    doc->changeActiveDraftBlock(m_activeBlockName);//Without this user will not see this change
 
     QDomElement calcElement;
     if (doc->getActiveNodeElement(VAbstractPattern::TagCalculation, calcElement))
@@ -102,7 +104,7 @@ void AddToCalc::undo()
     emit NeedFullParsing();
     emit doc->FullUpdateFromFile();
     VMainGraphicsView::NewSceneRect(qApp->getCurrentScene(), qApp->getSceneView());
-    doc->setCurrentDraftBlock(activeBlockName);//Return current pattern piece after undo
+    doc->setCurrentDraftBlock(m_activeBlockName);//Return current pattern piece after undo
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -110,19 +112,19 @@ void AddToCalc::redo()
 {
     qCDebug(vUndo, "Redo.");
 
-    doc->changeActiveDraftBlock(activeBlockName);//Without this user will not see this change
-    doc->setCursor(cursor);
+    doc->changeActiveDraftBlock(m_activeBlockName);//Without this user will not see this change
+    doc->setCursorId(m_cursorId);
 
     QDomElement calcElement;
     if (doc->getActiveNodeElement(VAbstractPattern::TagCalculation, calcElement))
     {
-        if (cursor == NULL_ID)
+        if (m_cursorId == NULL_ID)
         {
             calcElement.appendChild(xml);
         }
         else
         {
-            QDomElement refElement = doc->elementById(cursor);
+            QDomElement refElement = doc->elementById(m_cursorId);
             if (refElement.isElement())
             {
                 calcElement.insertAfter(xml, refElement);
@@ -150,7 +152,7 @@ void AddToCalc::RedoFullParsing()
     {
         emit NeedFullParsing();
         emit doc->FullUpdateFromFile();
-        doc->setCurrentDraftBlock(activeBlockName);//Return current pattern piece after undo
+        doc->setCurrentDraftBlock(m_activeBlockName);//Return current pattern piece after undo
     }
     else
     {

--- a/src/libs/vtools/undocommands/addtocalc.h
+++ b/src/libs/vtools/undocommands/addtocalc.h
@@ -73,8 +73,8 @@ protected:
     virtual void RedoFullParsing() override;
 private:
     Q_DISABLE_COPY(AddToCalc)
-    const QString     activeBlockName;
-    quint32           cursor;
+    const QString     m_activeBlockName;
+    quint32           m_cursorId;
 };
 
 #endif // ADDTOCALC_H


### PR DESCRIPTION
This PR fixes some bugs and adds some new features and functionality to the History dialog.

- The dialog will no longer close if you press the Enter or Return key in the Find edit box. This was due to the fact the OK button was set as the default action… so pressing Enter was as if you clicked the OK button. To make things clearer the OK has been changed to Close. Issue #1471

- The insert cursor will now automatically increment after inserting a new tool.  Issue #1436

- Closing the dialog will automatically move the insert cursor to the end of the list so you can’t forget and inadvertently be inserting new tools instead of appending.

- New features: You can now scroll the list to the top, bottom, or to the cursor… which under normal use would be the same as moving to the bottom.

  <img width="103" height="26" alt="image" src="https://github.com/user-attachments/assets/96ec16e5-93db-43f5-b3ea-2c5ba0f79e04" />
  
- The name of the draftblock is now displayed.  
  
  <img width="417" height="102" alt="image" src="https://github.com/user-attachments/assets/ecb13211-4618-40ac-94a3-2f06c036821f" />
  
 - The table now contains new columns for the Cursor, Radius / Length and Angle formulas for tools where applicable:
      
    <img width="779" height="163" alt="image" src="https://github.com/user-attachments/assets/1d5234ff-09da-4902-a9a5-c0c3c6fb0f41" />
  
    The Cursor now having it’s own column keeps the Id column formatting centered & cleaner looking, and not so wonky when the cursor is displayed.

    <img width="537" height="186" alt="image" src="https://github.com/user-attachments/assets/71892dd0-ee13-46f6-809c-a32f47cc437d" />
  
 -  The Dialog is now resizable, and the size is saved so it will open to the last saved size.
  
 - Operation tools will now display the name of all the destination objects.
  
    <img width="601" height="70" alt="image" src="https://github.com/user-attachments/assets/98e32910-482b-4497-8e04-3f6e6df72293" />
  
 -  Dialog will position itself on second monitor if that pref is set.

 -  Search will no longer timeout and clear… which was related to auto saving a backup.
  
 - lupdate

Closes issue #1471 and issue#1436
