### PR TITLE
BUG: fix dock visibility

### DIFF
--- a/src/app/seamly2d/dialogs/groups_widget.cpp
+++ b/src/app/seamly2d/dialogs/groups_widget.cpp
@@ -1,54 +1,54 @@
-/***************************************************************************
- **  @file   groups_widget.cpp
- **  @author Douglas S Caskey
- **  @date   17 Sep, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   groups_widget.h
+//  @author Douglas S Caskey
+//  @date   11 Jun, 2023
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2026 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
- /************************************************************************
-  **
-  **  @file   vwidgetgroups.cpp
-  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
-  **  @date   6 4, 2016
-  **
-  **  @brief
-  **  @copyright
-  **  This source code is part of the Valentina project, a pattern making
-  **  program, whose allow create and modeling patterns of clothing.
-  **  Copyright (C) 2016 Valentina project
-  ** <https://bitbucket.org/dismine/valentina> All Rights Reserved.
-  **
-  **  Valentina is free software: you can redistribute it and/or modify
-  **  it under the terms of the GNU General Public License as published by
-  **  the Free Software Foundation, either version 3 of the License, or
-  **  (at your option) any later version.
-  **
-  **  Valentina is distributed in the hope that it will be useful,
-  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  **  GNU General Public License for more details.
-  **
-  **  You should have received a copy of the GNU General Public License
-  **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
-  **
-  *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vwidgetgroups.h
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   Jun 4, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2016 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #include "groups_widget.h"
 #include "ui_groups_widget.h"

--- a/src/app/seamly2d/dialogs/groups_widget.h
+++ b/src/app/seamly2d/dialogs/groups_widget.h
@@ -1,54 +1,54 @@
-/***************************************************************************
- **  @file   groups_widget.h
- **  @author Douglas S Caskey
- **  @date   11 Jun, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   groups_widget.cpp
+//  @author Douglas S Caskey
+//  @date   11 Jun, 2023
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2026 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
- /************************************************************************
-  **
-  **  @file   vwidgetgroups.h
-  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
-  **  @date   6 4, 2016
-  **
-  **  @brief
-  **  @copyright
-  **  This source code is part of the Valentina project, a pattern making
-  **  program, whose allow create and modeling patterns of clothing.
-  **  Copyright (C) 2016 Valentina project
-  ** <https://bitbucket.org/dismine/valentina> All Rights Reserved.
-  **
-  **  Valentina is free software: you can redistribute it and/or modify
-  **  it under the terms of the GNU General Public License as published by
-  **  the Free Software Foundation, either version 3 of the License, or
-  **  (at your option) any later version.
-  **
-  **  Valentina is distributed in the hope that it will be useful,
-  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  **  GNU General Public License for more details.
-  **
-  **  You should have received a copy of the GNU General Public License
-  **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
-  **
-  *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vwidgetgroups.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   Jun 4, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2016 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #ifndef GROUPS_WIDGET_H
 #define GROUPS_WIDGET_H

--- a/src/app/seamly2d/dialogs/pieces_widget.cpp
+++ b/src/app/seamly2d/dialogs/pieces_widget.cpp
@@ -1,54 +1,54 @@
-/***************************************************************************
- **  @file   pieces_widget.cpp
- **  @author Douglas S Caskey
- **  @date   Nov 22, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   pieces_widget.cpp
+//  @author Douglas S Caskey
+//  @date   17 Sep, 2023
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2026 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
-/************************************************************************
- **
- **  @file   vwidgetdetails.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   25 6, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Valentina project
- **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vwidgetdetails.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   Jun 25, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2016 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #include "pieces_widget.h"
 #include "ui_pieces_widget.h"
@@ -257,6 +257,12 @@ void PiecesWidget::selectPiece(quint32 id)
             return;
         }
     }
+}
+
+void PiecesWidget::clear()
+{
+    ui->tableWidget->setRowCount(0);
+    ui->tableWidget->clearContents();
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/app/seamly2d/dialogs/pieces_widget.h
+++ b/src/app/seamly2d/dialogs/pieces_widget.h
@@ -1,54 +1,54 @@
-/***************************************************************************
- **  @file   pieces_widget.h
- **  @author Douglas S Caskey
- **  @date   Jan 3, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+ //-----------------------------------------------------------------------------
+ //  @file   pieces_widget.h
+ //  @author Douglas S Caskey
+ //  @date   17 Sep, 2023
+ //
+ //  @brief
+ //  @copyright
+ //  This source code is part of the Seamly2D project, a pattern making
+ //  program, whose allow create and modeling patterns of clothing.
+ //  Copyright (C) 2013-2026 Seamly2D project
+ //  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ //
+ //  Seamly2D is free software: you can redistribute it and/or modify
+ //  it under the terms of the GNU General Public License as published by
+ //  the Free Software Foundation, either version 3 of the License, or
+ //  (at your option) any later version.
+ //
+ //  Seamly2D is distributed in the hope that it will be useful,
+ //  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ //  GNU General Public License for more details.
+ //
+ //  You should have received a copy of the GNU General Public License
+ //  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+ //-----------------------------------------------------------------------------
 
-/************************************************************************
- **
- **  @file   vwidgetdetails.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   25 6, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Valentina project
- **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+ //-----------------------------------------------------------------------------
+ //  @file   vwidgetdetails.h
+ //  @author Roman Telezhynskyi <dismine(at)gmail.com>
+ //  @date   Jun 25, 2016
+ //
+ //  @brief
+ //  @copyright
+ //  This source code is part of the Valentina project, a pattern making
+ //  program, whose allow create and modeling patterns of clothing.
+ //  Copyright (C) 2016 Valentina project
+ //  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+ //
+ //  Valentina is free software: you can redistribute it and/or modify
+ //  it under the terms of the GNU General Public License as published by
+ //  the Free Software Foundation, either version 3 of the License, or
+ //  (at your option) any later version.
+ //
+ //  Valentina is distributed in the hope that it will be useful,
+ //  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ //  GNU General Public License for more details.
+ //
+ //  You should have received a copy of the GNU General Public License
+ //  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+ //-----------------------------------------------------------------------------
 
 #ifndef PIECES_WIDGET_H
 #define PIECES_WIDGET_H
@@ -80,6 +80,7 @@ public slots:
     void               togglePiece(quint32 id);
     void               updateList();
     void               selectPiece(quint32 id);
+    void               clear();
 
 private slots:
     void               cellClicked(int row, int column);

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -185,6 +185,7 @@ MainWindow::MainWindow(QWidget *parent)
     , currentToolBoxIndex(0)
     , isToolOptionsDockVisible(true)
     , isGroupsDockVisible(true)
+    , isPiecesDockVisible(true)
     , isLayoutsDockVisible(false)
     , isToolboxDockVisible(true)
     , drawMode(true)
@@ -200,7 +201,7 @@ MainWindow::MainWindow(QWidget *parent)
     , gradationSizesLabel(nullptr)
     , toolProperties(nullptr)
     , groupsWidget(nullptr)
-    , patternPiecesWidget(nullptr)
+    , piecesWidget(nullptr)
     , lock(nullptr)
     , zoomScaleSpinBox(nullptr)
     , m_penToolBar(nullptr)
@@ -326,6 +327,11 @@ MainWindow::MainWindow(QWidget *parent)
             menu->setAsDockMenu();
 
         #endif //defined(Q_OS_MAC)
+
+        ui->groups_DockWidget->setVisible(false);
+        ui->pieces_DockWidget->setVisible(false);
+        ui->toolProperties_DockWidget->setVisible(false);
+        ui->layoutPages_DockWidget->setVisible(false);
     }
 
 
@@ -1883,15 +1889,6 @@ void MainWindow::changeEvent(QEvent *event)
         setStatusMessage(QObject::tr("Changes applied."));
         draftBlockLabel->setText(tr("Draft Block:"));
 
-        if (doc->getDraftStage() == Draw::Calculation)
-        {
-            ui->groups_DockWidget->setWindowTitle(tr("Group Manager"));
-        }
-        else
-        {
-            ui->groups_DockWidget->setWindowTitle(tr("Pattern Pieces"));
-        }
-
         updateWindowTitle();
         initPenToolBar();
         initBasePointComboBox();
@@ -1941,6 +1938,7 @@ void MainWindow::CleanLayout()
     papers.clear();
     ui->listWidget->clear();
     groupsWidget->clear();
+    piecesWidget->clear();
     SetLayoutModeActions();
 }
 
@@ -3824,6 +3822,11 @@ void MainWindow::showDraftMode(bool checked)
         ui->pieceMode_Action->setChecked(false);
         ui->layoutMode_Action->setChecked(false);
 
+        ui->groups_DockWidget->setVisible(true);
+        ui->pieces_DockWidget->setVisible(false);
+        ui->toolProperties_DockWidget->setVisible(true);
+        ui->layoutPages_DockWidget->setVisible(false);
+
         SaveCurrentScene();
 
         currentScene = draftScene;
@@ -3856,8 +3859,6 @@ void MainWindow::showDraftMode(bool checked)
             gradationSizesLabel->setVisible(true);
             gradationSizes->setVisible(true);
         }
-        ui->groups_DockWidget->setWidget(groupsWidget);
-        ui->groups_DockWidget->setWindowTitle(tr("Group Manager"));
     }
     else
     {
@@ -3891,6 +3892,11 @@ void MainWindow::showPieceMode(bool checked)
         ui->pieceMode_Action->setChecked(true);
         ui->layoutMode_Action->setChecked(false);
 
+        ui->groups_DockWidget->setVisible(false);
+        ui->pieces_DockWidget->setVisible(true);
+        ui->toolProperties_DockWidget->setVisible(false);
+        ui->layoutPages_DockWidget->setVisible(false);
+
         if(!qApp->getOpeningPattern())
         {
             if (pattern->DataPieces()->count() == 0)
@@ -3903,7 +3909,7 @@ void MainWindow::showPieceMode(bool checked)
             }
         }
 
-        patternPiecesWidget->updateList();
+        piecesWidget->updateList();
 
         qCDebug(vMainWindow, "Show piece scene");
         SaveCurrentScene();
@@ -3934,8 +3940,6 @@ void MainWindow::showPieceMode(bool checked)
             gradationSizesLabel->setVisible(true);
             gradationSizes->setVisible(true);
         }
-        ui->groups_DockWidget->setWidget(patternPiecesWidget);
-        ui->groups_DockWidget->setWindowTitle(tr("Pattern Pieces"));
 
         setStatusMessage("");
     }
@@ -3970,6 +3974,11 @@ void MainWindow::showLayoutMode(bool checked)
         ui->showDraftMode->setChecked(false);
         ui->pieceMode_Action->setChecked(false);
         ui->layoutMode_Action->setChecked(true);
+
+        ui->groups_DockWidget->setVisible(false);
+        ui->pieces_DockWidget->setVisible(false);
+        ui->toolProperties_DockWidget->setVisible(false);
+        ui->layoutPages_DockWidget->setVisible(true);
 
         QHash<quint32, VPiece> pieces;
         if(!qApp->getOpeningPattern())
@@ -4362,6 +4371,7 @@ void MainWindow::Clear()
 
     //disable group actions
     ui->groups_DockWidget->setEnabled(false);
+    ui->pieces_DockWidget->setEnabled(false);
 
     //disable history menu actions
     ui->history_Action->setEnabled(false);
@@ -4402,6 +4412,11 @@ void MainWindow::Clear()
     qApp->getUndoStack()->clear();
     toolProperties->clearPropertyBrowser();
     toolProperties->itemClicked(nullptr);
+
+    ui->groups_DockWidget->setVisible(false);
+    ui->pieces_DockWidget->setVisible(false);
+    ui->toolProperties_DockWidget->setVisible(false);
+    ui->layoutPages_DockWidget->setVisible(false);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -4562,7 +4577,7 @@ void MainWindow::fullParseFile()
     changeDraftBlockGlobally(draftBlock);
 
     setToolsEnabled(draftBlockComboBox->count() > 0);
-    patternPiecesWidget->updateList();
+    piecesWidget->updateList();
 
     VMainGraphicsView::NewSceneRect(draftScene, qApp->getSceneView());
     VMainGraphicsView::NewSceneRect(pieceScene, qApp->getSceneView());
@@ -4714,11 +4729,13 @@ void MainWindow::setWidgetsEnabled(bool enable)
     ui->shortcuts_Action->setEnabled(enable);
 
     //enable dock widget actions
-    ui->groups_DockWidget->setEnabled(enable && designStage);
+    ui->groups_DockWidget->setEnabled(enable && draftStage);
+    ui->pieces_DockWidget->setEnabled(enable && pieceStage);
     ui->toolProperties_DockWidget->setEnabled(enable && draftStage);
     ui->layoutPages_DockWidget->setEnabled(enable && layoutStage);
-    actionDockWidgetToolOptions->setEnabled(enable && designStage);
-    actionDockWidgetGroups->setEnabled(enable && designStage);
+    actionDockWidgetToolOptions->setEnabled(enable && draftStage);
+    actionDockWidgetGroups->setEnabled(enable && draftStage);
+    actionDockWidgetPieces->setEnabled(enable && pieceStage);
     actionDockWidgetLayouts->setEnabled(enable && layoutStage);
 
     //Now we don't want allow user call context menu
@@ -5265,6 +5282,7 @@ void MainWindow::ReadSettings()
 
     isToolOptionsDockVisible = ui->toolProperties_DockWidget->isVisible();
     isGroupsDockVisible      = ui->groups_DockWidget->isVisible();
+    isPiecesDockVisible      = ui->pieces_DockWidget->isVisible();
     isLayoutsDockVisible     = ui->layoutPages_DockWidget->isVisible();
     isToolboxDockVisible     = ui->toolbox_DockWidget->isVisible();
 }
@@ -5394,12 +5412,48 @@ void MainWindow::createMenus()
     ui->edit_Menu->insertAction(ui->previousDraftBlock_Action, redoAction);
     ui->edit_Toolbar->insertAction(ui->previousDraftBlock_Action, redoAction);
 
+    // Add separator
     separatorAct = new QAction(this);
     separatorAct->setSeparator(true);
     ui->edit_Menu->insertAction(ui->previousDraftBlock_Action, separatorAct);
 
-    AddDocks();
+    //Add dock menus
+    actionDockWidgetToolOptions = ui->toolProperties_DockWidget->toggleViewAction();
+    ui->view_Menu->addAction(actionDockWidgetToolOptions);
+    connect(ui->toolProperties_DockWidget, &QDockWidget::visibilityChanged, this, [this](bool visible)
+    {
+        isToolOptionsDockVisible = visible;
+    });
 
+    actionDockWidgetGroups = ui->groups_DockWidget->toggleViewAction();
+    ui->view_Menu->addAction(actionDockWidgetGroups);
+    connect(ui->groups_DockWidget, &QDockWidget::visibilityChanged, this, [this](bool visible)
+    {
+        isGroupsDockVisible = visible;
+    });
+
+    actionDockWidgetPieces = ui->pieces_DockWidget->toggleViewAction();
+    ui->view_Menu->addAction(actionDockWidgetPieces);
+    connect(ui->pieces_DockWidget, &QDockWidget::visibilityChanged, this, [this](bool visible)
+    {
+        isPiecesDockVisible = visible;
+    });
+
+    actionDockWidgetLayouts = ui->layoutPages_DockWidget->toggleViewAction();
+    ui->view_Menu->addAction(actionDockWidgetLayouts);
+    connect(ui->layoutPages_DockWidget, &QDockWidget::visibilityChanged, this, [this](bool visible)
+    {
+        isLayoutsDockVisible = visible;
+    });
+
+    actionDockWidgetToolbox = ui->toolbox_DockWidget->toggleViewAction();
+    ui->view_Menu->addAction(actionDockWidgetToolbox);
+    connect(ui->toolbox_DockWidget, &QDockWidget::visibilityChanged, this, [this](bool visible)
+    {
+        isToolboxDockVisible  = visible;
+    });
+
+    // Add separator
     separatorAct = new QAction(this);
     separatorAct->setSeparator(true);
     ui->view_Menu->addAction(separatorAct);
@@ -5657,41 +5711,6 @@ void MainWindow::LastUsedTool()
 QT_WARNING_POP
 
 //---------------------------------------------------------------------------------------------------------------------
-void MainWindow::AddDocks()
-{
-    //Add dock
-    actionDockWidgetToolOptions = ui->toolProperties_DockWidget->toggleViewAction();
-    ui->view_Menu->addAction(actionDockWidgetToolOptions);
-    connect(ui->toolProperties_DockWidget, &QDockWidget::visibilityChanged, this, [this](bool visible)
-    {
-        isToolOptionsDockVisible = visible;
-    });
-
-    actionDockWidgetGroups = ui->groups_DockWidget->toggleViewAction();
-    ui->view_Menu->addAction(actionDockWidgetGroups);
-    connect(ui->groups_DockWidget, &QDockWidget::visibilityChanged, this, [this](bool visible)
-    {
-        isGroupsDockVisible = visible;
-    });
-
-    actionDockWidgetLayouts = ui->layoutPages_DockWidget->toggleViewAction();
-    ui->view_Menu->addAction(actionDockWidgetLayouts);
-    connect(ui->layoutPages_DockWidget, &QDockWidget::visibilityChanged, this, [this](bool visible)
-    {
-        isLayoutsDockVisible = visible;
-    });
-
-    actionDockWidgetToolbox = ui->toolbox_DockWidget->toggleViewAction();
-    ui->view_Menu->addAction(actionDockWidgetToolbox);
-    connect(ui->toolbox_DockWidget, &QDockWidget::visibilityChanged, this, [this](bool visible)
-    {
-        isToolboxDockVisible  = visible;
-    });
-
-    tabifyDockWidget(ui->groups_DockWidget, ui->toolProperties_DockWidget);
-	splitDockWidget(ui->toolProperties_DockWidget, ui->layoutPages_DockWidget, Qt::Vertical);
-}
-//---------------------------------------------------------------------------------------------------------------------
 void MainWindow::initializeDocksContain()
 {
     setTabPosition(Qt::RightDockWidgetArea, QTabWidget::West);
@@ -5704,12 +5723,20 @@ void MainWindow::initializeDocksContain()
     ui->groups_DockWidget->setWidget(groupsWidget);
     connect(doc, &VAbstractPattern::updateGroups, this, &MainWindow::updateGroups);
 
-    patternPiecesWidget = new PiecesWidget(pattern, doc, this);
-    connect(doc, &VPattern::FullUpdateFromFile, patternPiecesWidget, &PiecesWidget::updateList);
-    connect(doc, &VPattern::UpdateInLayoutList, patternPiecesWidget, &PiecesWidget::togglePiece);
-    connect(doc, &VPattern::showPiece, patternPiecesWidget, &PiecesWidget::selectPiece);
-    connect(patternPiecesWidget, &PiecesWidget::Highlight, pieceScene, &VMainGraphicsScene::HighlightItem);
-    patternPiecesWidget->setVisible(false);
+    piecesWidget = new PiecesWidget(pattern, doc, this);
+    ui->pieces_DockWidget->setWidget(piecesWidget);
+    connect(doc, &VPattern::FullUpdateFromFile, piecesWidget, &PiecesWidget::updateList);
+    connect(doc, &VPattern::UpdateInLayoutList, piecesWidget, &PiecesWidget::togglePiece);
+    connect(doc, &VPattern::showPiece, piecesWidget, &PiecesWidget::selectPiece);
+    connect(piecesWidget, &PiecesWidget::Highlight, pieceScene, &VMainGraphicsScene::HighlightItem);
+
+    //disable dock widget actions until pattern loaded.
+    ui->groups_DockWidget->setEnabled(false);
+    ui->pieces_DockWidget->setEnabled(false);
+    ui->toolProperties_DockWidget->setEnabled(false);
+    ui->layoutPages_DockWidget->setEnabled(false);
+
+    tabifyDockWidget(ui->groups_DockWidget, ui->toolProperties_DockWidget);
 
     ui->toolbox_StackedWidget->setCurrentIndex(0);
 }
@@ -6606,6 +6633,9 @@ bool MainWindow::LoadPattern(const QString &fileName, const QString& customMeasu
         qApp->setOpeningPattern();// End opening file
         return false;
     }
+
+    // Set the Property Editor dock widget as the active tab
+    ui->toolProperties_DockWidget->raise();
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -308,6 +308,7 @@ private:
     qint32                            currentToolBoxIndex; /// @brief currentToolBoxIndex  current set of tools.
     bool                              isToolOptionsDockVisible;
     bool                              isGroupsDockVisible;
+    bool                              isPiecesDockVisible;
     bool                              isLayoutsDockVisible;
     bool                              isToolboxDockVisible;
     bool                              drawMode;            /// @brief drawMode true if draft scene active.
@@ -326,7 +327,7 @@ private:
     QPointer<QLabel>                  gradationSizesLabel;
     VToolOptionsPropertyBrowser      *toolProperties;
     GroupsWidget                     *groupsWidget;
-    PiecesWidget                     *patternPiecesWidget;
+    PiecesWidget                     *piecesWidget;
     std::shared_ptr<VLockGuard<char>> lock;
 
     QDoubleSpinBox                   *zoomScaleSpinBox;
@@ -422,7 +423,6 @@ private:
     void               UpdateHeightsList(const QStringList &list);
     void               UpdateSizesList(const QStringList &list);
 
-    void               AddDocks();
     void               initializeDocksContain();
     bool               startNewSeamly2D(const QString &fileName = QString())const;
     void               FileClosedCorrect();

--- a/src/app/seamly2d/mainwindow.ui
+++ b/src/app/seamly2d/mainwindow.ui
@@ -444,6 +444,9 @@
    </attribute>
   </widget>
   <widget class="QDockWidget" name="toolProperties_DockWidget">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="minimumSize">
     <size>
      <width>220</width>
@@ -459,6 +462,9 @@
    <widget class="QWidget" name="dockWidgetContents_10"/>
   </widget>
   <widget class="QDockWidget" name="layoutPages_DockWidget">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="minimumSize">
     <size>
      <width>220</width>
@@ -545,7 +551,7 @@
   </widget>
   <widget class="QDockWidget" name="groups_DockWidget">
    <property name="enabled">
-    <bool>true</bool>
+    <bool>false</bool>
    </property>
    <property name="minimumSize">
     <size>
@@ -2375,8 +2381,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>98</width>
-              <height>28</height>
+              <width>120</width>
+              <height>82</height>
              </rect>
             </property>
             <property name="toolTip">
@@ -2509,8 +2515,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>100</width>
-              <height>54</height>
+              <width>120</width>
+              <height>82</height>
              </rect>
             </property>
             <attribute name="icon">
@@ -2624,6 +2630,21 @@
    <addaction name="toggleSeamAllowances_Action"/>
    <addaction name="toggleGrainLines_Action"/>
    <addaction name="toggleLabels_Action"/>
+  </widget>
+  <widget class="QDockWidget" name="pieces_DockWidget">
+   <property name="minimumSize">
+    <size>
+     <width>82</width>
+     <height>46</height>
+    </size>
+   </property>
+   <property name="windowTitle">
+    <string>Pattern Pieces</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>2</number>
+   </attribute>
+   <widget class="QWidget" name="dockWidgetContents_3"/>
   </widget>
   <action name="actionNew">
    <property name="icon">

--- a/src/app/seamly2d/mainwindowsnogui.cpp
+++ b/src/app/seamly2d/mainwindowsnogui.cpp
@@ -130,6 +130,7 @@ MainWindowsNoGUI::MainWindowsNoGUI(QWidget *parent)
       redoAction(nullptr),
       actionDockWidgetToolOptions(nullptr),
       actionDockWidgetGroups(nullptr),
+      actionDockWidgetPieces(nullptr),
       actionDockWidgetLayouts(nullptr),
       actionDockWidgetToolbox(nullptr),
       isNoScaling(false),

--- a/src/app/seamly2d/mainwindowsnogui.h
+++ b/src/app/seamly2d/mainwindowsnogui.h
@@ -115,6 +115,7 @@ protected:
     QAction     *redoAction;
     QAction     *actionDockWidgetToolOptions;
     QAction     *actionDockWidgetGroups;
+    QAction     *actionDockWidgetPieces;
     QAction     *actionDockWidgetLayouts;
     QAction     *actionDockWidgetToolbox;
 


### PR DESCRIPTION
This PR fixes the dock visibilty issue.

To avoid confusion:
- When in Draft mode only the Property Editor and Group Manager docks are visible.
- When in Piece mode only the Pattern Pieces dock is visible.
- When in Layout mode only the Layout Pages dock  is visible. 

closes issue #1482 