### PR TITLE
feat: add batch export  to multisize patterns

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -3794,6 +3794,45 @@ Zkuste prosím vrátit zpět poslední operaci nebo opravit poškozený vzorec.<
         <source>Paper format (tiled PDF only)</source>
         <translation>Papírový formát (pouze dlaždicově sladěné PDF)</translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation>Export vybraných velikostí</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation>Vyberte Vše</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Exportovat</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation>Exportování souborů...</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Soubor</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Stav</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation>Čeká na vyřízení</translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation>Dokončeno</translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation>Nepodařilo se</translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7072,6 +7111,10 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
     <message>
         <source>Next Draft Block</source>
         <translation>Další koncept bloku</translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation>Exportování...</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -3779,6 +3779,45 @@ Bitte versuchen Sie, den letzten Vorgang rückgängig zu machen oder die fehlerh
         <source>Paper format (tiled PDF only)</source>
         <translation>Papierformat (nur gekacheltes PDF)</translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation>Ausgewählte Größen exportieren</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation>Alles auswählen</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Export</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation>Dateien werden exportiert...</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Datei</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation>Ausstehend</translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation>Vollendet</translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation>Fehlgeschlagen</translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7057,6 +7096,10 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     <message>
         <source>Next Draft Block</source>
         <translation>Nächster Entwurfsblock</translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation>Exportiere...</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -3796,6 +3796,45 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <source>Paper format (tiled PDF only)</source>
         <translation>Μορφή χαρτιού (μόνο PDF με πλακίδια)</translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation>Εξαγωγή επιλεγμένων μεγεθών</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation>Επιλέξτε Όλα</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Εξαγωγή</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation>Εξαγωγή αρχείων...</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Αρχείο</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Κατάσταση</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation>Εκκρεμής</translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation>Ολοκληρώθηκε το</translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation>Αποτυχημένος</translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7076,6 +7115,10 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Next Draft Block</source>
         <translation>Επόμενο μπλοκάρισμα στο προσχέδιο</translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation>Εξαγωγή...</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -3778,6 +3778,45 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <source>Paper format (tiled PDF only)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation type="unfinished">Export</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation type="unfinished">File</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7041,6 +7080,10 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -3778,6 +3778,45 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <source>Paper format (tiled PDF only)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation type="unfinished">Export</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7041,6 +7080,10 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -3778,6 +3778,45 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <source>Paper format (tiled PDF only)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation type="unfinished">Export</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation type="unfinished">File</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7041,6 +7080,10 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -3778,6 +3778,45 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <source>Paper format (tiled PDF only)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation type="unfinished">Export</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7041,6 +7080,10 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -3814,6 +3814,45 @@ Intente deshacer la última operación o corregir la fórmula defectuosa.</trans
         <source>Paper format (tiled PDF only)</source>
         <translation>Formato de papel (solo PDF en mosaico)</translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation>Exportar tamaños seleccionados</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation>Seleccionar todo</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation>Exportando archivos...</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Archivo</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Estado</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation>Pendiente</translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation>Terminado</translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation>Fallido</translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7093,6 +7132,10 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Next Draft Block</source>
         <translation>Próximo Bloque de borrador</translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation>Exportador...</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -3794,6 +3794,45 @@ Yritä kumota viimeisin operaatio tai korjata rikkinäinen kaava.</translation>
         <source>Paper format (tiled PDF only)</source>
         <translation>Paperimuoto (vain laatoitettu PDF)</translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation>Vie valitut koot</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation>Valitse Kaikki</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Vie</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation>Viedään tiedostoja...</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Tiedosto</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation>Odottaa</translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation>Valmis</translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation>Epäonnistui</translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7073,6 +7112,10 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
     <message>
         <source>Next Draft Block</source>
         <translation>Seuraava luonnospala</translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation>Viedään...</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -3817,6 +3817,45 @@ points de contrôle</translation>
         <source>Paper format (tiled PDF only)</source>
         <translation>Format papier (en PDF mosaïque uniquement)</translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation>Exporter les tailles sélectionnées</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation>Tout sélectionner</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Exporter</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation>Exportation des fichiers...</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Fichier</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Statut</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation>En attente</translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation>Complété</translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation>Échoué</translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7098,6 +7137,10 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
     <message>
         <source>Next Draft Block</source>
         <translation>Bloc de travail suivants</translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation>Exportation en cours...</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -3778,6 +3778,45 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <source>Paper format (tiled PDF only)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation type="unfinished">קובץ</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7037,6 +7076,10 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -3794,6 +3794,45 @@ Silakan coba batalkan operasi terakhir atau perbaiki rumus yang rusak.</translat
         <source>Paper format (tiled PDF only)</source>
         <translation>Format kertas (hanya PDF yang diubin)</translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation>Ekspor Ukuran Terpilih</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation>Pilih Semua</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Ekspor</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation>Mengekspor file...</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Berkas</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation>Tertunda</translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation>Selesai</translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation>Gagal</translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7074,6 +7113,10 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
     <message>
         <source>Next Draft Block</source>
         <translation>Blok Draf Berikutnya</translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation>Sedang mengekspor...</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -3781,6 +3781,45 @@ punti di controllo</translation>
         <source>Paper format (tiled PDF only)</source>
         <translation>Formato cartaceo (solo PDF affiancato)</translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation>Esporta dimensioni selezionate</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation>Seleziona tutto</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Esportare</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation>Esportazione dei file...</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>File</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Stato</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation>In attesa di</translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation>Completato</translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation>Fallito</translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7062,6 +7101,10 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
     <message>
         <source>Next Draft Block</source>
         <translation>Blocco bozza successivo</translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation>Esportazione in corso...</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -3779,6 +3779,45 @@ Probeer de laatste bewerking ongedaan te maken of de defecte formule te herstell
         <source>Paper format (tiled PDF only)</source>
         <translation>Papierformaat (alleen betegelde PDF)</translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation>Geselecteerde maten exporteren</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation>Alles selecteren</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Exporteren</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation>Bestanden exporteren...</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Bestand</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation>In behandeling</translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation>Voltooid</translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation>Mislukt</translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7057,6 +7096,10 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
     <message>
         <source>Next Draft Block</source>
         <translation>Volgende ontwerpblok</translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation>Exporteren...</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -3780,6 +3780,45 @@ pontos de controle</translation>
         <source>Paper format (tiled PDF only)</source>
         <translation>Formato de papel (somente PDF em mosaico)</translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation>Exportar tamanhos selecionados</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation>Selecionar tudo</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation>Exportando arquivos...</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Arquivo</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation>Pendente</translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation>Concluído</translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation>Fracassado</translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7060,6 +7099,10 @@ Prima enter para o adicionar temporariamente à lista.</translation>
     <message>
         <source>Next Draft Block</source>
         <translation>Prâximo bloco de rascunho</translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation>Exportador...</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -3796,6 +3796,45 @@ Vă rugăm să încercați să anulați ultima operațiune sau să remediați fo
         <source>Paper format (tiled PDF only)</source>
         <translation>Format hârtie (doar PDF cu tile)</translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation>Exportați dimensiunile selectate</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation>Selectați Toate</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Exportare</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation>Se exportă fișiere...</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Fișier</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Stare</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation>În așteptare</translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation>Terminat</translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation>A eșuat</translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7076,6 +7115,10 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
     <message>
         <source>Next Draft Block</source>
         <translation>Următorul bloc de schițe</translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation>Exportator...</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -3798,6 +3798,45 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <source>Paper format (tiled PDF only)</source>
         <translation>Формат бумаги (только мозаичный PDF)</translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation>Экспортировать выбранные размеры</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation>Выбрать всё</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Экспорт</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation>Экспорт файлов...</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Файл</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Статус</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation>В ожидании</translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation>Завершенный</translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation>Неуспешный</translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7078,6 +7117,10 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Next Draft Block</source>
         <translation>Следующий черновик блока</translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation>Экспорт...</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -3794,6 +3794,45 @@ Lütfen son işlemi geri almayı veya bozuk formülü düzeltmeyi deneyin.</tran
         <source>Paper format (tiled PDF only)</source>
         <translation>Kağıt formatı (sadece döşenmiş PDF)</translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation>Seçili Boyutları Dışa Aktar</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation>Tümünü Seç</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Dışa Aktar</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation>Dosyalar dışa aktarılıyor...</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Dosya</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Durum</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation>Askıda olması</translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation>Tamamlanmış</translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation>Arızalı</translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7074,6 +7113,10 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
     <message>
         <source>Next Draft Block</source>
         <translation>Sonraki Taslak Bloğu</translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation>Dışa aktarılıyor...</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -3796,6 +3796,45 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <source>Paper format (tiled PDF only)</source>
         <translation>Формат паперу (лише PDF з плитками)</translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation>Експортувати вибрані розміри</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation>Виберіть усі</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Експорт</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation>Експорт файлів...</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Файл</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Статус</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation>В очікуванні</translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation>Виконано</translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation>Не вдалося</translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7075,6 +7114,10 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Next Draft Block</source>
         <translation>Επόμενο μπλοκάρισμα στο προσχέδιο</translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation>Експорт...</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -3794,6 +3794,45 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <source>Paper format (tiled PDF only)</source>
         <translation>纸张格式（仅限平铺 PDF）</translation>
     </message>
+    <message>
+        <source>Export Selected Sizes</source>
+        <translation>导出选定尺寸</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation>全选</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>导出</translation>
+    </message>
+</context>
+<context>
+    <name>ExportProgressDialog</name>
+    <message>
+        <source>Exporting files...</source>
+        <translation>正在导出文件...</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>文件</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>地位</translation>
+    </message>
+    <message>
+        <source>Pending</source>
+        <translation>待办的</translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation>完全的</translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation>失败的</translation>
+    </message>
 </context>
 <context>
     <name>FvUpdater</name>
@@ -7074,6 +7113,10 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Next Draft Block</source>
         <translation>下一个样板</translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation>出口...</translation>
     </message>
 </context>
 <context>

--- a/src/app/seamly2d/dialogs/dialogs.pri
+++ b/src/app/seamly2d/dialogs/dialogs.pri
@@ -9,6 +9,7 @@ HEADERS += \
     $$PWD/dialogs.h \
     $$PWD/dialogpatternproperties.h \
     $$PWD/dialognewpattern.h \
+    $$PWD/export_progress_dialog.h \
     $$PWD/layoutsettings_dialog.h \
     $$PWD/dialoglayoutprogress.h \
     $$PWD/dialogvariables.h \
@@ -33,6 +34,7 @@ SOURCES += \
     $$PWD/decimalchart_dialog.cpp \
     $$PWD/dialogpatternproperties.cpp \
     $$PWD/dialognewpattern.cpp \
+    $$PWD/export_progress_dialog.cpp \
     $$PWD/layoutsettings_dialog.cpp \
     $$PWD/dialoglayoutprogress.cpp \
     $$PWD/dialogvariables.cpp \
@@ -59,6 +61,7 @@ FORMS += \
     $$PWD/dialoglayoutprogress.ui \
     $$PWD/dialogvariables.ui \
     $$PWD/export_layout_dialog.ui \
+    $$PWD/export_progress_dialog.ui \
     $$PWD/groups_widget.ui \
     $$PWD/history_dialog.ui \
     $$PWD/layoutsettings_dialog.ui \

--- a/src/app/seamly2d/dialogs/export_layout_dialog.cpp
+++ b/src/app/seamly2d/dialogs/export_layout_dialog.cpp
@@ -1,33 +1,53 @@
-/************************************************************************
- **
- **  @file   export_layout_dialog.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   22 1, 2015
- **
- **  @author Douglas S Caskey
- **  @date   Nov 4, 2022
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Seamly2D project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2022 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   export_layout_dialog.cpp
+//  @author Douglas S Caskey
+//  @date   Apr 1, 2026
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2026 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+//  @file   export_layout_dialog.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   22 1, 2015
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017-2026 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #include "export_layout_dialog.h"
 #include "ui_export_layout_dialog.h"
@@ -70,6 +90,7 @@ ExportLayoutDialog::ExportLayoutDialog(int count, Draw mode, const QString &file
     m_SaveButton = ui->buttonBox->button(QDialogButtonBox::Save);
     SCASSERT(m_SaveButton != nullptr)
     m_SaveButton->setEnabled(false);
+    m_SaveButton->setText(tr("Export"));
 
     ui->filename_LineEdit->setValidator( new QRegularExpressionValidator(QRegularExpression(fileNameRegExp), this));
 
@@ -184,6 +205,21 @@ ExportLayoutDialog::ExportLayoutDialog(int count, Draw mode, const QString &file
     ui->path_LineEdit->setText(qApp->Seamly2DSettings()->getLayoutPath());
 
     initTemplates(ui->templates_ComboBox);
+
+    // Size selection group box: hidden by default, shown when setAvailableSizes() is called
+    ui->sizeSelection_GroupBox->setVisible(false);
+
+    connect(ui->selectAll_CheckBox, &QCheckBox::toggled, [=](bool checked)
+    {
+        if (checked)
+        {
+            selectAllSizes();
+        }
+        else
+        {
+            deselectAllSizes();
+        }
+    });
 
     readSettings();
     showExportFiles(); //Show example for current format.
@@ -485,6 +521,12 @@ QString ExportLayoutDialog::fileName() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+void ExportLayoutDialog::setFileName(const QString &name)
+{
+    ui->filename_LineEdit->setText(name);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 LayoutExportFormat ExportLayoutDialog::format() const
 {
     return static_cast<LayoutExportFormat>(ui->format_ComboBox->currentData().toInt());
@@ -594,26 +636,66 @@ void ExportLayoutDialog::showExportFiles()
 
     if (currentFormat == LayoutExportFormat::PDFTiled)
     {
-        const QString name = QString("%1%2")
-        .arg(fileName())                     //1
-        .arg(exportFormatSuffix(format()));  //2
-
-        QListWidgetItem *item = new QListWidgetItem(name);
-        SCASSERT(item != nullptr)
-        ui->exportFiles_ListWidget->addItem(item);
-    }
-    else
-    {
-        for (int i=0; i < m_count; ++i)
+        // Batch mode
+        if (!selectedSizes().isEmpty())
         {
-            const QString name = QString("%1_0%2%3")
+            for (const QString &size : selectedSizes())
+            {
+                const QString name = QString("%1_%2%3")
+                .arg(fileName())                     //1
+                .arg(size)                           //2
+                .arg(exportFormatSuffix(format()));  //3
+
+                QListWidgetItem *item = new QListWidgetItem(name);
+                SCASSERT(item != nullptr)
+                ui->exportFiles_ListWidget->addItem(item);
+            }
+        }
+        else
+        {
+            const QString name = QString("%1%2")
             .arg(fileName())                     //1
-            .arg(QString::number(i+1))           //2
-            .arg(exportFormatSuffix(format()));  //3
+            .arg(exportFormatSuffix(format()));  //2
 
             QListWidgetItem *item = new QListWidgetItem(name);
             SCASSERT(item != nullptr)
             ui->exportFiles_ListWidget->addItem(item);
+        }
+    }
+    else
+    {
+        // Batch mode
+        if (!selectedSizes().isEmpty())
+        {
+            for (const QString &size : selectedSizes())
+            {
+                for (int i=0; i < m_count; ++i)
+                {
+                    const QString name = QString("%1_%2_0%3%4")
+                    .arg(fileName())                     //1
+                    .arg(size)                           //2
+                    .arg(QString::number(i+1))           //3
+                    .arg(exportFormatSuffix(format()));  //4
+
+                    QListWidgetItem *item = new QListWidgetItem(name);
+                    SCASSERT(item != nullptr)
+                    ui->exportFiles_ListWidget->addItem(item);
+                }
+            }
+        }
+        else
+        {
+            for (int i=0; i < m_count; ++i)
+            {
+                const QString name = QString("%1_0%2%3")
+                .arg(fileName())                     //1
+                .arg(QString::number(i+1))           //2
+                .arg(exportFormatSuffix(format()));  //3
+
+                QListWidgetItem *item = new QListWidgetItem(name);
+                SCASSERT(item != nullptr)
+                ui->exportFiles_ListWidget->addItem(item);
+            }
         }
     }
 
@@ -719,13 +801,12 @@ void ExportLayoutDialog::removeFormatFromList(LayoutExportFormat format)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * Reads the values of the variables needed for the save layout dialog, for instance
- * the margins, teamplte and orientation of tiled pdf. Then sets the corresponding
- * elements of the dialog to these values.
- *
- * @brief ExportLayoutDialog::readSettings
- */
+//  Reads the values of the variables needed for the save layout dialog, for instance
+//  the margins, teamplte and orientation of tiled pdf. Then sets the corresponding
+//  elements of the dialog to these values.
+//
+//  @brief ExportLayoutDialog::readSettings
+//---------------------------------------------------------------------------------------------------------------------
 void ExportLayoutDialog::readSettings()
 {
     VSettings *settings = qApp->Seamly2DSettings();
@@ -769,12 +850,11 @@ void ExportLayoutDialog::readSettings()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * Writes the values of some variables (like the margins, template and orientation of tiled pdf).
- * of the save layout dialog into the settings.
- *
- * @brief ExportLayoutDialog::writeSettings
- */
+//  Writes the values of some variables (like the margins, template and orientation of tiled pdf).
+//  of the save layout dialog into the settings.
+//
+//  @brief ExportLayoutDialog::writeSettings
+//---------------------------------------------------------------------------------------------------------------------
 void ExportLayoutDialog::writeSettings() const
 {
     VSettings *settings = qApp->Seamly2DSettings();
@@ -815,10 +895,9 @@ void ExportLayoutDialog::writeSettings() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief modeString()
- * @return Returns a string that is the mode type
- */
+//  @brief modeString()
+//  @return Returns a string that is the mode type
+//---------------------------------------------------------------------------------------------------------------------
 QString ExportLayoutDialog::modeString() const
 {
     QString modeStr = QStringLiteral("");
@@ -845,4 +924,83 @@ QString ExportLayoutDialog::modeString() const
         }
     }
     return modeStr;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void ExportLayoutDialog::setAvailableSizes(const QStringList &sizes)
+{
+    ui->sizes_ListWidget->clear();
+
+    if (sizes.isEmpty())
+    {
+        ui->sizeSelection_GroupBox->setVisible(false);
+        setMinimumHeight(380);
+        adjustSize();
+        return;
+    }
+
+    ui->sizeSelection_GroupBox->setVisible(true);
+    setMinimumHeight(470);
+    adjustSize();
+    if (m_mode != Draw::Layout)
+    {
+        setMinimumHeight(400);
+    }
+
+    for (const QString &size : sizes)
+    {
+        QListWidgetItem *item = new QListWidgetItem(size + QString(" "));
+        SCASSERT(item != nullptr)
+        item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+        item->setCheckState(Qt::Unchecked);
+        ui->sizes_ListWidget->addItem(item);
+    }
+
+    // Reconnect to update file preview when sizes change
+    connect(ui->sizes_ListWidget, &QListWidget::itemChanged, this, &ExportLayoutDialog::showExportFiles);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+QStringList ExportLayoutDialog::selectedSizes() const
+{
+    QStringList sizes;
+    for (int i = 0; i < ui->sizes_ListWidget->count(); ++i)
+    {
+        QListWidgetItem *item = ui->sizes_ListWidget->item(i);
+        if (item->checkState() == Qt::Checked)
+        {
+            sizes.append(item->text());
+        }
+    }
+    return sizes;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+bool ExportLayoutDialog::isBatchExport() const
+{
+    return !selectedSizes().isEmpty();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void ExportLayoutDialog::selectAllSizes()
+{
+    ui->sizes_ListWidget->blockSignals(true);
+    for (int i = 0; i < ui->sizes_ListWidget->count(); ++i)
+    {
+        ui->sizes_ListWidget->item(i)->setCheckState(Qt::Checked);
+    }
+    ui->sizes_ListWidget->blockSignals(false);
+    showExportFiles();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void ExportLayoutDialog::deselectAllSizes()
+{
+    ui->sizes_ListWidget->blockSignals(true);
+    for (int i = 0; i < ui->sizes_ListWidget->count(); ++i)
+    {
+        ui->sizes_ListWidget->item(i)->setCheckState(Qt::Unchecked);
+    }
+    ui->sizes_ListWidget->blockSignals(false);
+    showExportFiles();
 }

--- a/src/app/seamly2d/dialogs/export_layout_dialog.h
+++ b/src/app/seamly2d/dialogs/export_layout_dialog.h
@@ -1,33 +1,54 @@
-/************************************************************************
- **
- **  @file   export_layout_dialog.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   22 1, 2015
- **
- **  @author Douglas S Caskey
- **  @date   Nov 4, 2022
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Seamly2D project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2022 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   export_layout_dialog.h
+//  @author Douglas S Caskey
+//  @date   Apr 1, 2026
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2026 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+//  @file   export_layout_dialog.h
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   22 1, 2015
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017-2026 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #ifndef EXPORT_LAYOUT_DIALOG_H
 #define EXPORT_LAYOUT_DIALOG_H
@@ -50,53 +71,61 @@ class ExportLayoutDialog : public  AbstractLayoutDialog
     Q_OBJECT
 
 public:
-    explicit              ExportLayoutDialog(int count, Draw mode = Draw::Layout, const QString &fileName = QString(),
+    explicit                ExportLayoutDialog(int count, Draw mode = Draw::Layout, const QString &fileName = QString(),
                                            QWidget *parent = nullptr);
 
-    virtual              ~ExportLayoutDialog();
+    virtual                ~ExportLayoutDialog();
 
-    QString               path() const;
-    QString               fileName() const;
-    QString               modeString() const;
+    QString                 path() const;
+    QString                 fileName() const;
+    void                    setFileName(const QString &name);
 
-    LayoutExportFormat    format() const;
-    QString               formatText() const;
-    void                  selectFormat(LayoutExportFormat format);
+    QString                 modeString() const;
 
-    void                  setBinaryDXFFormat(bool binary);
-    bool                  isBinaryDXFFormat() const;
-    void                  enableBinaryDXFFormatCheckbox();
+    LayoutExportFormat      format() const;
+    QString                 formatText() const;
+    void                    selectFormat(LayoutExportFormat format);
 
-    void                  setDestinationPath(const QString& cmdDestinationPath);
+    void                    setBinaryDXFFormat(bool binary);
+    bool                    isBinaryDXFFormat() const;
+    void                    enableBinaryDXFFormatCheckbox();
 
-    Draw                  mode() const;
+    void                    setDestinationPath(const QString& cmdDestinationPath);
 
-    static QString        exportFormatSuffix(LayoutExportFormat format);
+    Draw                    mode() const;
 
-    bool                  isTextAsPaths() const;
-    void                  setTextAsPaths(bool textAsPaths);
+    static QString          exportFormatSuffix(LayoutExportFormat format);
+
+    bool                    isTextAsPaths() const;
+    void                    setTextAsPaths(bool textAsPaths);
+
+    void                    setAvailableSizes(const QStringList &sizes);
+    QStringList             selectedSizes() const;
+    bool                    isBatchExport() const;
 
 protected:
-    virtual void          showEvent(QShowEvent *event) override;
-    void                  initTemplates(QComboBox *templates);
+    virtual void            showEvent(QShowEvent *event) override;
+    void                    initTemplates(QComboBox *templates);
 
 private slots:
-    void                  save();
-    void                  pathChanged(const QString &text);
-    void                  showExportFiles();
+    void                    save();
+    void                    pathChanged(const QString &text);
+    void                    showExportFiles();
+    void                    selectAllSizes();
+    void                    deselectAllSizes();
 
 private:
     Q_DISABLE_COPY(ExportLayoutDialog)
     Ui::ExportLayoutDialog *ui;
-    int                   m_count;
-    bool                  m_isInitialized;
-    Draw                  m_mode;
-    QPushButton          *m_SaveButton;
+    int                     m_count;
+    bool                    m_isInitialized;
+    Draw                    m_mode;
+    QPushButton            *m_SaveButton;
 
-    void                  removeFormatFromList(LayoutExportFormat format);
+    void                    removeFormatFromList(LayoutExportFormat format);
 
-    void                  readSettings();
-    void                  writeSettings() const;
+    void                    readSettings();
+    void                    writeSettings() const;
 };
 
 #endif // EXPORT_LAYOUT_DIALOG_H

--- a/src/app/seamly2d/dialogs/export_layout_dialog.ui
+++ b/src/app/seamly2d/dialogs/export_layout_dialog.ui
@@ -3,20 +3,26 @@
  <class>ExportLayoutDialog</class>
  <widget class="QDialog" name="ExportLayoutDialog">
   <property name="windowModality">
-   <enum>Qt::WindowModality::ApplicationModal</enum>
+   <enum>Qt::NonModal</enum>
   </property>
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
     <width>762</width>
-    <height>342</height>
+    <height>467</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>900</width>
-    <height>400</height>
+    <width>16777215</width>
+    <height>16777215</height>
    </size>
   </property>
   <property name="font">
@@ -32,7 +38,7 @@
     <normaloff>:/toolicon/32x32/export.png</normaloff>:/toolicon/32x32/export.png</iconset>
   </property>
   <property name="sizeGripEnabled">
-   <bool>false</bool>
+   <bool>true</bool>
   </property>
   <property name="modal">
    <bool>true</bool>
@@ -66,11 +72,14 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="frameShape">
-      <enum>QFrame::Shape::StyledPanel</enum>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
-     <property name="frameShadow">
-      <enum>QFrame::Shadow::Raised</enum>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
@@ -99,7 +108,7 @@
            <string>Path:</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
@@ -148,10 +157,7 @@
         <item>
          <widget class="QFrame" name="file_Frame">
           <property name="frameShape">
-           <enum>QFrame::Shape::Box</enum>
-          </property>
-          <property name="frameShadow">
-           <enum>QFrame::Shadow::Raised</enum>
+           <enum>QFrame::Box</enum>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_3">
            <item>
@@ -163,7 +169,7 @@
               <widget class="QLabel" name="format_Label">
                <property name="minimumSize">
                 <size>
-                 <width>120</width>
+                 <width>90</width>
                  <height>0</height>
                 </size>
                </property>
@@ -171,7 +177,7 @@
                 <string>File format:</string>
                </property>
                <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -195,7 +201,7 @@
               <widget class="QLabel" name="filename_Label">
                <property name="minimumSize">
                 <size>
-                 <width>120</width>
+                 <width>90</width>
                  <height>0</height>
                 </size>
                </property>
@@ -203,7 +209,7 @@
                 <string>File name:</string>
                </property>
                <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -233,7 +239,7 @@
               <widget class="QLabel" name="quality_Label">
                <property name="minimumSize">
                 <size>
-                 <width>120</width>
+                 <width>90</width>
                  <height>0</height>
                 </size>
                </property>
@@ -246,7 +252,7 @@
                 <string>Quality (0-100):</string>
                </property>
                <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -276,9 +282,6 @@
                  </property>
                  <property name="text">
                   <string notr="true">-</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                  </property>
                  <property name="indent">
                   <number>0</number>
@@ -372,9 +375,6 @@ border-radius: 4px;
                  <property name="sliderPosition">
                   <number>75</number>
                  </property>
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
-                 </property>
                 </widget>
                </item>
                <item>
@@ -399,9 +399,6 @@ border-radius: 4px;
                  <property name="text">
                   <string notr="true">+</string>
                  </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-                 </property>
                 </widget>
                </item>
                <item>
@@ -413,7 +410,7 @@ border-radius: 4px;
                   </sizepolicy>
                  </property>
                  <property name="buttonSymbols">
-                  <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                  <enum>QAbstractSpinBox::UpDownArrows</enum>
                  </property>
                  <property name="maximum">
                   <number>100</number>
@@ -430,10 +427,7 @@ border-radius: 4px;
         <item>
          <widget class="QFrame" name="export_Frame">
           <property name="frameShape">
-           <enum>QFrame::Shape::Box</enum>
-          </property>
-          <property name="frameShadow">
-           <enum>QFrame::Shadow::Raised</enum>
+           <enum>QFrame::NoFrame</enum>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_5">
            <item>
@@ -446,7 +440,7 @@ border-radius: 4px;
              </property>
              <property name="minimumSize">
               <size>
-               <width>100</width>
+               <width>90</width>
                <height>0</height>
               </size>
              </property>
@@ -454,7 +448,7 @@ border-radius: 4px;
               <string>Export files:</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTop|Qt::AlignmentFlag::AlignTrailing</set>
+              <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
              </property>
             </widget>
            </item>
@@ -489,11 +483,88 @@ border-radius: 4px;
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="sizeSelection_GroupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Export Selected Sizes</string>
+     </property>
+     <layout class="QVBoxLayout" name="sizeSelection_VLayout">
+      <property name="bottomMargin">
+       <number>6</number>
+      </property>
+      <item>
+       <widget class="QCheckBox" name="selectAll_CheckBox">
+        <property name="text">
+         <string>Select All</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QListWidget" name="sizes_ListWidget">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>50</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>50</height>
+         </size>
+        </property>
+        <property name="verticalScrollBarPolicy">
+         <enum>Qt::ScrollBarAlwaysOff</enum>
+        </property>
+        <property name="isWrapping" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="viewMode">
+         <enum>QListView::IconMode</enum>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+        <property name="itemAlignment">
+         <set>Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QWidget" name="tiledPDF_Widget" native="true">
      <property name="enabled">
       <bool>true</bool>
      </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <layout class="QVBoxLayout" name="verticalLayout_7">
+      <property name="topMargin">
+       <number>6</number>
+      </property>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <property name="leftMargin">
@@ -548,7 +619,7 @@ border-radius: 4px;
                   <string>Right:</string>
                  </property>
                  <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
                 </widget>
                </item>
@@ -596,7 +667,7 @@ border-radius: 4px;
                   <string>Left:</string>
                  </property>
                  <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
                 </widget>
                </item>
@@ -616,7 +687,7 @@ border-radius: 4px;
                   <string>Top:</string>
                  </property>
                  <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
                 </widget>
                </item>
@@ -648,7 +719,7 @@ border-radius: 4px;
                   <string>Bottom:</string>
                  </property>
                  <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
                 </widget>
                </item>
@@ -722,7 +793,7 @@ border-radius: 4px;
                 <string>Templates: </string>
                </property>
                <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -760,7 +831,7 @@ border-radius: 4px;
                 <string>Orientation: </string>
                </property>
                <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -804,9 +875,9 @@ border-radius: 4px;
                 </widget>
                </item>
                <item>
-                <spacer name="horizontalSpacer">
+                <spacer name="horizontalSpacer_3">
                  <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
+                  <enum>Qt::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -825,27 +896,24 @@ border-radius: 4px;
         </item>
        </layout>
       </item>
+      <item>
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
      </layout>
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
-     </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
      </property>

--- a/src/app/seamly2d/dialogs/export_progress_dialog.cpp
+++ b/src/app/seamly2d/dialogs/export_progress_dialog.cpp
@@ -1,0 +1,139 @@
+//-----------------------------------------------------------------------------
+//  @file   export_progress_dialog.cpp
+//  @author Douglas S Caskey
+//  @date   31 Mar 2026
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017-2026 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
+
+#include "export_progress_dialog.h"
+#include "ui_export_progress_dialog.h"
+
+#include <QProgressBar>
+#include <QTableWidget>
+
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief ExportProgressDialog Progress report dialog.
+///
+/// This class provides a dialog to report the status and progress of files exported.
+///
+/// @param minimum property for the progress bar's minimum value.
+/// @param maximum property for the progress bar's maximum value.
+/// @param parent parent widget of dialog.
+//---------------------------------------------------------------------------------------------------------------------
+ExportProgressDialog::ExportProgressDialog(int minimum, int maximum, QWidget *parent)
+    : QDialog(parent)
+    , ui(new Ui::ExportProgressDialog)
+
+{
+    ui->setupUi(this);
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+    ui->export_ProgressBar->setMinimum(minimum);
+    ui->export_ProgressBar->setMaximum(maximum);
+    ui->export_ProgressBar->setValue(0);
+
+    ui->files_TableWidget->setColumnWidth(StatusColumn, 120);
+    ui->files_TableWidget->horizontalHeader()->setSectionResizeMode(FileNameColumn, QHeaderView::Stretch);
+
+    adjustSize();
+    setFixedHeight(this->height());
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+ExportProgressDialog::~ExportProgressDialog()
+{
+    delete ui;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief insertFileName Insert a new filename.
+///
+/// This method inserts a new row with the flename and default status of pending.
+///
+/// @param filename export filename.
+//---------------------------------------------------------------------------------------------------------------------
+void ExportProgressDialog::insertFileName(const QString &filename)
+{
+    ui->files_TableWidget->insertRow(0);
+    ui->files_TableWidget->setItem(0, FileNameColumn, new QTableWidgetItem(filename));
+    ui->files_TableWidget->setItem(0, StatusColumn, new QTableWidgetItem(tr("Pending")));
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief setFileStatus Create a new draft block.
+///
+/// This method set the status of the exported file.
+///
+/// @param status status result of export.
+//
+/// @details
+///  - ProgressStatus::Pending (default) displays "Pending".
+///  - ProgressStatus::Completed displays "Completed".
+///  - ProgressStatus::Failed displays "Failed".
+//---------------------------------------------------------------------------------------------------------------------
+void ExportProgressDialog::setFileStatus(const ProgressStatus &status)
+{
+    QTableWidgetItem *item = ui->files_TableWidget->item(0, StatusColumn);
+    item->setTextAlignment(Qt::AlignHCenter);
+
+    switch (status)
+    {
+        case ProgressStatus::Completed:
+            item->setText(tr("Completed"));
+            break;
+        case ProgressStatus::Failed:
+            item->setText(tr("Failed"));
+            break;
+        case ProgressStatus::Pending:
+        default:
+            item->setText(tr("Pending"));
+            break;
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief setProgress Sets the progress
+///
+/// This method sets the current progress of the progress bar widget.
+///
+/// @param value  current step value.
+//---------------------------------------------------------------------------------------------------------------------
+void ExportProgressDialog::setProgress(const int &value)
+{
+    ui->export_ProgressBar->setValue(value);
+}
+
+/// @brief showProgressBar show ot hide progress bar.
+///
+/// This method shows or hides the progress bar widget.
+///
+/// @param state visibilty state of the progress.
+//
+/// @details
+///  - Visible if true.
+///  - Hidden if false.
+//---------------------------------------------------------------------------------------------------------------------
+void ExportProgressDialog::showProgressBar(const bool &state)
+{
+    ui->export_ProgressBar->setVisible(state);
+}

--- a/src/app/seamly2d/dialogs/export_progress_dialog.h
+++ b/src/app/seamly2d/dialogs/export_progress_dialog.h
@@ -1,0 +1,61 @@
+//-----------------------------------------------------------------------------
+//  @file   export_progress_dialog.cpp
+//  @author Douglas S Caskey
+//  @date   31 Mar 2026
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017-2026 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
+
+#ifndef EXPORT_PROGRESS_DIALOG_H
+#define EXPORT_PROGRESS_DIALOG_H
+
+#include <QDialog>
+#include <QProgressBar>
+
+enum {FileNameColumn = 0, StatusColumn};
+enum class ProgressStatus {Pending = 0, Completed, Failed};
+
+namespace Ui
+{
+    class ExportProgressDialog;
+}
+
+
+class ExportProgressDialog : public  QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit                ExportProgressDialog(int minimum, int maximum, QWidget *parent = nullptr);
+
+    virtual                ~ExportProgressDialog();
+
+    void                    insertFileName(const QString &filename);
+    void                    setFileStatus(const ProgressStatus &status);
+    void                    setProgress(const int &value);
+    void                    showProgressBar(const bool &state);
+
+private:
+    Q_DISABLE_COPY(ExportProgressDialog)
+    Ui::ExportProgressDialog *ui;
+};
+
+#endif // EXPORT_PROGRESS_DIALOG_H

--- a/src/app/seamly2d/dialogs/export_progress_dialog.ui
+++ b/src/app/seamly2d/dialogs/export_progress_dialog.ui
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ExportProgressDialog</class>
+ <widget class="QDialog" name="ExportProgressDialog">
+  <property name="windowModality">
+   <enum>Qt::NonModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>623</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>600</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>16777215</height>
+   </size>
+  </property>
+  <property name="font">
+   <font>
+    <pointsize>9</pointsize>
+   </font>
+  </property>
+  <property name="windowTitle">
+   <string>Exporting files...</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="../share/resources/toolicon.qrc">
+    <normaloff>:/toolicon/32x32/export.png</normaloff>:/toolicon/32x32/export.png</iconset>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTableWidget" name="files_TableWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>200</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAsNeeded</enum>
+     </property>
+     <property name="dragDropOverwriteMode">
+      <bool>false</bool>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::NoSelection</enum>
+     </property>
+     <property name="showGrid">
+      <bool>false</bool>
+     </property>
+     <property name="wordWrap">
+      <bool>false</bool>
+     </property>
+     <property name="cornerButtonEnabled">
+      <bool>false</bool>
+     </property>
+     <property name="columnCount">
+      <number>2</number>
+     </property>
+     <column>
+      <property name="text">
+       <string>File</string>
+      </property>
+      <property name="font">
+       <font>
+        <bold>true</bold>
+       </font>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Status</string>
+      </property>
+      <property name="font">
+       <font>
+        <bold>true</bold>
+       </font>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <widget class="QProgressBar" name="export_ProgressBar">
+     <property name="value">
+      <number>24</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../share/resources/toolicon.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ExportProgressDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ExportProgressDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -61,6 +61,7 @@
 #include "dialogs/dialogs.h"
 #include "dialogs/calculator_dialog.h"
 #include "dialogs/decimalchart_dialog.h"
+#include "dialogs/export_progress_dialog.h"
 #include "../ifc/exception/vexceptionobjecterror.h"
 #include "../ifc/exception/vexceptionconversionerror.h"
 #include "../ifc/exception/vexceptionemptyparameter.h"
@@ -6795,13 +6796,180 @@ void MainWindow::exportLayoutAs()
     {
         ExportLayoutDialog dialog(scenes.size(), Draw::Layout, FileName(), this);
 
+        // Populate size selection if multisize pattern
+        if (qApp->patternType() == MeasurementsType::Multisize)
+        {
+            const QStringList sizes = MeasurementVariable::ListSizes(doc->GetGradationSizes(), qApp->patternUnit());
+            dialog.setAvailableSizes(sizes);
+        }
+
         if (dialog.exec() == QDialog::Rejected)
         {
             ui->exportLayout_ToolButton->setChecked(false);
             return;
         }
 
-        ExportData(QVector<VLayoutPiece>(), dialog);
+        if (!dialog.isBatchExport())
+        {
+            // Original single-export path (unchanged)
+            ExportData(QVector<VLayoutPiece>(), dialog);
+        }
+        else
+        {
+            // Batch export: iterate over selected sizes
+            const QStringList sizes = dialog.selectedSizes();
+            const QString originalFileName = dialog.fileName();
+
+            // Save current state
+            const int originalSize = static_cast<int>(VContainer::size());
+            const int currentHeight = static_cast<int>(VContainer::height());
+            const QString measurementPath = AbsoluteMPath(qApp->getFilePath(), doc->MPath());
+
+            int exportedCount = 0;
+            bool exportFailed = false;
+
+            ExportProgressDialog *progressDialog = new ExportProgressDialog(0, sizes.size(), this);
+            progressDialog->showProgressBar(false);
+
+            for (const QString &size : sizes)
+            {
+                bool ok;
+                const int newSize = size.toInt(&ok);
+                if (!ok)
+                {
+                    exportFailed = true;
+                    continue;
+                }
+
+                // Apply new size
+                if (!updateMeasurements(measurementPath, newSize, currentHeight))
+                {
+                    exportFailed = true;
+                    continue;
+                }
+                doc->LiteParseTree(Document::LiteParse);
+
+                // Regenerate piece list for new size
+                const QString exportFilename = originalFileName + QStringLiteral("_") + size;
+                setStatusMessage(tr("Exporting...") + exportFilename + ExportLayoutDialog::exportFormatSuffix(dialog.format()));
+
+                const QHash<quint32, VPiece> *allPieces = pattern->DataPieces();
+                QHash<quint32, VPiece> piecesInLayout;
+                QHash<quint32, VPiece>::const_iterator it = allPieces->constBegin();
+                while (it != allPieces->constEnd())
+                {
+                    if (it.value().isInLayout())
+                    {
+                        piecesInLayout.insert(it.key(), it.value());
+                    }
+                    ++it;
+                }
+                pieceList = preparePiecesForLayout(piecesInLayout);
+
+                // Recreate layout generator with saved settings
+                VLayoutGenerator lGenerator;
+                const VSettings *settings = qApp->Seamly2DSettings();
+                lGenerator.setLayoutGap(settings->getLayoutGap());
+                lGenerator.setCaseType(settings->GetLayoutGroup());
+                lGenerator.SetPaperHeight(settings->GetLayoutPaperHeight());
+                lGenerator.SetPaperWidth(settings->GetLayoutPaperWidth());
+                lGenerator.SetShift(static_cast<quint32>(qFloor(settings->GetLayoutShift())));
+                lGenerator.SetRotate(settings->GetLayoutRotate());
+                lGenerator.SetRotationIncrease(settings->GetLayoutRotationIncrease());
+                lGenerator.SetAutoCrop(settings->GetLayoutAutoCrop());
+                lGenerator.SetSaveLength(settings->GetLayoutSaveLength());
+                lGenerator.SetUnitePages(settings->GetLayoutUnitePages());
+                lGenerator.setStripOptimization(settings->useStripOptimization());
+                lGenerator.SetMultiplier(settings->GetMultiplier());
+                lGenerator.setTextAsPaths(settings->GetTextAsPaths());
+
+                if (settings->GetIgnoreAllFields())
+                {
+                    lGenerator.SetPrinterFields(false, QMarginsF());
+                }
+                else
+                {
+                    lGenerator.SetPrinterFields(true, settings->GetFields(QMarginsF()));
+                }
+
+                if (!LayoutSettings(lGenerator))
+                {
+                    exportFailed = true;
+                }
+
+                // Set filename with size suffix and export
+                dialog.setFileName(exportFilename);
+                ExportData(QVector<VLayoutPiece>(), dialog);
+
+                // Insert current file
+                progressDialog->insertFileName(exportFilename + ExportLayoutDialog::exportFormatSuffix(dialog.format()));
+                if (exportFailed)
+                {
+                    progressDialog->setFileStatus(ProgressStatus::Failed);
+                    exportFailed = false;
+                }
+                else
+                {
+                    progressDialog->setFileStatus(ProgressStatus::Completed);
+                }
+
+                exportedCount++;
+                progressDialog->setProgress(exportedCount);
+            }
+            setStatusMessage("");
+
+            // Restore original size
+            if (updateMeasurements(measurementPath, originalSize, currentHeight))
+            {
+                doc->LiteParseTree(Document::LiteParse);
+                emit pieceScene->DimensionsChanged();
+            }
+
+            // Regenerate original layout
+            const QHash<quint32, VPiece> *allPieces = pattern->DataPieces();
+            QHash<quint32, VPiece> piecesInLayout;
+            QHash<quint32, VPiece>::const_iterator it = allPieces->constBegin();
+            while (it != allPieces->constEnd())
+            {
+                if (it.value().isInLayout())
+                {
+                    piecesInLayout.insert(it.key(), it.value());
+                }
+                ++it;
+            }
+            pieceList = preparePiecesForLayout(piecesInLayout);
+
+            VLayoutGenerator lGenerator;
+            const VSettings *settings = qApp->Seamly2DSettings();
+            lGenerator.setLayoutGap(settings->getLayoutGap());
+            lGenerator.setCaseType(settings->GetLayoutGroup());
+            lGenerator.SetPaperHeight(settings->GetLayoutPaperHeight());
+            lGenerator.SetPaperWidth(settings->GetLayoutPaperWidth());
+            lGenerator.SetShift(static_cast<quint32>(qFloor(settings->GetLayoutShift())));
+            lGenerator.SetRotate(settings->GetLayoutRotate());
+            lGenerator.SetRotationIncrease(settings->GetLayoutRotationIncrease());
+            lGenerator.SetAutoCrop(settings->GetLayoutAutoCrop());
+            lGenerator.SetSaveLength(settings->GetLayoutSaveLength());
+            lGenerator.SetUnitePages(settings->GetLayoutUnitePages());
+            lGenerator.setStripOptimization(settings->useStripOptimization());
+            lGenerator.SetMultiplier(settings->GetMultiplier());
+            lGenerator.setTextAsPaths(settings->GetTextAsPaths());
+            if (settings->GetIgnoreAllFields())
+            {
+                lGenerator.SetPrinterFields(false, QMarginsF());
+            }
+            else
+            {
+                lGenerator.SetPrinterFields(true, settings->GetFields(QMarginsF()));
+            }
+            LayoutSettings(lGenerator);
+
+            // Restore original filename in dialog
+            dialog.setFileName(originalFileName);
+
+            // Show summary
+            progressDialog->show();
+        }
     }
 
     catch (const VException &exception)
@@ -6862,13 +7030,93 @@ void MainWindow::exportPiecesAs()
         ExportLayoutDialog dialog(1, Draw::Modeling, FileName(), this);
         dialog.setWindowTitle("Export Pattern Pieces");
 
+        // Populate size selection if multisize pattern
+        if (qApp->patternType() == MeasurementsType::Multisize)
+        {
+            const QStringList sizes = MeasurementVariable::ListSizes(doc->GetGradationSizes(), qApp->patternUnit());
+            dialog.setAvailableSizes(sizes);
+        }
+
         if (dialog.exec() == QDialog::Rejected)
         {
             ui->exportPiecesAs_ToolButton->setChecked(false);
             return;
         }
 
-        ExportData(pieceList, dialog);
+        if (dialog.isBatchExport())
+        {
+            const QStringList selectedSizes = dialog.selectedSizes();
+            const QString baseName = FileName();
+            const qreal originalSize = VContainer::size();
+            const QString measurementPath = AbsoluteMPath(qApp->getFilePath(), doc->MPath());
+            int exportCount = 0;
+            bool  failed = false;
+
+            ExportProgressDialog *exportProgress = new ExportProgressDialog(0, selectedSizes.size(), this);
+            exportProgress->showProgressBar(true);
+            exportProgress->show();
+
+            for (const QString &size : selectedSizes)
+            {
+                const int sizeValue = qRound(UnitConvertor(size.toDouble(), qApp->patternUnit(), Unit::Cm));
+
+                // Switch to this size
+                updateMeasurements(measurementPath, sizeValue, static_cast<int>(VContainer::height()));
+                doc->LiteParseTree(Document::LiteParse);
+
+                // Rebuild piece list for this size
+                const QHash<quint32, VPiece> *pieces = pattern->DataPieces();
+                QHash<quint32, VPiece> inLayout;
+                for (auto it = pieces->constBegin(); it != pieces->constEnd(); ++it)
+                {
+                    if (it.value().isInLayout())
+                    {
+                        inLayout.insert(it.key(), it.value());
+                    }
+                }
+
+                QVector<VLayoutPiece> sizePieceList;
+                try
+                {
+                    sizePieceList = preparePiecesForLayout(inLayout);
+                }
+                catch (VException &)
+                {
+                    failed = true;
+                    continue;
+                }
+
+                // Set size-suffixed filename and export
+                const QFileInfo fileInfo(baseName);
+                const QString sizeName = fileInfo.baseName() + "_" + size;
+                dialog.setFileName(sizeName);
+                ExportData(sizePieceList, dialog);
+
+                // Insert current file
+                exportProgress->insertFileName(sizeName + ExportLayoutDialog::exportFormatSuffix(dialog.format()));
+                if (failed)
+                {
+                    exportProgress->setFileStatus(ProgressStatus::Failed);
+                    failed = false;
+                }
+                else
+                {
+                    exportProgress->setFileStatus(ProgressStatus::Completed);
+                }
+
+                ++exportCount;
+                exportProgress->setProgress(exportCount);
+                QCoreApplication::processEvents();
+            }
+
+            // Restore original size
+            updateMeasurements(measurementPath, static_cast<int>(originalSize), static_cast<int>(VContainer::height()));
+            doc->LiteParseTree(Document::LiteParse);
+        }
+        else
+        {
+            ExportData(pieceList, dialog);
+        }
     }
 
     catch (const VException &exception)


### PR DESCRIPTION
This PR implements batch exporting of multisize patterns.

- Allows user to select which sizes of the pattern to export:

 
  <img width="705" height="436" alt="Screenshot 2026-04-05 053530" src="https://github.com/user-attachments/assets/bfc367d7-de51-429a-a2e9-572b9c797cb6" />

- When exporting from Piece mode the Export displays an Export Progress dialog with a progress bar. Each file exported will displayed "Completed" if successful, or "Failed" is th export failed.

  <img width="608" height="363" alt="Screenshot 2026-04-05 053825" src="https://github.com/user-attachments/assets/f5b293c6-5b83-421f-bd98-026390ed6b7c" />

- Since when in Layout mode each size creates a new layout which has it's own dialog & progress bar, the export progress dialog is shown with no progress bar only after all the exports are completed.

 
  <img width="585" height="170" alt="Screenshot 2026-04-05 054147" src="https://github.com/user-attachments/assets/0bdf3c14-1525-42c6-8480-958752609cd7" />

  <img width="619" height="367" alt="Screenshot 2026-04-05 054241" src="https://github.com/user-attachments/assets/b1ba1877-31d8-402c-9058-dcfcba3d9efc" />

- Individual export dialog remains unchanged.

  <img width="706" height="298" alt="Screenshot 2026-04-05 054831" src="https://github.com/user-attachments/assets/a0c7e35b-970d-4e28-9c46-afceaeaf9a38" />

- lupdate


closes issue #1529 