### PR TITLE
BUG: Normalize angle calculations display

### DIFF
--- a/src/libs/vpatterndb/vformula.cpp
+++ b/src/libs/vpatterndb/vformula.cpp
@@ -266,7 +266,7 @@ void VFormula::Eval()
         {
             QScopedPointer<Calculator> cal(new Calculator());
             QString expression = qApp->translateVariables()->FormulaFromUser(formula, qApp->Settings()->getOsSeparator());
-            const qreal result = cal->EvalFormula(data->DataVariables(), expression);
+            qreal result = cal->EvalFormula(data->DataVariables(), expression);
 
             if (qIsInf(result) || qIsNaN(result))
             {
@@ -285,6 +285,10 @@ void VFormula::Eval()
                 }
                 else
                 {
+                    if (postfix == degreeSymbol)
+                    {
+                        result = result - 360.0 * qFloor(result / 360.0);
+                    }
                     dValue = result;
                     value = QString(qApp->LocaleToString(result) + " " + postfix);
                     _error = false;

--- a/src/libs/vtools/dialogs/tools/dialogtool.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogtool.cpp
@@ -868,6 +868,10 @@ qreal DialogTool::Eval(const QString &text, bool &flag, QLabel *label, const QSt
                 }
                 else
                 {
+                    if (postfix == degreeSymbol)
+                    {
+                        result = normalize(result, 0, 360);
+                    }
                     label->setText(qApp->LocaleToString(result) + " " +postfix);
                     flag = true;
                     ChangeColor(labelEditFormula, okColor);


### PR DESCRIPTION
This PR fixes the display of angle calculations in the tool Dialogs and Property Editor. The calculated value displayed will now be a normalized value between 0 and 360 degrees. 

<img width="663" height="345" alt="Screenshot 2026-02-12 173411" src="https://github.com/user-attachments/assets/aafdd80a-4ace-467e-bf60-b80142463087" />

<img width="693" height="314" alt="Screenshot 2026-02-12 173441" src="https://github.com/user-attachments/assets/3fed19c9-40ac-4432-9557-2e4e45cd79b7" />

<img width="653" height="361" alt="Screenshot 2026-02-12 174516" src="https://github.com/user-attachments/assets/e8f8cb43-0140-471a-a31f-d2694d83d332" />

closes issue #384