### PR TITLE
BUG: fix pref font combo boxes

### DIFF
--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
@@ -823,6 +823,9 @@
               <property name="styleSheet">
                <string notr="true"/>
               </property>
+              <property name="fontFilters">
+               <set>QFontComboBox::ScalableFonts</set>
+              </property>
              </widget>
             </item>
            </layout>
@@ -925,6 +928,9 @@
               </property>
               <property name="styleSheet">
                <string notr="true"/>
+              </property>
+              <property name="fontFilters">
+               <set>QFontComboBox::ScalableFonts</set>
               </property>
              </widget>
             </item>
@@ -1235,6 +1241,9 @@
               </property>
               <property name="styleSheet">
                <string notr="true"/>
+              </property>
+              <property name="fontFilters">
+               <set>QFontComboBox::ScalableFonts</set>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
This PR fixes the issue of showing bitmap fonts in the fontcombobox lists of the Font Preferences. This will prevent the bitmap fonts from showing in the drop down. and not allowing a user to select a bitmap font which can cause issues. 

The solution was to simply set the ScalableFonts filter attribute for the font comboboxes:

<img width="382" height="128" alt="Screenshot 2026-03-06 073501" src="https://github.com/user-attachments/assets/b0f90a29-1de2-425d-8bbd-ca44f277717f" />

closes issue #1504 