### PR TITLE
FEATURE: Add measurement descriptions to fx editor

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -3392,6 +3392,14 @@ Zkuste prosím vrátit zpět poslední operaci nebo opravit poškozený vzorec.<
         <source>Description</source>
         <translation>Popis</translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation>Celé Jméno:</translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation>Popis:</translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -3377,6 +3377,14 @@ Bitte versuchen Sie, den letzten Vorgang rückgängig zu machen oder die fehlerh
         <source>Description</source>
         <translation>Beschreibung</translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation>Vollständige Bezeichnung:</translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation>Beschreibung:</translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -3394,6 +3394,14 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <source>Description</source>
         <translation>Περιγραφή</translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation>Πλήρες όνομα:</translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation>Περιγραφή:</translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -3376,6 +3376,14 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <source>Description</source>
         <translation type="unfinished">Description</translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation type="unfinished">Description:</translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -3376,6 +3376,14 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <source>Description</source>
         <translation type="unfinished">Description</translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation type="unfinished">Description:</translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -3376,6 +3376,14 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <source>Description</source>
         <translation type="unfinished">Description</translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation type="unfinished">Description:</translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -3410,6 +3410,14 @@ Intente deshacer la última operación o corregir la fórmula defectuosa.</trans
         <source>Description</source>
         <translation>Descripción</translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation>Nombre Completo:</translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation>Descripción:</translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -3392,6 +3392,14 @@ Yritä kumota viimeisin operaatio tai korjata rikkinäinen kaava.</translation>
         <source>Description</source>
         <translation>Kuvaus</translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation>Kokonimi:</translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation>Kuvaus:</translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -3410,6 +3410,14 @@ points de contrôle</translation>
         <source>Description</source>
         <translation>Description</translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation>Nom Complet :</translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation>Description :</translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -3376,6 +3376,14 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -3392,6 +3392,14 @@ Silakan coba batalkan operasi terakhir atau perbaiki rumus yang rusak.</translat
         <source>Description</source>
         <translation>Deskripsi</translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation>Nama Lengkap:</translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation>Deskripsi:</translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -3379,6 +3379,14 @@ punti di controllo</translation>
         <source>Description</source>
         <translation>Descrizione</translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation>Nome Intero:</translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation>Descrizione:</translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -3377,6 +3377,14 @@ Probeer de laatste bewerking ongedaan te maken of de defecte formule te herstell
         <source>Description</source>
         <translation>Beschrijving</translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation>Volledige Naam:</translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation>Beschrijving:</translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -3378,6 +3378,14 @@ pontos de controle</translation>
         <source>Description</source>
         <translation>Descrição</translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation>Nome Completo:</translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation>Descrição:</translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -3394,6 +3394,14 @@ Vă rugăm să încercați să anulați ultima operațiune sau să remediați fo
         <source>Description</source>
         <translation>Descrie</translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation>Nume Complet:</translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation>Descriere:</translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -3394,6 +3394,14 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <source>Description</source>
         <translation>Описание</translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation>Полное Имя:</translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation>Описание:</translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -3392,6 +3392,14 @@ Lütfen son işlemi geri almayı veya bozuk formülü düzeltmeyi deneyin.</tran
         <source>Description</source>
         <translation>Açıklama</translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation>Tam Adınız:</translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation>Açıklama:</translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -3394,6 +3394,14 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <source>Description</source>
         <translation>Περιγραφή</translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation>Повне Iм&apos;я:</translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation></translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -3392,6 +3392,14 @@ Please try to undo the latest operation or fix the broken formula.</source>
         <source>Description</source>
         <translation>描述</translation>
     </message>
+    <message>
+        <source>Full Name:</source>
+        <translation>姓名:</translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation>描述:</translation>
+    </message>
 </context>
 <context>
     <name>EditGroupDialog</name>

--- a/src/libs/vformat/measurements.cpp
+++ b/src/libs/vformat/measurements.cpp
@@ -326,7 +326,7 @@ void MeasurementDoc::readMeasurements() const
             qreal kheight = GetParametrDouble(dom, AttrHeightIncrease, "0");
 
             tempMeash = QSharedPointer<MeasurementVariable>(new MeasurementVariable(static_cast<quint32>(i), name, BaseSize(),
-                                                                      BaseHeight(), base, ksize, kheight));
+                                                                      BaseHeight(), base, ksize, kheight, fullName, description));
             tempMeash->setSize(m_currentSize);
             tempMeash->setHeight(m_currentHeight);
             tempMeash->SetUnit(data->GetPatternUnit());
@@ -351,7 +351,7 @@ void MeasurementDoc::readMeasurements() const
             qreal value = EvalFormula(tempData.data(), formula, &ok);
 
             tempMeash = QSharedPointer<MeasurementVariable>(new MeasurementVariable(tempData.data(), static_cast<quint32>(i), name,
-                                                                      value, formula, ok));
+                                                                      value, formula, ok, fullName, description));
 
             value = UnitConvertor(value, measurementUnits(), *data->GetPatternUnit());
             meash = QSharedPointer<MeasurementVariable>(new MeasurementVariable(data, static_cast<quint32>(i), name, value, formula,

--- a/src/libs/vtools/dialogs/support/edit_formula_dialog.cpp
+++ b/src/libs/vtools/dialogs/support/edit_formula_dialog.cpp
@@ -170,10 +170,9 @@ EditFormulaDialog::EditFormulaDialog(const VContainer *data, const quint32 &tool
     connect(ui->tableWidget,&QTableWidget::itemDoubleClicked,
             this, [this, rotation = QString("")]() {insertVariable(rotation);});
 
-    connect(ui->clear_PushButton,         &QPushButton::clicked,            this, &EditFormulaDialog::clearFormula);
-    connect(ui->undo_PushButton,          &QPushButton::clicked,            this, &EditFormulaDialog::undoFormula);
-
-    connect(ui->plainTextEditFormula,     &QPlainTextEdit::textChanged,     this, &EditFormulaDialog::FormulaChanged);
+    connect(ui->clear_PushButton,     &QPushButton::clicked,        this, &EditFormulaDialog::clearFormula);
+    connect(ui->undo_PushButton,      &QPushButton::clicked,        this, &EditFormulaDialog::undoFormula);
+    connect(ui->plainTextEditFormula, &QPlainTextEdit::textChanged, this, &EditFormulaDialog::FormulaChanged);
 
     //Disable Qt::WaitCursor
 #ifndef QT_NO_CURSOR
@@ -191,6 +190,8 @@ EditFormulaDialog::EditFormulaDialog(const VContainer *data, const quint32 &tool
     ui->tableWidget->setEditTriggers(QTableWidget::NoEditTriggers);
     ui->tableWidget->verticalHeader()->hide();
     ui->tableWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
+
+    ui->info_Label->setTextInteractionFlags(Qt::TextSelectableByMouse);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -238,7 +239,7 @@ void EditFormulaDialog::valueChanged(int row)
 {
     if (ui->tableWidget->rowCount() == 0)
     {
-        ui->description_Label->setText("");
+        ui->info_Label->setText("");
         return;
     }
     QTableWidgetItem *item = ui->tableWidget->item( row, NameColumn );
@@ -248,58 +249,61 @@ void EditFormulaDialog::valueChanged(int row)
         case VariableTab::Measurements:
         {
             const QString name = qApp->translateVariables()->VarFromUser(item->text());
-            const QSharedPointer<MeasurementVariable> measurements = data->getVariable<MeasurementVariable>(name);
-            const QString desc = (measurements->getGuiText() == "") ? "" : QString("\nDescription: %1").arg(measurements->getGuiText());
-            setDescription(item->text(), *data->DataVariables()->value(name)->GetValue(),
-                           UnitsToStr(qApp->patternUnit(), true), tr("Measurement"), desc);
+            const QSharedPointer<MeasurementVariable> measurement = data->getVariable<MeasurementVariable>(item->text());
+
+            setInfo(item->text(), *data->DataVariables()->value(name)->GetValue(),
+                    UnitsToStr(qApp->patternUnit(), true), tr("Measurement"),
+                    description(measurement), fullName(measurement));
             break;
         }
         case VariableTab::Custom:
         {
-            const QSharedPointer<CustomVariable> variables = data->getVariable<CustomVariable>(item->text());
-            const QString desc =(variables->GetDescription() == "") ? "" : QString("\nDescription: %1").arg(variables->GetDescription());
-            setDescription(item->text(), *data->DataVariables()->value(item->text())->GetValue(),
-                           UnitsToStr(qApp->patternUnit(), true), tr("Custom Variable"), desc);
+            const QString name = item->text();
+            const QSharedPointer<CustomVariable> variable = data->getVariable<CustomVariable>(item->text());
+            const QString desc = variable->GetDescription();
+            setInfo(name, *data->DataVariables()->value(item->text())->GetValue(),
+                    UnitsToStr(qApp->patternUnit(), true), tr("Custom Variable"),
+                    desc, "");
             break;
         }
         case VariableTab::LineLengths:
             {
-                setDescription(item->text(),
+                setInfo(item->text(),
                         *data->getVariable<VLengthLine>(qApp->translateVariables()->VarFromUser(item->text()))->GetValue(),
-                        UnitsToStr(qApp->patternUnit(), true), tr("Line length"), "");
+                        UnitsToStr(qApp->patternUnit(), true), tr("Line length"), "", "");
                 break;
             }
         case VariableTab::CurveLengths:
         {
-            setDescription(item->text(),
-                           *data->getVariable<VCurveLength>(qApp->translateVariables()->VarFromUser(item->text()))->GetValue(),
-                           UnitsToStr(qApp->patternUnit(), true), tr("Curve length"), "");
+            setInfo(item->text(),
+                    *data->getVariable<VCurveLength>(qApp->translateVariables()->VarFromUser(item->text()))->GetValue(),
+                     UnitsToStr(qApp->patternUnit(), true), tr("Curve length"), "", "");
             break;
         }
         case VariableTab::LineAngles:
         {
-            setDescription(item->text(),
-                           *data->getVariable<VLineAngle>(qApp->translateVariables()->VarFromUser(item->text()))->GetValue(),
-                           degreeSymbol, tr("Line Angle"), "");
+            setInfo(item->text(),
+                    *data->getVariable<VLineAngle>(qApp->translateVariables()->VarFromUser(item->text()))->GetValue(),
+                    degreeSymbol, tr("Line Angle"), "", "");
             break;
         }
         case VariableTab::ArcRadii:
         {
-            setDescription(item->text(),
-                           *data->getVariable<VArcRadius>(qApp->translateVariables()->VarFromUser(item->text()))->GetValue(),
-                           UnitsToStr(qApp->patternUnit(), true), tr("Arc radius"), "");
+            setInfo(item->text(),
+                    *data->getVariable<VArcRadius>(qApp->translateVariables()->VarFromUser(item->text()))->GetValue(),
+                    UnitsToStr(qApp->patternUnit(), true), tr("Arc radius"), "", "");
             break;
         }
         case VariableTab::CurveAngles:
         {
-            setDescription(item->text(),
-                           *data->getVariable<VCurveAngle>(qApp->translateVariables()->VarFromUser(item->text()))->GetValue(),
-                           degreeSymbol, tr("Curve angle"), "");
+            setInfo(item->text(),
+                    *data->getVariable<VCurveAngle>(qApp->translateVariables()->VarFromUser(item->text()))->GetValue(),
+                    degreeSymbol, tr("Curve angle"), "", "");
         break;
         }
         case VariableTab::Functions:
         {
-            ui->description_Label->setText(item->toolTip());
+            ui->info_Label->setText(item->toolTip());
             break;
         }
     }
@@ -615,11 +619,21 @@ void EditFormulaDialog::initializeVariables()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void EditFormulaDialog::setDescription(const QString &name, qreal value, const QString &unit,
-                                            const QString &type, const QString &description)
+void EditFormulaDialog::setInfo(const QString &name, qreal value, const QString &unit, const QString &type,
+                                const QString &description, const QString &fullName)
 {
-    const QString desc = QString("%5: %1(%2 %3)%4").arg(name).arg(value).arg(unit).arg(description).arg(type);
-    ui->description_Label->setText(desc);
+    QString desc = QString("%1: %2 = %3 %4\n").arg(type, name, QString::number(value), unit);
+    if (!fullName.isEmpty())
+    {
+        desc += QString("%1: %2\n").arg(tr("Full Name:"), fullName);
+    }
+
+    if (!description.isEmpty())
+    {
+        desc += QString("%1: %2").arg(tr("Description:"), description);
+    }
+
+    ui->info_Label->setText(desc);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -637,7 +651,7 @@ void EditFormulaDialog::showVariable(const QMap<key, val> &var)
     ui->tableWidget->setColumnHidden(ValueColumn, false);
     ui->tableWidget->setColumnHidden(NumberColumn, true);
     ui->tableWidget->setColumnHidden(FullNameColumn, true);
-    ui->description_Label->setText("");
+    ui->info_Label->setText("");
 
     QMapIterator<key, val> iMap(var);
     while (iMap.hasNext())
@@ -682,7 +696,7 @@ void EditFormulaDialog::showCustomVariable(const QMap<key, val> &var)
     ui->tableWidget->setColumnHidden(ValueColumn, false);
     ui->tableWidget->setColumnHidden(NumberColumn, true);
     ui->tableWidget->setColumnHidden(FullNameColumn, true);
-    ui->description_Label->setText("");
+    ui->info_Label->setText("");
 
     QMapIterator<key, val> iMap(var);
     while (iMap.hasNext())
@@ -692,30 +706,33 @@ void EditFormulaDialog::showCustomVariable(const QMap<key, val> &var)
         {
             continue; //skip this measurement
         }
-        if (iMap.value()->Filter(toolId) == false)
-        {// If we create this variable don't show
-            ui->tableWidget->setRowCount(ui->tableWidget->rowCount() + 1);
-            QTableWidgetItem *item = new QTableWidgetItem(iMap.key());
-            ui->tableWidget->setItem(ui->tableWidget->rowCount()-1, NameColumn, item);
 
-            QString desc = iMap.value()->GetDescription();
-            QTableWidgetItem *itemDesc = new QTableWidgetItem(desc);
-            itemDesc->setSizeHint(QSize(70, 20));
-            itemDesc->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
-            ui->tableWidget->setItem(ui->tableWidget->rowCount()-1, DescriptionColumn, itemDesc);
+        // Name
+        ui->tableWidget->setRowCount(ui->tableWidget->rowCount() + 1);
+        QTableWidgetItem *item = new QTableWidgetItem(iMap.key());
+        ui->tableWidget->setItem(ui->tableWidget->rowCount()-1, NameColumn, item);
 
-            qreal length = *iMap.value()->GetValue();
-            QTableWidgetItem *itemValue = new QTableWidgetItem(qApp->LocaleToString(length));
-            itemValue->setSizeHint(QSize(70, 20));
-            itemValue->setTextAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
-            ui->tableWidget->setItem(ui->tableWidget->rowCount()-1, ValueColumn, itemValue);
-        }
+        //Description
+        QString desc = iMap.value()->GetDescription();
+        QTableWidgetItem *itemDesc = new QTableWidgetItem(desc);
+        itemDesc->setToolTip(desc);
+        itemDesc->setSizeHint(QSize(70, 20));
+        itemDesc->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+        ui->tableWidget->setItem(ui->tableWidget->rowCount()-1, DescriptionColumn, itemDesc);
+
+        // Value
+        qreal length = *iMap.value()->GetValue();
+        QTableWidgetItem *itemValue = new QTableWidgetItem(qApp->LocaleToString(length));
+        itemValue->setSizeHint(QSize(70, 20));
+        itemValue->setTextAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+        ui->tableWidget->setItem(ui->tableWidget->rowCount()-1, ValueColumn, itemValue);
     }
+
     ui->tableWidget->blockSignals(false);
     ui->tableWidget->selectRow(0);
     ui->tableWidget->setColumnWidth(NameColumn, 80);
     ui->tableWidget->resizeColumnsToContents();
-    ui->tableWidget->horizontalHeader()->setSectionResizeMode(NameColumn, QHeaderView::Fixed);
+    ui->tableWidget->horizontalHeader()->setSectionResizeMode(NameColumn, QHeaderView::Stretch);
     ui->tableWidget->horizontalHeader()->setSectionResizeMode(DescriptionColumn, QHeaderView::Stretch);
     ui->tableWidget->setColumnWidth(ValueColumn, 80);
 }
@@ -731,10 +748,10 @@ void EditFormulaDialog::showMeasurements(const QMap<QString, QSharedPointer<Meas
     ui->tableWidget->setRowCount(0);
     ui->tableWidget->setColumnHidden(NumberColumn, false);
     ui->tableWidget->setColumnHidden(NameColumn, false);
-    ui->tableWidget->setColumnHidden(DescriptionColumn, true);
+    ui->tableWidget->setColumnHidden(DescriptionColumn, false);
     ui->tableWidget->setColumnHidden(ValueColumn, false);
     ui->tableWidget->setColumnHidden(FullNameColumn, false);
-    ui->description_Label->setText("");
+    ui->info_Label->setText("");
 
     QMapIterator<QString, QSharedPointer<MeasurementVariable>> iMap(var);
     while (iMap.hasNext())
@@ -744,55 +761,66 @@ void EditFormulaDialog::showMeasurements(const QMap<QString, QSharedPointer<Meas
         {
             continue; //skip this measurement
         }
-        if (iMap.value()->Filter(toolId) == false)
-        {// If we create this variable don't show
-            ui->tableWidget->setRowCount(ui->tableWidget->rowCount() + 1);
-            QTableWidgetItem *itemName = new QTableWidgetItem(iMap.key());
-            itemName->setSizeHint(QSize(70, 20));
-            itemName->setToolTip(itemName->text());
 
-            qreal length = *iMap.value()->GetValue();
-            QTableWidgetItem *itemValue = new QTableWidgetItem(qApp->LocaleToString(length));
-            itemValue->setSizeHint(QSize(70, 20));
-            itemValue->setTextAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+        // Name
+        ui->tableWidget->setRowCount(ui->tableWidget->rowCount() + 1);
+        QTableWidgetItem *itemName = new QTableWidgetItem(iMap.key());
+        itemName->setSizeHint(QSize(80, 20));
+        itemName->setToolTip(itemName->text());
 
-            QTableWidgetItem *itemNumber = new QTableWidgetItem();
-            itemNumber->setSizeHint(QSize(70, 20));
-            itemNumber->setTextAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+        // Description
+        const QString desc = description(iMap.value());
+        QTableWidgetItem *itemDesc = new QTableWidgetItem(desc);
+        itemDesc->setToolTip(desc);
+        itemDesc->setSizeHint(QSize(100, 20));
+        itemDesc->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
 
-            QTableWidgetItem *itemFullName = new QTableWidgetItem();
+        // Value
+        qreal length = *iMap.value()->GetValue();
+        QTableWidgetItem *itemValue = new QTableWidgetItem(qApp->LocaleToString(length));
+        itemValue->setSizeHint(QSize(70, 20));
+        itemValue->setTextAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
 
+        // Diagram number
+        QTableWidgetItem *itemNumber = new QTableWidgetItem();
+        itemNumber->setSizeHint(QSize(70, 20));
+        itemNumber->setTextAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
 
-            QString number =tr("Custom");
-            QString imgUrl = QString(":/diagrams/custom.svg");
-            if (iMap.value()->isCustom())
-            {
-                itemNumber->setText(QStringLiteral("na"));
-                itemFullName->setText(iMap.value()->getGuiText());
-            }
-            else
-            {
-                number = qApp->translateVariables()->MNumber(iMap.value()->GetName());
-                imgUrl = QString(":/diagrams/%1.svg").arg(MapDiagrams(qApp->translateVariables(), number));
-                itemNumber->setText(number);
-                itemFullName->setText(qApp->translateVariables()->guiText(iMap.value()->GetName()));
-            }
-
-            itemNumber->setToolTip(QString("<html><head/><body>"
-                                           "<p align=\"center\"><img src=%1/></p>"
-                                           "<p align=\"center\"><b>%2</b></p>"
-                                           "</body></html>").arg(imgUrl, number));
-
-            ui->tableWidget->setItem(ui->tableWidget->rowCount()-1, NumberColumn, itemNumber);
-            ui->tableWidget->setItem(ui->tableWidget->rowCount()-1, NameColumn, itemName);
-            ui->tableWidget->setItem(ui->tableWidget->rowCount()-1, ValueColumn, itemValue);
-            ui->tableWidget->setItem(ui->tableWidget->rowCount()-1, FullNameColumn, itemFullName);
+        // Fullname
+        QString number =tr("Custom");
+        QString imgUrl = QString(":/diagrams/custom.svg");
+        QTableWidgetItem *itemFullName = new QTableWidgetItem();
+        if (iMap.value()->isCustom())
+        {
+            itemNumber->setText(QStringLiteral("na"));
+            itemFullName->setText(iMap.value()->getGuiText());
         }
+        else
+        {
+            number = qApp->translateVariables()->MNumber(iMap.value()->GetName());
+            imgUrl = QString(":/diagrams/%1.svg").arg(MapDiagrams(qApp->translateVariables(), number));
+            itemNumber->setText(number);
+            itemFullName->setText(qApp->translateVariables()->guiText(iMap.value()->GetName()));
+        }
+
+        itemNumber->setToolTip(QString("<html><head/><body>"
+                                       "<p align=\"center\"><img src=%1/></p>"
+                                       "<p align=\"center\"><b>%2</b></p>"
+                                       "</body></html>").arg(imgUrl, number));
+
+        ui->tableWidget->setItem(ui->tableWidget->rowCount()-1, NumberColumn, itemNumber);
+        ui->tableWidget->setItem(ui->tableWidget->rowCount()-1, NameColumn, itemName);
+        ui->tableWidget->setItem(ui->tableWidget->rowCount()-1, DescriptionColumn, itemDesc);
+        ui->tableWidget->setItem(ui->tableWidget->rowCount()-1, ValueColumn, itemValue);
+        ui->tableWidget->setItem(ui->tableWidget->rowCount()-1, FullNameColumn, itemFullName);
     }
+
     ui->tableWidget->blockSignals(false);
     ui->tableWidget->selectRow(0);
     ui->tableWidget->resizeColumnsToContents();
+    ui->tableWidget->setColumnWidth(NameColumn, 80);
     ui->tableWidget->horizontalHeader()->setSectionResizeMode(NameColumn, QHeaderView::Stretch);
+    ui->tableWidget->horizontalHeader()->setSectionResizeMode(DescriptionColumn, QHeaderView::Stretch);
     ui->tableWidget->setColumnWidth(ValueColumn, 80);
 }
 
@@ -809,7 +837,7 @@ void EditFormulaDialog::showFunctions()
     ui->tableWidget->setColumnHidden(DescriptionColumn, true);
     ui->tableWidget->setColumnHidden(ValueColumn, true);
     ui->tableWidget->setColumnHidden(FullNameColumn, true);
-    ui->description_Label->setText("");
+    ui->info_Label->setText("");
 
     QMap<QString, qmu::QmuTranslation>::const_iterator i = qApp->translateVariables()->getFunctions().constBegin();
     while (i != qApp->translateVariables()->getFunctions().constEnd())
@@ -903,4 +931,44 @@ void EditFormulaDialog::clearFormula()
 void EditFormulaDialog::undoFormula()
 {
      ui->plainTextEditFormula->setPlainText(m_undoFormula);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief description get the description text.
+/// @param measurement measurment variable.
+/// @return description text.
+//---------------------------------------------------------------------------------------------------------------------
+QString EditFormulaDialog::description(QSharedPointer<MeasurementVariable> measurement)
+{
+    QString desc = QString("");
+
+    if (measurement->isCustom())
+    {
+        desc = measurement->GetDescription();
+    }
+    else
+    {
+        desc = qApp->translateVariables()->Description(measurement->GetName());
+    }
+    return desc;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief fullName get the fullName text.
+/// @param measurement measurment variable.
+/// @return fullName text.
+//---------------------------------------------------------------------------------------------------------------------
+QString EditFormulaDialog::fullName(QSharedPointer<MeasurementVariable> measurement)
+{
+    QString fullName = QString("");
+
+    if (measurement->isCustom())
+    {
+        fullName = measurement->getGuiText();
+    }
+    else
+    {
+        fullName = qApp->translateVariables()->guiText(measurement->GetName());
+    }
+    return fullName;
 }

--- a/src/libs/vtools/dialogs/support/edit_formula_dialog.h
+++ b/src/libs/vtools/dialogs/support/edit_formula_dialog.h
@@ -145,10 +145,14 @@ private:
     void         showInsertionButtons(const bool &visible);
     void         showHeaderUnits(QTableWidget *table, const QString &unit);
 
-    void         setDescription(const QString &name, qreal value, const QString &unit,
-                                const QString &type, const QString &description);
+    void         setInfo(const QString &name, qreal value, const QString &unit, const QString &type,
+                         const QString &description, const QString &fullName);
     void         clearFormula();
     void         undoFormula();
+
+    QString      description(QSharedPointer<MeasurementVariable> measurement);
+    QString      fullName(QSharedPointer<MeasurementVariable> measurement);
+
 };
 
 

--- a/src/libs/vtools/dialogs/support/edit_formula_dialog.ui
+++ b/src/libs/vtools/dialogs/support/edit_formula_dialog.ui
@@ -990,7 +990,7 @@ QListWidget::item:selected {
         </widget>
        </item>
        <item>
-        <widget class="QLabel" name="description_Label">
+        <widget class="QLabel" name="info_Label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
            <horstretch>0</horstretch>


### PR DESCRIPTION
This PR adds the description and full name info for measurments in the FX Editor dialog. 

- Adds a description column to the data table for Known and Custom measurements. Cell items display full description text in the tooltip. 

    <img width="554" height="99" alt="image" src="https://github.com/user-attachments/assets/7da003ff-c162-4ec4-ae65-c46eccf19e80" />

- Adds the Full name and Description text to the info box below the table.


    <img width="437" height="71" alt="image" src="https://github.com/user-attachments/assets/63de571b-cc21-4291-bf40-ee7e8710b769" />

- Makes the text in the QLabel info box  copyable by setting the interaction flag to TextSelectableByMouse.

    <img width="428" height="105" alt="image" src="https://github.com/user-attachments/assets/2374d35c-c1dc-472a-9e8d-84499eb937d1" />

- lupdate

closes issue #1554 