### PR TITLE
Feature: Auto remove extra lfs from files

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -7116,6 +7116,10 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
         <source>Exporting...</source>
         <translation>Exportování...</translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Chyba při vytváření záložní kopie: %1.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8911,6 +8915,14 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Pozitivní signál</translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation>Maximální počet záloh:</translation>
+    </message>
+    <message>
+        <source> per file</source>
+        <translation> na soubor</translation>
     </message>
 </context>
 <context>
@@ -11776,8 +11788,8 @@ SeamlyME jako obvykle.
         <translation>Nebylo možné změnit verzi.</translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
-        <translation>Chyba při vytváření rezervní kopie: %1.</translation>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Chyba při vytváření záložní kopie: %1.</translation>
     </message>
     <message>
         <source>Unexpected version &quot;%1&quot;.</source>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -7101,6 +7101,10 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <source>Exporting...</source>
         <translation>Exportiere...</translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Fehler bei der Erstellung einer Sicherungskopie: %1.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8897,6 +8901,14 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     <message>
         <source>Positive Sign</source>
         <translation>Positives Vorzeichen</translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation>Maximale Anzahl an Backups:</translation>
+    </message>
+    <message>
+        <source> per file</source>
+        <translation>pro Datei</translation>
     </message>
 </context>
 <context>
@@ -11762,8 +11774,8 @@ wie gewohnt in SeamlyME laden können.
         <translation>Versionsnummer konnte nicht geändert werden.</translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
-        <translation>Fehler bei der Erstellung einer Reservekopie : %1.</translation>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Fehler bei der Erstellung einer Sicherungskopie: %1.</translation>
     </message>
     <message>
         <source>Unexpected version &quot;%1&quot;.</source>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -7120,6 +7120,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Exporting...</source>
         <translation>Εξαγωγή...</translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Σφάλμα κατά τη δημιουργία αντιγράφου ασφαλείας: %1.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8915,6 +8919,14 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Positive Sign</source>
         <translation>Θετικό Πρόσημο</translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation>Μέγιστος αριθμός αντιγράφων ασφαλείας:</translation>
+    </message>
+    <message>
+        <source> per file</source>
+        <translation> ανά αρχείο</translation>
     </message>
 </context>
 <context>
@@ -11780,8 +11792,8 @@ load in SeamlyME as usual.
         <translation>Δεν είναι δυνατή η αλλαγή έκδοσης.</translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
-        <translation>Σφάλμα κατά τη δημιουργία ενός εφεδρικού αντιγράφου: %1.</translation>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Σφάλμα κατά τη δημιουργία αντιγράφου ασφαλείας: %1.</translation>
     </message>
     <message>
         <source>Unexpected version &quot;%1&quot;.</source>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -7086,6 +7086,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Exporting...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation type="unfinished">Error creating a backup copy: %1.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8880,6 +8884,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Positive Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> per file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11740,8 +11752,8 @@ load in SeamlyME as usual.
         <translation>Could not change version.</translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
-        <translation>Error creating a reserv copy: %1.</translation>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Error creating a backup copy: %1.</translation>
     </message>
     <message>
         <source>Unexpected version &quot;%1&quot;.</source>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -7086,6 +7086,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Exporting...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8880,6 +8884,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Positive Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> per file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11740,7 +11752,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
+        <source>Error creating a backup copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -7086,6 +7086,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Exporting...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation type="unfinished">Error creating a backup copy: %1.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8880,6 +8884,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Positive Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> per file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11740,8 +11752,8 @@ load in SeamlyME as usual.
         <translation>Could not change version.</translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
-        <translation>Error creating a reserv copy: %1.</translation>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Error creating a backup copy: %1.</translation>
     </message>
     <message>
         <source>Unexpected version &quot;%1&quot;.</source>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -7086,6 +7086,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Exporting...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8880,6 +8884,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Positive Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> per file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11740,7 +11752,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
+        <source>Error creating a backup copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -7137,6 +7137,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Exporting...</source>
         <translation>Exportador...</translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Error al crear una copia de seguridad: %1.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8950,6 +8954,14 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Positive Sign</source>
         <translation>Signo Positivo</translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation>Número máximo de copias de seguridad:</translation>
+    </message>
+    <message>
+        <source> per file</source>
+        <translation> por archivo</translation>
     </message>
 </context>
 <context>
@@ -11818,8 +11830,8 @@ load in SeamlyME as usual.
         <translation>No se pudo cambiar la versión.</translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
-        <translation>Error al crear una copia de reserva: %1.</translation>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Error al crear una copia de seguridad: %1.</translation>
     </message>
     <message>
         <source>Unexpected version &quot;%1&quot;.</source>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -7118,6 +7118,10 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
         <source>Exporting...</source>
         <translation>Viedään...</translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Virhe luotaessa varakopiota: %1.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8913,6 +8917,14 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
     <message>
         <source>Positive Sign</source>
         <translation>Positiivinen merkki</translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation>Varmuuskopioiden enimmäismäärä:</translation>
+    </message>
+    <message>
+        <source> per file</source>
+        <translation> tiedosto</translation>
     </message>
 </context>
 <context>
@@ -11766,7 +11778,7 @@ Haluatko tallentaa muutokset?</translation>
         <translation>Versio &quot;0.0.0&quot; on virheellinen.</translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
+        <source>Error creating a backup copy: %1.</source>
         <translation>Virhe luotaessa varakopiota: %1.</translation>
     </message>
     <message>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -7142,6 +7142,10 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
         <source>Exporting...</source>
         <translation>Exportation en cours...</translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Erreur lors de la création d&apos;un copie de sauvegarde: %1.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8939,6 +8943,14 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
     <message>
         <source>Positive Sign</source>
         <translation>Signe positif</translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation>Nombre maximal de sauvegardes :</translation>
+    </message>
+    <message>
+        <source> per file</source>
+        <translation> par fichier</translation>
     </message>
 </context>
 <context>
@@ -11807,8 +11819,8 @@ charger dans SeamlyME comme d&apos;habitude.
         <translation>La version n&apos;a pas pu être changée.</translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
-        <translation>Erreur lors de la création d&apos;un copie de réserve: %1.</translation>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Erreur lors de la création d&apos;un copie de sauvegarde: %1.</translation>
     </message>
     <message>
         <source>Unexpected version &quot;%1&quot;.</source>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -7082,6 +7082,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Exporting...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8876,6 +8880,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Positive Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> per file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11735,7 +11747,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
+        <source>Error creating a backup copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -7118,6 +7118,10 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
         <source>Exporting...</source>
         <translation>Sedang mengekspor...</translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Gagal membuat salinan cadangan: %1.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8913,6 +8917,14 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Tanda positif</translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation>Jumlah maksimum cadangan:</translation>
+    </message>
+    <message>
+        <source> per file</source>
+        <translation>per berkas</translation>
     </message>
 </context>
 <context>
@@ -11778,8 +11790,8 @@ unggah ke SeamlyME seperti biasa.
         <translation>Tidak dapat mengubah versi.</translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
-        <translation>Kesalahan saat membuat salinan cadangan: %1.</translation>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Error creating a backup copy: %1.</translation>
     </message>
     <message>
         <source>Unexpected version &quot;%1&quot;.</source>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -7106,6 +7106,10 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
         <source>Exporting...</source>
         <translation>Esportazione in corso...</translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Errore nella creazione di una copia di backup: %1.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8901,6 +8905,14 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Segno positivo</translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation>Numero massimo di backup:</translation>
+    </message>
+    <message>
+        <source> per file</source>
+        <translation> per file</translation>
     </message>
 </context>
 <context>
@@ -11766,8 +11778,8 @@ caricare in SeamlyME come di consueto.
         <translation>Impossibile cambiare versione.</translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
-        <translation>Errore nella creazione di una copia di riserva: %1.</translation>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Errore nella creazione di una copia di backup: %1.</translation>
     </message>
     <message>
         <source>Unexpected version &quot;%1&quot;.</source>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -7101,6 +7101,10 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
         <source>Exporting...</source>
         <translation>Exporteren...</translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Fout bij het maken van een back-upkopie: %1.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8896,6 +8900,14 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Positief Teken</translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation>Maximum aantal back-ups:</translation>
+    </message>
+    <message>
+        <source> per file</source>
+        <translation> per bestand</translation>
     </message>
 </context>
 <context>
@@ -11760,8 +11772,8 @@ load in SeamlyME as usual.
         <translation>Kon de versie niet veranderen.</translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
-        <translation>Fout bij het maken van reserve bestand: %1.</translation>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Fout bij het maken van een back-upkopie: %1.</translation>
     </message>
     <message>
         <source>Unexpected version &quot;%1&quot;.</source>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -7104,6 +7104,10 @@ Prima enter para o adicionar temporariamente à lista.</translation>
         <source>Exporting...</source>
         <translation>Exportador...</translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Erro ao criar uma cópia de backup: %1.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8900,6 +8904,14 @@ Prima enter para o adicionar temporariamente à lista.</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Sinal Positivo</translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation>Número máximo de backups:</translation>
+    </message>
+    <message>
+        <source> per file</source>
+        <translation> Por arquivo</translation>
     </message>
 </context>
 <context>
@@ -11765,8 +11777,8 @@ carregar no SeamlyME como de costume.
         <translation>Nâo foi possâvel alterar a versâo.</translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
-        <translation>Erro ao criar uma câpia de reserva: %1.</translation>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Erro ao criar uma cópia de backup: %1.</translation>
     </message>
     <message>
         <source>Unexpected version &quot;%1&quot;.</source>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -7120,6 +7120,10 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
         <source>Exporting...</source>
         <translation>Exportator...</translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Eroare la crearea unei copii rezervate: %1.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8915,6 +8919,14 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Semn Pozitiv</translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation>Număr maxim de copii de rezervă:</translation>
+    </message>
+    <message>
+        <source> per file</source>
+        <translation> pe fișier</translation>
     </message>
 </context>
 <context>
@@ -11779,7 +11791,7 @@ load in SeamlyME as usual.
         <translation>Nu s-a putut schimba versiunea.</translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
+        <source>Error creating a backup copy: %1.</source>
         <translation>Eroare la crearea unei copii rezervate: %1.</translation>
     </message>
     <message>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -7122,6 +7122,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Exporting...</source>
         <translation>Экспорт...</translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Ошибка создания резервной копии: %1.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8919,6 +8923,14 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Positive Sign</source>
         <translation>Положительный Знак</translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation>Максимальное количество резервных копий:</translation>
+    </message>
+    <message>
+        <source> per file</source>
+        <translation> за файл</translation>
     </message>
 </context>
 <context>
@@ -11785,7 +11797,7 @@ load in SeamlyME as usual.
         <translation>Не удалось изменить версию.</translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
+        <source>Error creating a backup copy: %1.</source>
         <translation>Ошибка создания резервной копии: %1.</translation>
     </message>
     <message>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -7118,6 +7118,10 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
         <source>Exporting...</source>
         <translation>Dışa aktarılıyor...</translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Yedek kopyası oluşturulurken hata oluştu: %1.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8913,6 +8917,14 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Olumlu Işaret</translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation>Maksimum yedekleme sayısı:</translation>
+    </message>
+    <message>
+        <source> per file</source>
+        <translation> dosya başına</translation>
     </message>
 </context>
 <context>
@@ -11777,8 +11789,8 @@ load in SeamlyME as usual.
         <translation>Sürüm değiştirilemedi.</translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
-        <translation>Rezerv kopyası oluşturulurken hata oluştu: %1.</translation>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Yedek kopyası oluşturulurken hata oluştu: %1.</translation>
     </message>
     <message>
         <source>Unexpected version &quot;%1&quot;.</source>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -7119,6 +7119,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Exporting...</source>
         <translation>Експорт...</translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>Помилка створення резервної копії: %1.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8914,6 +8918,14 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Positive Sign</source>
         <translation>Θετικό Πρόσημο</translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation>Максимальна кількість резервних копій:</translation>
+    </message>
+    <message>
+        <source> per file</source>
+        <translation> за файл</translation>
     </message>
 </context>
 <context>
@@ -11779,7 +11791,7 @@ load in SeamlyME as usual.
         <translation>Не давлося змінити версію.</translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
+        <source>Error creating a backup copy: %1.</source>
         <translation>Помилка створення резервної копії: %1.</translation>
     </message>
     <message>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -7118,6 +7118,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Exporting...</source>
         <translation>出口...</translation>
     </message>
+    <message>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>创建备份副本出错:%1.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -8913,6 +8917,14 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Positive Sign</source>
         <translation>正号</translation>
+    </message>
+    <message>
+        <source>Max number of backups:</source>
+        <translation>最大备份数量</translation>
+    </message>
+    <message>
+        <source> per file</source>
+        <translation> 按文件</translation>
     </message>
 </context>
 <context>
@@ -11778,8 +11790,8 @@ load in SeamlyME as usual.
         <translation>无法更改版本.</translation>
     </message>
     <message>
-        <source>Error creating a reserv copy: %1.</source>
-        <translation>创建保留副本时出错:%1.</translation>
+        <source>Error creating a backup copy: %1.</source>
+        <translation>创建备份副本出错:%1.</translation>
     </message>
     <message>
         <source>Unexpected version &quot;%1&quot;.</source>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -8920,7 +8920,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Max number of backups:</source>
-        <translation>最大备份数量</translation>
+        <translation>最大备份数量:</translation>
     </message>
     <message>
         <source> per file</source>

--- a/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp
@@ -178,8 +178,35 @@ PreferencesConfigurationPage::PreferencesConfigurationPage(QWidget *parent)
     // File handling
     // Backups
     ui->convertBackupEnabled_CheckBox->setChecked(qApp->Seamly2DSettings()->getConvertBackupEnabled());
+
+    // If conversion backups are emabled set backup limit to a mi-n of 2
+    connect(ui->convertBackupEnabled_CheckBox, &QCheckBox::stateChanged, this, [=](int newState)
+    {
+        if (newState == Qt::Checked && ui->maxBackusp_SpinBox->value() < 2)
+        {
+            ui->maxBackusp_SpinBox->blockSignals(true);
+            ui->maxBackusp_SpinBox->setValue(2);
+            ui->maxBackusp_SpinBox->blockSignals(false);
+        }
+    });
+
     ui->autoSave_CheckBox->setChecked(qApp->Seamly2DSettings()->GetAutosaveState());
     ui->autoInterval_Spinbox->setValue(qApp->Seamly2DSettings()->getAutosaveInterval());
+    if (ui->convertBackupEnabled_CheckBox->isChecked())
+    {
+        qApp->Seamly2DSettings()->setMaxBackups(2);
+    }
+    ui->maxBackusp_SpinBox->setValue(qApp->Seamly2DSettings()->getMaxBackups());
+
+    connect(ui->maxBackusp_SpinBox, QOverload<int>::of(&QSpinBox::valueChanged), [=](int newValue)
+    {
+        if (ui->convertBackupEnabled_CheckBox->isChecked() && ui->maxBackusp_SpinBox->value() < 2)
+        {
+            ui->maxBackusp_SpinBox->blockSignals(true);
+            ui->maxBackusp_SpinBox->setValue(2);
+            ui->maxBackusp_SpinBox->blockSignals(false);
+        }
+    });
 
     // Export Format
     ui->useModeType_CheckBox->setChecked(qApp->Seamly2DSettings()->useModeType());
@@ -289,6 +316,7 @@ void PreferencesConfigurationPage::apply()
 
     settings->setAutosaveState(ui->autoSave_CheckBox->isChecked());
     settings->setAutosaveInterval(ui->autoInterval_Spinbox->value());
+    settings->setMaxBackups(ui->maxBackusp_SpinBox->value());
 
     QTimer *autoSaveTimer = qApp->getAutoSaveTimer();
     SCASSERT(autoSaveTimer)

--- a/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui
@@ -61,7 +61,7 @@
       <enum>QTabWidget::West</enum>
      </property>
      <property name="currentIndex">
-      <number>3</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -1011,6 +1011,76 @@
            </widget>
           </item>
           <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QLabel" name="maxBackusp_Label">
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Max number of backups:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="maxBackusp_SpinBox">
+              <property name="minimumSize">
+               <size>
+                <width>120</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="suffix">
+               <string> per file</string>
+              </property>
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>10</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
            <widget class="QCheckBox" name="autoSave_CheckBox">
             <property name="text">
              <string>Enable Autosave</string>
@@ -1021,9 +1091,15 @@
            </widget>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="interval_HorizontalLayout">
+           <layout class="QHBoxLayout" name="horizontalLayout">
             <item>
              <widget class="QLabel" name="interval_Label">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="minimumSize">
                <size>
                 <width>140</width>
@@ -1068,7 +1144,7 @@
                <string notr="true"/>
               </property>
               <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
               </property>
               <property name="suffix">
                <string> min</string>
@@ -1085,7 +1161,7 @@
              </widget>
             </item>
             <item>
-             <spacer name="horizontalSpacer_6">
+             <spacer name="horizontalSpacer_2">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>

--- a/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui
@@ -61,7 +61,7 @@
       <enum>QTabWidget::West</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -1001,22 +1001,51 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout">
           <item>
-           <widget class="QCheckBox" name="convertBackupEnabled_CheckBox">
-            <property name="text">
-             <string>Create backup file when converting</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <item>
+             <widget class="QCheckBox" name="convertBackupEnabled_CheckBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Create backup file when converting</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <layout class="QHBoxLayout" name="horizontalLayout">
             <item>
              <widget class="QLabel" name="maxBackusp_Label">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="minimumSize">
                <size>
-                <width>140</width>
+                <width>170</width>
                 <height>0</height>
                </size>
               </property>
@@ -1081,28 +1110,51 @@
            </layout>
           </item>
           <item>
-           <widget class="QCheckBox" name="autoSave_CheckBox">
-            <property name="text">
-             <string>Enable Autosave</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <item>
+             <widget class="QCheckBox" name="autoSave_CheckBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Enable Autosave</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_8">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout">
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
             <item>
              <widget class="QLabel" name="interval_Label">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
               <property name="minimumSize">
                <size>
-                <width>140</width>
+                <width>170</width>
                 <height>0</height>
                </size>
               </property>
@@ -1220,11 +1272,23 @@
            <layout class="QHBoxLayout" name="defaultExportFormat_HlLayout">
             <item>
              <widget class="QLabel" name="defaultExportFormat_Label">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="minimumSize">
                <size>
-                <width>140</width>
+                <width>70</width>
                 <height>0</height>
                </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+                <bold>false</bold>
+               </font>
               </property>
               <property name="text">
                <string>Default:</string>

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -616,7 +616,7 @@ QSharedPointer<MeasurementDoc> MainWindow::openMeasurementFile(const QString &fi
 bool MainWindow::loadMeasurements(const QString &fileName)
 {
     // remove any extraneous LF's or trailing white space.
-    removeEmptyLinesText(fileName);
+    removeEmptyLinesText(fileName, false);
 
     m_measurements = openMeasurementFile(fileName);
 
@@ -6470,7 +6470,7 @@ bool MainWindow::LoadPattern(const QString &fileName, const QString &customMeasu
     qCInfo(vMainWindow, "Loading new file %s.", qUtf8Printable(fileName));
 
     // remove any extraneous LF's or trailing white space.
-    removeEmptyLinesText(fileName);
+    removeEmptyLinesText(fileName, true);
 
     //We have unsaved changes or load more then one file per time
     if (startNewSeamly2D(fileName))

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -112,6 +112,7 @@
 #include <thread>
 #include <QAction>
 #include <QComboBox>
+#include <QDateTime>
 #include <QFontComboBox>
 #include <QDoubleSpinBox>
 #include <QFileDialog>
@@ -614,6 +615,9 @@ QSharedPointer<MeasurementDoc> MainWindow::openMeasurementFile(const QString &fi
 //---------------------------------------------------------------------------------------------------------------------
 bool MainWindow::loadMeasurements(const QString &fileName)
 {
+    // remove any extraneous LF's or trailing white space.
+    removeEmptyLinesText(fileName, false);
+
     m_measurements = openMeasurementFile(fileName);
 
     if (m_measurements->isNull())
@@ -6461,9 +6465,12 @@ MainWindow::~MainWindow()
  * @brief LoadPattern open pattern file.
  * @param fileName name of file.
  */
-bool MainWindow::LoadPattern(const QString &fileName, const QString& customMeasureFile)
+bool MainWindow::LoadPattern(const QString &fileName, const QString &customMeasureFile)
 {
     qCInfo(vMainWindow, "Loading new file %s.", qUtf8Printable(fileName));
+
+    // remove any extraneous LF's or trailing white space.
+    removeEmptyLinesText(fileName, true);
 
     //We have unsaved changes or load more then one file per time
     if (startNewSeamly2D(fileName))
@@ -6635,6 +6642,108 @@ bool MainWindow::LoadPattern(const QString &fileName, const QString& customMeasu
 
     // Set the Property Editor dock widget as the active tab
     ui->toolProperties_DockWidget->raise();
+}
+
+void MainWindow::removeEmptyLinesText(const QString &filename, bool isPattern)
+{
+    // backup file
+    saveBackupFile(filename);
+
+    QFile file(filename);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) return;
+
+    QString cleanedContent;
+    QTextStream in(&file);
+    while (!in.atEnd())
+    {
+        QString line = in.readLine();
+        if (isPattern)
+        {
+            line.replace(QString("lineWeight=\"1.00\""), QString("lineWeight=\"1\""));
+        }
+        // trimmed().isEmpty() checks if line is empty or only whitespace
+        if (!line.trimmed().isEmpty())
+        {
+            cleanedContent += line + "\n";
+        }
+    }
+    file.close();
+
+    if (file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text))
+    {
+        QTextStream out(&file);
+        out << cleanedContent;
+        file.close();
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void MainWindow::saveBackupFile(const QString &filename) const
+{
+    QString error;
+    const QFileInfo info(filename);
+
+    QString path = qApp->Settings()->getBackupFilePath();
+    if (!info.exists(path))
+    {
+        path = info.absoluteDir().absolutePath();
+    }
+
+    QDir dir(path);
+    if (!dir.exists())
+    {
+        return;
+    }
+
+    QString baseFileName = info.baseName();
+
+    // replace any spaces in filename with underscore to pevent
+    // errors when opening file in Linux through the command line.
+    baseFileName.replace(" ", "_");
+
+    // Filter files by baseFileName
+    QFileInfoList allFiles = dir.entryInfoList(QDir::Files | QDir::NoDotAndDotDot);
+    QFileInfoList filteredList;
+
+    // Get list, sorting by creation time (Time) descending (Reversed)
+    for (const QFileInfo &fileInfo : allFiles)
+    {
+        if (fileInfo.baseName().contains(baseFileName, Qt::CaseInsensitive))
+        {
+            filteredList.append(fileInfo);
+        }
+    }
+
+    // Sort by modification time (Oldest first)
+    // Use std::sort with a lambda for comparison
+    std::sort(filteredList.begin(), filteredList.end(), [](const QFileInfo &a, const QFileInfo &b)
+    {
+        return a.lastModified() < b.lastModified();
+    });
+
+    // Delete oldest if over limit
+    int maxFiles = qApp->Seamly2DSettings()->getMaxBackups();
+    int filesToDelete = filteredList.size() - maxFiles + 1;
+
+    for (int i = 0; i < filesToDelete; ++i)
+    {
+        const QFileInfo &toDelete = filteredList.at(i);
+        QFile::remove(toDelete.absoluteFilePath());
+    }
+
+    QString backupFileName;
+    QString timestamp = QDateTime::currentDateTime().toString("ddMMyyyy-hhmmss");
+
+    backupFileName = QString("%1/%2_%3%4.%5").arg(path, baseFileName, timestamp, "(backup)", info.completeSuffix());
+
+    if (!VDomDocument::SafeCopy(filename, backupFileName, error))
+    {
+        if (info.isWritable())
+        {
+            const QString errorMsg(tr("Error creating a reserv copy: %1.").arg(error));
+            throw VException(errorMsg);
+        }
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -6740,7 +6740,7 @@ void MainWindow::saveBackupFile(const QString &filename) const
     {
         if (info.isWritable())
         {
-            const QString errorMsg(tr("Error creating a reserv copy: %1.").arg(error));
+            const QString errorMsg(tr("Error creating a backup copy: %1.").arg(error));
             throw VException(errorMsg);
         }
     }

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -614,6 +614,9 @@ QSharedPointer<MeasurementDoc> MainWindow::openMeasurementFile(const QString &fi
 //---------------------------------------------------------------------------------------------------------------------
 bool MainWindow::loadMeasurements(const QString &fileName)
 {
+    // remove any extraneous LF's or trailing white space.
+    removeEmptyLinesText(fileName);
+
     m_measurements = openMeasurementFile(fileName);
 
     if (m_measurements->isNull())
@@ -6461,9 +6464,12 @@ MainWindow::~MainWindow()
  * @brief LoadPattern open pattern file.
  * @param fileName name of file.
  */
-bool MainWindow::LoadPattern(const QString &fileName, const QString& customMeasureFile)
+bool MainWindow::LoadPattern(const QString &fileName, const QString &customMeasureFile)
 {
     qCInfo(vMainWindow, "Loading new file %s.", qUtf8Printable(fileName));
+
+    // remove any extraneous LF's or trailing white space.
+    removeEmptyLinesText(fileName);
 
     //We have unsaved changes or load more then one file per time
     if (startNewSeamly2D(fileName))
@@ -6635,6 +6641,33 @@ bool MainWindow::LoadPattern(const QString &fileName, const QString& customMeasu
 
     // Set the Property Editor dock widget as the active tab
     ui->toolProperties_DockWidget->raise();
+}
+
+void MainWindow::removeEmptyLinesText(const QString &filePath)
+{
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) return;
+
+    QString cleanedContent;
+    QTextStream in(&file);
+    while (!in.atEnd())
+    {
+        QString line = in.readLine();
+        line.replace(QString("lineWeight=\"1.00\""), QString("lineWeight=\"1\""));
+        // trimmed().isEmpty() checks if line is empty or only whitespace
+        if (!line.trimmed().isEmpty())
+        {
+            cleanedContent += line + "\n";
+        }
+    }
+    file.close();
+
+    if (file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text))
+    {
+        QTextStream out(&file);
+        out << cleanedContent;
+        file.close();
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -338,6 +338,8 @@ private:
 
     QSharedPointer<MeasurementDoc>    m_measurements;
 
+    void                              removeEmptyLinesText(const QString &filename, bool isPattern);
+    void                              saveBackupFile(const QString &filename) const;
     void                              SetDefaultHeight();
     void                              SetDefaultSize();
 

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -338,6 +338,8 @@ private:
 
     QSharedPointer<MeasurementDoc>    m_measurements;
 
+    void                              removeEmptyLinesText(const QString &filePath);
+
     void                              SetDefaultHeight();
     void                              SetDefaultSize();
 

--- a/src/libs/ifc/xml/abstract_converter.cpp
+++ b/src/libs/ifc/xml/abstract_converter.cpp
@@ -252,7 +252,7 @@ void VAbstractConverter::saveBackupFile() const
 
             if (!isReadOnly() && isFileWritable)
             {
-                const QString errorMsg(tr("Error creating a reserv copy: %1.").arg(error));
+                const QString errorMsg(tr("Error creating a backup copy: %1.").arg(error));
                 throw VException(errorMsg);
             }
         }

--- a/src/libs/ifc/xml/abstract_converter.cpp
+++ b/src/libs/ifc/xml/abstract_converter.cpp
@@ -52,6 +52,7 @@
 
 #include "abstract_converter.h"
 
+#include <QDateTime>
 #include <QDir>
 #include <QDomElement>
 #include <QDomNode>
@@ -236,7 +237,8 @@ void VAbstractConverter::saveBackupFile() const
             path = info.absoluteDir().absolutePath();
         }
         QString backupFileName;
-        backupFileName = QString("%1/%2%3.%4").arg(path, baseFileName, "_(backup)", info.completeSuffix());
+        QString timestamp = QDateTime::currentDateTime().toString("ddMMyyyy-hhmmss");
+        backupFileName = QString("%1/%2_%3%4.%5").arg(path, baseFileName, timestamp, "(backup)", info.completeSuffix());
 
         if (!SafeCopy(m_convertedFileName, backupFileName, error))
         {

--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -97,6 +97,7 @@ const QString settingConfigurationOsSeparator            = QStringLiteral("confi
 const QString settingConfigurationConvertBackup          = QStringLiteral("configuration/backup/convertBackupEnabled");
 const QString settingConfigurationAutosaveState          = QStringLiteral("configuration/autosave/state");
 const QString settingConfigurationAutosaveTime           = QStringLiteral("configuration/autosave/time");
+const QString settingConfigurationMaxBackups             = QStringLiteral("configuration/autosave/maxBackups");
 
 const QString settingConfigurationUseModeType            = QStringLiteral("configuration/autosave/useModeType");
 const QString settingConfigurationUseLastExportFormat    = QStringLiteral("configuration/autosave/useLastExportFormat");
@@ -651,6 +652,24 @@ int VCommonSettings::getAutosaveInterval() const
 void VCommonSettings::setAutosaveInterval(const int &value)
 {
     setValue(settingConfigurationAutosaveTime, value);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+int VCommonSettings::getMaxBackups() const
+{
+    bool ok = false;
+    int val = value(settingConfigurationMaxBackups, 1).toInt(&ok);
+    if (ok == false)
+    {
+        val = 1;
+    }
+    return val;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VCommonSettings::setMaxBackups(const int &value)
+{
+    setValue(settingConfigurationMaxBackups, value);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vmisc/vcommonsettings.h
+++ b/src/libs/vmisc/vcommonsettings.h
@@ -129,6 +129,9 @@ public:
     int                  getAutosaveInterval() const;
     void                 setAutosaveInterval(const int &value);
 
+    int                  getMaxBackups() const;
+    void                 setMaxBackups(const int &value);
+
     bool                 useModeType() const;
     void                 setUseModeType(const bool &value);
 


### PR DESCRIPTION
The PR adds the following:

- Removes extraneous LF's from 2D and ME files. 

- Replaces any incorrect lineWeight values of "1.00" with "1" only for 2D files. 

- Adds a limit preference for how many backups per file are created in the default My Backups directory. The range for the limit is 1 to 10 with the exception of when the backup when converting checkbox is checked, in which case the min is 2 files... 1 for the conversion, and one for the post converison. The default limit value is 1 (or 2) file(s)  until a user specifically changes the limit. 

    <img width="293" height="80" alt="Screenshot 2026-04-18 181112" src="https://github.com/user-attachments/assets/2a325e40-caf9-45e5-9231-e5bf86ad7d06" />

- When loading a pattern automatically makes a backup of the 2D pattern file and any associated ME file. The limit pref determines how many backups are made before old ones are removed. Depending on the state of the conversion backup checkbox there will be at least 1 backup file created BEFORE any changes are made to 2D or ME files. 

- The backup files will be date & time stamped in the following format:

     [My Backups path] basename_Date-Time(backup).ext
     
    <img width="725" height="170" alt="Screenshot 2026-04-18 173728" src="https://github.com/user-attachments/assets/12e397d2-ab88-469d-af90-f085b4988ea1" />

- lupdate.
 
closes issue #1536