### PR TITLE
ci: disable pre-releases on each commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,7 @@ jobs:
           if-no-files-found: error
 
   publish:
-    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'push') && github.ref_name == 'develop'
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref_name == 'develop'
     runs-on: ubuntu-latest
     needs: [version, linux, macos, windows]
     env:
@@ -329,7 +329,7 @@ jobs:
           name: ${{ env.VERSION_NUMBER }}
           generate_release_notes: true
           fail_on_unmatched_files: true
-          prerelease: ${{ github.event_name == 'push' }}
+          prerelease: false
           files: |
             Seamly2D-x86_64.AppImage
             Seamly2D-macos.zip


### PR DESCRIPTION
Lets reduce the noise on the repo and only create weekly releases.

With that also the automatic changelogs of the weekly releases contain
all changes of that week automatically, instead of just the last one
since the last pre-release.
