### PR TITLE
BUG: Fix label placeholders

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -3553,15 +3553,15 @@ Zkuste prosím vrátit zpět poslední operaci nebo opravit poškozený vzorec.<
         <translation>Jméno zákazníka</translation>
     </message>
     <message>
-        <source>Pattern extension</source>
-        <translation>Rozšíření vzoru</translation>
+        <source>Pattern file extension</source>
+        <translation>Rozšíření souboru vzoru</translation>
     </message>
     <message>
         <source>Pattern file name</source>
         <translation>Název souboru se vzorem</translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation>Název souboru s měřeními</translation>
     </message>
     <message>
@@ -3573,8 +3573,8 @@ Zkuste prosím vrátit zpět poslední operaci nebo opravit poškozený vzorec.<
         <translation>Výška</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
-        <translation>Rozšíření měření</translation>
+        <source>Measurements file extension</source>
+        <translation>Rozšíření souboru měření</translation>
     </message>
     <message>
         <source>Piece letter</source>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -3538,15 +3538,15 @@ Bitte versuchen Sie, den letzten Vorgang rückgängig zu machen oder die fehlerh
         <translation>Name des Kunden</translation>
     </message>
     <message>
-        <source>Pattern extension</source>
-        <translation>Schnittmustererweiterung</translation>
+        <source>Pattern file extension</source>
+        <translation>Schnittmuster datei erweiterung</translation>
     </message>
     <message>
         <source>Pattern file name</source>
         <translation>Schnittmusterdateiname</translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation>Maßsatz Dateiname</translation>
     </message>
     <message>
@@ -3558,8 +3558,8 @@ Bitte versuchen Sie, den letzten Vorgang rückgängig zu machen oder die fehlerh
         <translation>Körperhöhe</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
-        <translation>Maßsatz Erweiterung</translation>
+        <source>Measurements file extension</source>
+        <translation>Maßsatz datei erweiterung</translation>
     </message>
     <message>
         <source>Piece letter</source>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -3555,15 +3555,15 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation>Όνομα πελάτη</translation>
     </message>
     <message>
-        <source>Pattern extension</source>
-        <translation>Επέκταση μοτίβου</translation>
+        <source>Pattern file extension</source>
+        <translation>Επέκταση αρχείου μοτίβου</translation>
     </message>
     <message>
         <source>Pattern file name</source>
         <translation>Όνομα αρχείου μοτίβου</translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation>Όνομα αρχείου μετρήσεων</translation>
     </message>
     <message>
@@ -3575,8 +3575,8 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation>Ύψος</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
-        <translation>Επέκταση μετρήσεων</translation>
+        <source>Measurements file extension</source>
+        <translation>Επέκταση αρχείου μετρήσεων</translation>
     </message>
     <message>
         <source>Piece letter</source>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -3537,7 +3537,7 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Pattern extension</source>
+        <source>Pattern file extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3545,7 +3545,7 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3557,7 +3557,7 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished">Height</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
+        <source>Measurements file extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -3537,7 +3537,7 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Pattern extension</source>
+        <source>Pattern file extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3545,7 +3545,7 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3557,7 +3557,7 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished">Height</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
+        <source>Measurements file extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -3537,7 +3537,7 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Pattern extension</source>
+        <source>Pattern file extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3545,7 +3545,7 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3557,7 +3557,7 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished">Height</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
+        <source>Measurements file extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -3537,7 +3537,7 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Pattern extension</source>
+        <source>Pattern file extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3545,7 +3545,7 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3557,7 +3557,7 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished">Height</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
+        <source>Measurements file extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -3573,15 +3573,15 @@ Intente deshacer la última operación o corregir la fórmula defectuosa.</trans
         <translation>Nombre personalizado</translation>
     </message>
     <message>
-        <source>Pattern extension</source>
-        <translation>Extensión de patrón</translation>
+        <source>Pattern file extension</source>
+        <translation>Extensión de archivo de patrón</translation>
     </message>
     <message>
         <source>Pattern file name</source>
         <translation>Nombre del archivo de patrón</translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation>Nombre del archivo de medidas</translation>
     </message>
     <message>
@@ -3593,8 +3593,8 @@ Intente deshacer la última operación o corregir la fórmula defectuosa.</trans
         <translation>Altura</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
-        <translation>Extención de medidas</translation>
+        <source>Measurements file extension</source>
+        <translation>Extensión de archivo de medidas</translation>
     </message>
     <message>
         <source>Piece letter</source>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -3561,15 +3561,15 @@ Yritä kumota viimeisin operaatio tai korjata rikkinäinen kaava.</translation>
         <translation>Asiakkaan nimi</translation>
     </message>
     <message>
-        <source>Pattern extension</source>
-        <translation>Kaavan laajennus</translation>
+        <source>Pattern file extension</source>
+        <translation>Kaavan tiedostopääte</translation>
     </message>
     <message>
         <source>Pattern file name</source>
         <translation>Kaavatiedoston nimi</translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation>Mittaustiedoston nimi</translation>
     </message>
     <message>
@@ -3581,8 +3581,8 @@ Yritä kumota viimeisin operaatio tai korjata rikkinäinen kaava.</translation>
         <translation>Pituus</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
-        <translation>Mittausten laajennus</translation>
+        <source>Measurements file extension</source>
+        <translation>Mittausten tiedostopääte</translation>
     </message>
     <message>
         <source>Piece letter</source>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -3573,15 +3573,15 @@ points de contrôle</translation>
         <translation>Nom du client</translation>
     </message>
     <message>
-        <source>Pattern extension</source>
-        <translation>Extension du patron</translation>
+        <source>Pattern file extension</source>
+        <translation>Extension du fichier de patron</translation>
     </message>
     <message>
         <source>Pattern file name</source>
         <translation>Nom du fichier de patron</translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation>Nom du fichier de mesures</translation>
     </message>
     <message>
@@ -3593,7 +3593,7 @@ points de contrôle</translation>
         <translation>Stature</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
+        <source>Measurements file extension</source>
         <translation>Extension du fichier de mesure</translation>
     </message>
     <message>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -3545,7 +3545,7 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3557,7 +3557,7 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Measurments extension</source>
+        <source>Measurements extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -3553,15 +3553,15 @@ Silakan coba batalkan operasi terakhir atau perbaiki rumus yang rusak.</translat
         <translation>Nama pelanggan</translation>
     </message>
     <message>
-        <source>Pattern extension</source>
-        <translation>Perpanjangan pola</translation>
+        <source>Pattern file extension</source>
+        <translation>Perpanjangan file pola</translation>
     </message>
     <message>
         <source>Pattern file name</source>
         <translation>Nama file pola</translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation>Nama file pengukuran</translation>
     </message>
     <message>
@@ -3573,8 +3573,8 @@ Silakan coba batalkan operasi terakhir atau perbaiki rumus yang rusak.</translat
         <translation>Tinggi</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
-        <translation>Perpanjangan pengukuran</translation>
+        <source>Measurements file extension</source>
+        <translation>Perpanjangan file pengukuran</translation>
     </message>
     <message>
         <source>Piece letter</source>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -3540,15 +3540,15 @@ punti di controllo</translation>
         <translation>Nome del cliente</translation>
     </message>
     <message>
-        <source>Pattern extension</source>
-        <translation>Estensione del modello</translation>
+        <source>Pattern file extension</source>
+        <translation>Estensione del file modello</translation>
     </message>
     <message>
         <source>Pattern file name</source>
         <translation>Nome del file modello</translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation>Nome file misurazioni</translation>
     </message>
     <message>
@@ -3560,8 +3560,8 @@ punti di controllo</translation>
         <translation>Altezza</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
-        <translation>Estensione delle misure</translation>
+        <source>Measurements file extension</source>
+        <translation>Estensione del file di misurazione</translation>
     </message>
     <message>
         <source>Piece letter</source>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -3538,15 +3538,15 @@ Probeer de laatste bewerking ongedaan te maken of de defecte formule te herstell
         <translation>Klant naam</translation>
     </message>
     <message>
-        <source>Pattern extension</source>
-        <translation>Patroon uitbreiding</translation>
+        <source>Pattern file extension</source>
+        <translation>Patroon bestandsextensie</translation>
     </message>
     <message>
         <source>Pattern file name</source>
         <translation>Naam patroonbestand</translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation>Naam matenbestand</translation>
     </message>
     <message>
@@ -3558,8 +3558,8 @@ Probeer de laatste bewerking ongedaan te maken of de defecte formule te herstell
         <translation>Hoogte</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
-        <translation>Maten uitbreiding</translation>
+        <source>Measurements file extension</source>
+        <translation>Maten Bestandsextensie</translation>
     </message>
     <message>
         <source>Piece letter</source>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -3539,15 +3539,15 @@ pontos de controle</translation>
         <translation>Nome do cliente</translation>
     </message>
     <message>
-        <source>Pattern extension</source>
-        <translation>Extensâo de padrâo</translation>
+        <source>Pattern file extension</source>
+        <translation>Extensão de arquivo padrão</translation>
     </message>
     <message>
         <source>Pattern file name</source>
         <translation>Nome do arquivo do padrâo</translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation>Nome do arquivo de medições</translation>
     </message>
     <message>
@@ -3559,8 +3559,8 @@ pontos de controle</translation>
         <translation>Altura</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
-        <translation>Extensâo de medidas</translation>
+        <source>Measurements file extension</source>
+        <translation>Extensão de arquivo medição</translation>
     </message>
     <message>
         <source>Piece letter</source>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -3555,15 +3555,15 @@ Vă rugăm să încercați să anulați ultima operațiune sau să remediați fo
         <translation>Nume client</translation>
     </message>
     <message>
-        <source>Pattern extension</source>
-        <translation>Extensie de model</translation>
+        <source>Pattern file extension</source>
+        <translation>Extensie de fișier de model</translation>
     </message>
     <message>
         <source>Pattern file name</source>
         <translation>Nume fișier model</translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation>Nume fișier măsurători</translation>
     </message>
     <message>
@@ -3575,8 +3575,8 @@ Vă rugăm să încercați să anulați ultima operațiune sau să remediați fo
         <translation>Înălțime</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
-        <translation>Extensie măsurători</translation>
+        <source>Measurements file extension</source>
+        <translation>Extensie de fișier măsurători</translation>
     </message>
     <message>
         <source>Piece letter</source>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -3557,15 +3557,15 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation>Имя клиента</translation>
     </message>
     <message>
-        <source>Pattern extension</source>
-        <translation>Расширение выкройки</translation>
+        <source>Pattern file extension</source>
+        <translation>Расширение файла шаблона</translation>
     </message>
     <message>
         <source>Pattern file name</source>
         <translation>Название файла выкройки</translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation>Название файла мерок</translation>
     </message>
     <message>
@@ -3577,8 +3577,8 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation>Рост</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
-        <translation>Расширение мерок</translation>
+        <source>Measurements file extension</source>
+        <translation>Расширение файла измерений</translation>
     </message>
     <message>
         <source>Piece letter</source>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -3553,15 +3553,15 @@ Lütfen son işlemi geri almayı veya bozuk formülü düzeltmeyi deneyin.</tran
         <translation>Müşteri adı</translation>
     </message>
     <message>
-        <source>Pattern extension</source>
-        <translation>Desen uzantısı</translation>
+        <source>Pattern file extension</source>
+        <translation>Desen dosya uzantısı</translation>
     </message>
     <message>
         <source>Pattern file name</source>
         <translation>Desen dosyası adı</translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation>Ölçüm dosyası adı</translation>
     </message>
     <message>
@@ -3573,8 +3573,8 @@ Lütfen son işlemi geri almayı veya bozuk formülü düzeltmeyi deneyin.</tran
         <translation>Yükseklik</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
-        <translation>Ölçüm uzantısı</translation>
+        <source>Measurements file extension</source>
+        <translation>Ölçümler dosya uzantısı</translation>
     </message>
     <message>
         <source>Piece letter</source>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -3555,15 +3555,15 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation>Όνομα πελάτη</translation>
     </message>
     <message>
-        <source>Pattern extension</source>
-        <translation>Επέκταση μοτίβου</translation>
+        <source>Pattern file extension</source>
+        <translation>Розширення файлу шаблону</translation>
     </message>
     <message>
         <source>Pattern file name</source>
         <translation>Όνομα αρχείου μοτίβου</translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation>Όνομα αρχείου μετρήσεων</translation>
     </message>
     <message>
@@ -3575,8 +3575,8 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation>Ζρίστ</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
-        <translation>Επέκταση μετρήσεων</translation>
+        <source>Measurements file extension</source>
+        <translation>Розширення файлу вимірювань</translation>
     </message>
     <message>
         <source>Piece letter</source>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -3545,7 +3545,7 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Measurments file name</source>
+        <source>Measurements file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3557,7 +3557,7 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished">高度</translation>
     </message>
     <message>
-        <source>Measurments extension</source>
+        <source>Measurements extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/libs/vlayout/vtextmanager.cpp
+++ b/src/libs/vlayout/vtextmanager.cpp
@@ -1,30 +1,52 @@
-/************************************************************************
- **
- **  @file   vpatternpiecedata.cpp
- **  @author Bojan Kverh
- **  @date   July 19, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vtextmanager.cpp
+//  @author Douglas S Caskey
+//  @date   1 Mar, 2026
+//
+//  @copyright
+//  Copyright (C) 2017 - 2026 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vtextmanager.cpp
+//  @author Bojan Kverh
+//  @date   July 19, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2017 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #include <QDate>
 #include <QFileInfo>
@@ -42,15 +64,14 @@
 #include "vtextmanager.h"
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief TextLine::TextLine default constructor
- */
+/// @brief TextLine::TextLine default constructor
+//---------------------------------------------------------------------------------------------------------------------
 TextLine::TextLine()
-    : m_text(),
-      m_iFontSize(MIN_FONT_SIZE),
-      bold(false),
-      italic(false),
-      m_eAlign(Qt::AlignCenter)
+    : m_text()
+    , m_iFontSize(MIN_FONT_SIZE)
+    , bold(false)
+    , italic(false)
+    , m_eAlign(Qt::AlignCenter)
 {}
 
 QList<TextLine> VTextManager::m_patternLabelLines = QList<TextLine>();
@@ -78,29 +99,27 @@ QMap<QString, QString> PreparePlaceholders(const VAbstractPattern *doc)
     placeholders.insert(pl_patternNumber, doc->GetPatternNumber());
     placeholders.insert(pl_author, doc->GetCompanyName());
     placeholders.insert(pl_customer, doc->GetCustomerName());
-    placeholders.insert(pl_pExt, QString("val"));
+    placeholders.insert(pl_pExt, QFileInfo(qApp->getFilePath()).suffix());
     placeholders.insert(pl_pFileName, QFileInfo(qApp->getFilePath()).baseName());
+
+    placeholders.insert(pl_mExt, QFileInfo(doc->MPath()).suffix());
     placeholders.insert(pl_mFileName, QFileInfo(doc->MPath()).baseName());
 
     QString curSize;
     QString curHeight;
-    QString mExt;
     if (qApp->patternType() == MeasurementsType::Multisize)
     {
         curSize = QString::number(VContainer::size());
         curHeight = QString::number(VContainer::height());
-        mExt = "vst";
     }
     else if (qApp->patternType() == MeasurementsType::Individual)
     {
         curSize = QString::number(VContainer::size());
         curHeight = QString::number(VContainer::height());
-        mExt = "vit";
     }
 
     placeholders.insert(pl_size, curSize);
     placeholders.insert(pl_height, curHeight);
-    placeholders.insert(pl_mExt, mExt);
 
     // Piece tags
     placeholders.insert(pl_pLetter, "");
@@ -177,16 +196,17 @@ QList<TextLine> PrepareLines(const QVector<VLabelTemplateLine> &lines)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VTextManager::VTextManager constructor
- */
+/// @brief VTextManager::VTextManager constructor
+//---------------------------------------------------------------------------------------------------------------------
 VTextManager::VTextManager()
-     : m_font(), m_liLines()
+     : m_font()
+     , m_liLines()
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
 VTextManager::VTextManager(const VTextManager &text)
-    : m_font(text.GetFont()), m_liLines(text.GetAllSourceLines())
+    : m_font(text.GetFont())
+    , m_liLines(text.GetAllSourceLines())
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -202,40 +222,36 @@ VTextManager &VTextManager::operator=(const VTextManager &text)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief GetSpacing returns the vertical spacing between the lines
- * @return spacing
- */
+// @brief GetSpacing returns the vertical spacing between the lines
+// @return spacing
+//---------------------------------------------------------------------------------------------------------------------
 int VTextManager::GetSpacing() const
 {
     return 0;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief SetFont set the text base font
- * @param font text base font
- */
+// @brief SetFont set the text base font
+// @param font text base font
+//---------------------------------------------------------------------------------------------------------------------
 void VTextManager::setFont(const QFont& font)
 {
     m_font = font;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief GetFont returns the text base font
- * @return text base font
- */
+// @brief GetFont returns the text base font
+// @return text base font
+//---------------------------------------------------------------------------------------------------------------------
 const QFont& VTextManager::GetFont() const
 {
     return m_font;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief SetFontSize sets the font size
- * @param iFS font size in pixels
- */
+// @brief SetFontSize sets the font size
+// @param iFS font size in pixels
+//---------------------------------------------------------------------------------------------------------------------
 void VTextManager::SetFontSize(int iFS)
 {
     iFS < MIN_FONT_SIZE ? m_font.setPixelSize(MIN_FONT_SIZE) : m_font.setPixelSize(iFS);
@@ -248,21 +264,19 @@ QList<TextLine> VTextManager::GetAllSourceLines() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VTextManager::GetSourceLinesCount returns the number of input text lines
- * @return number of text lines that were added to the list by calling AddLine
- */
+// @brief VTextManager::GetSourceLinesCount returns the number of input text lines
+// @return number of text lines that were added to the list by calling AddLine
+//---------------------------------------------------------------------------------------------------------------------
 int VTextManager::GetSourceLinesCount() const
 {
     return m_liLines.count();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VTextManager::GetSourceLine returns the reference to i-th text line
- * @param i index of the requested line
- * @return reference to the requested TextLine object
- */
+// @brief VTextManager::GetSourceLine returns the reference to i-th text line
+// @param i index of the requested line
+// @return reference to the requested TextLine object
+//---------------------------------------------------------------------------------------------------------------------
 const TextLine& VTextManager::GetSourceLine(int i) const
 {
     Q_ASSERT(i >= 0);
@@ -271,12 +285,11 @@ const TextLine& VTextManager::GetSourceLine(int i) const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VTextManager::FitFontSize sets the font size just big enough, so that the text fits into rectangle of
- * size (fW, fH)
- * @param fW rectangle width
- * @param fH rectangle height
- */
+// @brief VTextManager::FitFontSize sets the font size just big enough, so that the text fits into rectangle of
+// size (fW, fH)
+// @param fW rectangle width
+// @param fH rectangle height
+//---------------------------------------------------------------------------------------------------------------------
 void VTextManager::FitFontSize(qreal fW, qreal fH)
 {
     int iFS = 0;
@@ -331,11 +344,10 @@ void VTextManager::FitFontSize(qreal fW, qreal fH)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VTextManager::Update updates the text lines with detail data
- * @param qsName detail name
- * @param data reference to the detail data
- */
+// @brief VTextManager::Update updates the text lines with detail data
+// @param qsName detail name
+// @param data reference to the detail data
+//---------------------------------------------------------------------------------------------------------------------
 void VTextManager::Update(const QString& qsName, const VPieceLabelData& data)
 {
     m_liLines.clear();
@@ -354,10 +366,9 @@ void VTextManager::Update(const QString& qsName, const VPieceLabelData& data)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VTextManager::Update updates the text lines with pattern info
- * @param pDoc pointer to the abstract pattern object
- */
+// @brief VTextManager::Update updates the text lines with pattern info
+// @param pDoc pointer to the abstract pattern object
+//---------------------------------------------------------------------------------------------------------------------
 void VTextManager::Update(VAbstractPattern *pDoc)
 {
     m_liLines.clear();

--- a/src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp
+++ b/src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp
@@ -4,7 +4,7 @@
 //  @date   17 Sep, 2023
 //
 //  @copyright
-//  Copyright (C) 2017 - 2022 Seamly, LLC
+//  Copyright (C) 2017 - 2026 Seamly, LLC
 //  https://github.com/fashionfreedom/seamly2d
 //
 //  @brief
@@ -473,14 +473,24 @@ void EditLabelTemplateDialog::SetupControls()
 void EditLabelTemplateDialog::InitPlaceholdersMenu()
 {
     QChar per('%');
+
+    // Sort the QPair part of the m_placeholders items.
+    QMap<QString, QString> sortedItems;
     auto i = m_placeholders.constBegin();
     while (i != m_placeholders.constEnd())
     {
-        auto value = i.value();
-        QAction *action = m_placeholdersMenu->addAction(value.first);
-        action->setData(per + qApp->translateVariables()->PlaceholderToUser(i.key()) + per);
-        connect(action, &QAction::triggered, this, &EditLabelTemplateDialog::InsertPlaceholder);
+        sortedItems.insert(i.value().first, per + i.key() + per);
         ++i;
+    }
+
+    // Insert sorted items into popup menu. 
+    auto j = sortedItems.constBegin();
+    while (j != sortedItems.constEnd())
+    {
+        QAction *action = m_placeholdersMenu->addAction(j.key());
+        action->setData(j.value());
+        connect(action, &QAction::triggered, this, &EditLabelTemplateDialog::InsertPlaceholder);
+        ++j;
     }
 }
 
@@ -501,33 +511,30 @@ void EditLabelTemplateDialog::InitPlaceholders()
     m_placeholders.insert(pl_author, qMakePair(tr("Company name or designer name"),
                                                            m_doc->GetCompanyName()));
     m_placeholders.insert(pl_customer, qMakePair(tr("Customer name"), m_doc->GetCustomerName()));
-    m_placeholders.insert(pl_pExt, qMakePair(tr("Pattern extension"), QString("val")));
 
     const QString patternFilePath = QFileInfo(qApp->getFilePath()).baseName();
     m_placeholders.insert(pl_pFileName, qMakePair(tr("Pattern file name"), patternFilePath));
+    m_placeholders.insert(pl_pExt, qMakePair(tr("Pattern file extension"), QFileInfo(qApp->getFilePath()).suffix()));
 
     const QString measurementsFilePath = QFileInfo(m_doc->MPath()).baseName();
-    m_placeholders.insert(pl_mFileName, qMakePair(tr("Measurments file name"), measurementsFilePath));
+    m_placeholders.insert(pl_mFileName, qMakePair(tr("Measurements file name"), measurementsFilePath));
+    m_placeholders.insert(pl_mExt, qMakePair(tr("Measurements file extension"), QFileInfo(m_doc->MPath()).suffix()));
 
     QString curSize;
     QString curHeight;
-    QString mExt;
     if (qApp->patternType() == MeasurementsType::Multisize)
     {
         curSize = QString::number(VContainer::size());
         curHeight = QString::number(VContainer::height());
-        mExt = "vst";
     }
     else if (qApp->patternType() == MeasurementsType::Individual)
     {
         curSize = QString::number(VContainer::size());
         curHeight = QString::number(VContainer::height());
-        mExt = "vit";
     }
 
     m_placeholders.insert(pl_size, qMakePair(tr("Size"), curSize));
     m_placeholders.insert(pl_height, qMakePair(tr("Height"), curHeight));
-    m_placeholders.insert(pl_mExt, qMakePair(tr("Measurments extension"), mExt));
 
     // Piece tags
     m_placeholders.insert(pl_pLetter, qMakePair(tr("Piece letter"), QString("")));


### PR DESCRIPTION
This PR addresses the following with the Label placeholders:

- The pExt and mExt placeholders are no longer fixed to the Valentina extensions. They are replaced with the suffix from the corresponding pattern or measurement file - whatever the suffix is. 

    <img width="236" height="204" alt="image" src="https://github.com/user-attachments/assets/a7df52e4-9daf-4c6a-bb72-69d1951842fe" />

    <img width="235" height="203" alt="image" src="https://github.com/user-attachments/assets/b2dc7d1f-799c-4818-9ce5-7b56b09a17fe" />

-  Added "File" to the Pattern extension and Measurements extension popup menu items

    <img width="193" height="179" alt="Screenshot 2026-03-01 160748" src="https://github.com/user-attachments/assets/56e4c4b4-defa-4da5-9af5-a556992165c6" />

- Fixed the "Measurments" typos, and the placeholder popup menu items are now sorted:
 
    <img width="224" height="579" alt="Screenshot 2026-03-01 175047" src="https://github.com/user-attachments/assets/cc870b40-9dae-425c-933e-4db7e00d762e" />

- lupdate

closes issue #1501 