### PR TITLE
Add bulk import custom variables

### DIFF
--- a/src/app/seamly2d/dialogs/dialogs.pri
+++ b/src/app/seamly2d/dialogs/dialogs.pri
@@ -13,6 +13,7 @@ HEADERS += \
     $$PWD/layoutsettings_dialog.h \
     $$PWD/dialoglayoutprogress.h \
     $$PWD/dialogvariables.h \
+    $$PWD/dialogvariablesimport.h \
     $$PWD/export_layout_dialog.h \
     $$PWD/groups_widget.h \
     $$PWD/history_dialog.h \
@@ -38,6 +39,7 @@ SOURCES += \
     $$PWD/layoutsettings_dialog.cpp \
     $$PWD/dialoglayoutprogress.cpp \
     $$PWD/dialogvariables.cpp \
+    $$PWD/dialogvariablesimport.cpp \
     $$PWD/export_layout_dialog.cpp \
     $$PWD/groups_widget.cpp \
     $$PWD/history_dialog.cpp \

--- a/src/app/seamly2d/dialogs/dialogvariables.cpp
+++ b/src/app/seamly2d/dialogs/dialogvariables.cpp
@@ -52,6 +52,7 @@
 
 #include "dialogvariables.h"
 #include "ui_dialogvariables.h"
+#include "dialogvariablesimport.h"
 #include "../vwidgets/vwidgetpopup.h"
 #include "../vmisc/vsettings.h"
 #include "../qmuparser/qmudef.h"
@@ -63,16 +64,134 @@
 #include <QFileDialog>
 #include <QDir>
 #include <QGuiApplication>
+#include <QHeaderView>
 #include <QMessageBox>
 #include <QCloseEvent>
+#include <QDialogButtonBox>
+#include <QHBoxLayout>
 #include <QTabBar>
 #include <QTableWidget>
 #include <QScreen>
 #include <QSettings>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QSet>
 #include <QTableWidgetItem>
+#include <QToolButton>
+#include <QVBoxLayout>
 #include <QtNumeric>
 
 #define DIALOG_MAX_FORMULA_HEIGHT 64
+
+namespace
+{
+using DialogVariablesImport::ImportedVariable;
+using DialogVariablesImport::cNumber;
+using DialogVariablesImport::parseImportedVariables;
+using DialogVariablesImport::parseUnit;
+using DialogVariablesImport::unitConvertVariableName;
+
+class DialogImportCustomVariables : public QDialog
+{
+public:
+    DialogImportCustomVariables(VContainer *data, QWidget *parent)
+        : QDialog(parent)
+        , m_data(data)
+        , m_textEdit(new QPlainTextEdit(this))
+        , m_preview(new QTableWidget(this))
+        , m_buttonBox(new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this))
+    {
+        setWindowTitle(QObject::tr("Import Custom Variables"));
+        resize(760, 520);
+
+        QPushButton *fileButton = new QPushButton(QObject::tr("Open CSV File"), this);
+        connect(fileButton, &QPushButton::clicked, this, [this]()
+        {
+            const QString fileName = QFileDialog::getOpenFileName(this, QObject::tr("Open CSV File"), QDir::homePath(),
+                                                                  QObject::tr("CSV files (*.csv);;All files (*.*)"));
+            if (fileName.isEmpty())
+            {
+                return;
+            }
+
+            QString text;
+            QString error;
+            if (!DialogVariablesImport::readImportTextFile(fileName, &text, &error))
+            {
+                QMessageBox::warning(this, QObject::tr("Import Custom Variables"),
+                                     QObject::tr("Cannot read file %1. %2")
+                                     .arg(QDir::toNativeSeparators(fileName), error));
+                return;
+            }
+            m_textEdit->setPlainText(text);
+        });
+
+        m_textEdit->setPlaceholderText(QObject::tr("Paste CSV here. Supported columns: Name, Value, Unit, Formula, Description."));
+        m_preview->setColumnCount(4);
+        m_preview->setHorizontalHeaderLabels(QStringList() << QObject::tr("Name") << QObject::tr("Formula")
+                                                           << QObject::tr("Description") << QObject::tr("Status"));
+        m_preview->horizontalHeader()->setStretchLastSection(true);
+        m_preview->setEditTriggers(QAbstractItemView::NoEditTriggers);
+        m_preview->setSelectionBehavior(QAbstractItemView::SelectRows);
+
+        QHBoxLayout *topLayout = new QHBoxLayout();
+        topLayout->addWidget(fileButton);
+        topLayout->addStretch();
+
+        QVBoxLayout *layout = new QVBoxLayout(this);
+        layout->addLayout(topLayout);
+        layout->addWidget(m_textEdit, 1);
+        layout->addWidget(m_preview, 1);
+        layout->addWidget(m_buttonBox);
+
+        connect(m_textEdit, &QPlainTextEdit::textChanged, this, &DialogImportCustomVariables::refreshPreview);
+        connect(m_buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+        connect(m_buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+        refreshPreview();
+    }
+
+    QList<ImportedVariable> variables() const
+    {
+        return m_variables;
+    }
+
+    QSet<QString> convertVariables() const
+    {
+        return m_convertVariables;
+    }
+
+private:
+    void refreshPreview()
+    {
+        m_variables = parseImportedVariables(m_textEdit->toPlainText(), m_data, qApp->patternUnit(), &m_convertVariables);
+        int validCount = 0;
+
+        m_preview->setRowCount(m_variables.size());
+        for (int row = 0; row < m_variables.size(); ++row)
+        {
+            const ImportedVariable &variable = m_variables.at(row);
+            m_preview->setItem(row, 0, new QTableWidgetItem(variable.name));
+            m_preview->setItem(row, 1, new QTableWidgetItem(variable.formula));
+            m_preview->setItem(row, 2, new QTableWidgetItem(variable.description));
+            m_preview->setItem(row, 3, new QTableWidgetItem(variable.status));
+
+            if (variable.valid)
+            {
+                ++validCount;
+            }
+        }
+        m_preview->resizeColumnsToContents();
+        m_buttonBox->button(QDialogButtonBox::Ok)->setEnabled(validCount > 0 && validCount == m_variables.size());
+    }
+
+    VContainer *m_data;
+    QPlainTextEdit *m_textEdit;
+    QTableWidget *m_preview;
+    QDialogButtonBox *m_buttonBox;
+    QList<ImportedVariable> m_variables;
+    QSet<QString> m_convertVariables;
+};
+}
 
 //---------------------------------------------------------------------------------------------------------------------
 /// @brief DialogVariables create dialog
@@ -138,7 +257,8 @@ DialogVariables::DialogVariables(VContainer *data, VPattern *doc, QWidget *paren
     connect(ui->variables_TableWidget, &QTableWidget::itemSelectionChanged, this,
             &DialogVariables::showCustomVariableDetails);
 
-    connect(ui->addCustomVariable_ToolButton, &QPushButton::clicked, this, &DialogVariables::addCustomVariable);
+    connect(ui->addCustomVariable_ToolButton, &QToolButton::clicked, this, &DialogVariables::addCustomVariable);
+    connect(ui->importCustomVariables_ToolButton, &QToolButton::clicked, this, &DialogVariables::importCustomVariables);
     connect(ui->removeCustomVariable_ToolButton, &QToolButton::clicked, this, &DialogVariables::removeCustomVariable);
     connect(ui->toolButtonUp, &QToolButton::clicked, this, &DialogVariables::moveUp);
     connect(ui->toolButtonDown, &QToolButton::clicked, this, &DialogVariables::moveDown);
@@ -656,6 +776,87 @@ void DialogVariables::addCustomVariable()
     localUpdateTree();
 
     ui->variables_TableWidget->selectRow(currentRow);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief importCustomVariables import custom variables from pasted or loaded CSV text.
+//---------------------------------------------------------------------------------------------------------------------
+void DialogVariables::importCustomVariables()
+{
+    DialogImportCustomVariables dialog(data, this);
+    if (dialog.exec() != QDialog::Accepted)
+    {
+        return;
+    }
+
+    const QList<ImportedVariable> variables = dialog.variables();
+    if (variables.isEmpty())
+    {
+        return;
+    }
+
+    const QMap<QString, QSharedPointer<CustomVariable>> existing = data->variablesData();
+    const QSet<QString> convertVariables = dialog.convertVariables();
+    QStringList convertNames = convertVariables.values();
+    convertNames.sort();
+
+    for (const QString &convertName : convertNames)
+    {
+        if (existing.contains(convertName))
+        {
+            continue;
+        }
+
+        Unit from = Unit::Cm;
+        Unit to = Unit::Cm;
+        const QString displayName = convertName.mid(CustomIncrSign.length());
+        const QStringList parts = displayName.split(QLatin1String("to"));
+        if (parts.size() == 2 && parseUnit(parts.at(0), &from) && parseUnit(parts.at(1), &to))
+        {
+            doc->addEmptyCustomVariable(convertName);
+            doc->setVariableFormula(convertName, cNumber(UnitConvertor(1, from, to)));
+            doc->setVariableDescription(convertName, tr("CSV unit conversion factor %1 to %2.")
+                                        .arg(UnitsToStr(from), UnitsToStr(to)));
+        }
+    }
+
+    const int moveLimit = existing.size() + convertNames.size() + variables.size();
+    for (int i = convertNames.size() - 1; i >= 0; --i)
+    {
+        const QString &convertName = convertNames.at(i);
+        for (int move = 0; move < moveLimit; ++move)
+        {
+            doc->moveVariableUp(convertName);
+        }
+    }
+
+    if (!convertNames.isEmpty())
+    {
+        localUpdateTree();
+    }
+
+    for (const ImportedVariable &variable : variables)
+    {
+        if (!variable.valid)
+        {
+            continue;
+        }
+
+        if (!existing.contains(variable.name))
+        {
+            doc->addEmptyCustomVariable(variable.name);
+        }
+        doc->setVariableFormula(variable.name, variable.formula);
+        doc->setVariableDescription(variable.name, variable.description);
+    }
+
+    hasChanges = true;
+    localUpdateTree();
+
+    if (ui->variables_TableWidget->rowCount() > 0)
+    {
+        ui->variables_TableWidget->selectRow(0);
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/app/seamly2d/dialogs/dialogvariables.cpp
+++ b/src/app/seamly2d/dialogs/dialogvariables.cpp
@@ -126,7 +126,7 @@ public:
             m_textEdit->setPlainText(text);
         });
 
-        m_textEdit->setPlaceholderText(QObject::tr("Paste CSV here. Supported columns: Name, Value, Unit, Formula, Description."));
+        m_textEdit->setPlaceholderText(QObject::tr("Paste CSV here. Supported format:\nName, Formula, Description."));
         m_preview->setColumnCount(4);
         m_preview->setHorizontalHeaderLabels(QStringList() << QObject::tr("Name") << QObject::tr("Formula")
                                                            << QObject::tr("Description") << QObject::tr("Status"));

--- a/src/app/seamly2d/dialogs/dialogvariables.h
+++ b/src/app/seamly2d/dialogs/dialogvariables.h
@@ -91,6 +91,7 @@ private slots:
     void                             showCustomVariableDetails();
     void                             filterVariables(const QString &filterString);
     void                             addCustomVariable();
+    void                             importCustomVariables();
     void                             removeCustomVariable();
     void                             moveUp();
     void                             moveDown();

--- a/src/app/seamly2d/dialogs/dialogvariables.ui
+++ b/src/app/seamly2d/dialogs/dialogvariables.ui
@@ -261,6 +261,26 @@
             </widget>
            </item>
            <item alignment="Qt::AlignRight">
+            <widget class="QToolButton" name="importCustomVariables_ToolButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="toolTip">
+              <string>Import custom variables from CSV</string>
+             </property>
+             <property name="text">
+              <string notr="true">...</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../../../libs/vmisc/share/resources/theme.qrc">
+               <normaloff>:/icons/win.icon.theme/24x24/actions/document-open.png</normaloff>:/icons/win.icon.theme/24x24/actions/document-open.png</iconset>
+             </property>
+            </widget>
+           </item>
+           <item alignment="Qt::AlignRight">
             <widget class="QToolButton" name="addCustomVariable_ToolButton">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">

--- a/src/app/seamly2d/dialogs/dialogvariablesimport.cpp
+++ b/src/app/seamly2d/dialogs/dialogvariablesimport.cpp
@@ -7,11 +7,15 @@
 
 #include "../ifc/ifcdef.h"
 #include "../qmuparser/qmudef.h"
+#include "../qmuparser/qmuparsererror.h"
+#include "../vpatterndb/calculator.h"
 #include "../vpatterndb/vcontainer.h"
 #include "../vpatterndb/variables/custom_variable.h"
 
 #include <QFile>
 #include <QRegularExpression>
+#include <QScopedPointer>
+#include <QtNumeric>
 
 namespace DialogVariablesImport
 {
@@ -180,17 +184,90 @@ bool splitValueAndUnit(const QString &text, qreal *value, Unit *unit)
     }
     return parseNumber(match.captured(1), value) && parseUnit(match.captured(2), unit);
 }
+
+bool hasHeader(const QList<QStringList> &rows)
+{
+    return !rows.isEmpty() && (cellText(rows, 0, 0).trimmed().toLower() == QLatin1String("name")
+                               || cellText(rows, 0, 0).trimmed().toLower() == QObject::tr("name").toLower());
 }
 
-bool looksLikeHeader(const QList<QStringList> &rows)
+bool looksLikeExportedTable(const QList<QStringList> &rows, int firstDataRow)
 {
-    if (rows.isEmpty())
+    if (columnCount(rows) != 3)
     {
         return false;
     }
 
-    const QString first = cellText(rows, 0, 0).trimmed().toLower();
-    return first == QLatin1String("name") || first == QObject::tr("name").toLower();
+    for (int row = firstDataRow; row < rows.size(); ++row)
+    {
+        qreal value = 0;
+        if (!cellText(rows, row, 0).trimmed().startsWith(CustomIncrSign)
+            || !parseNumber(cellText(rows, row, 1), &value)
+            || cellText(rows, row, 2).trimmed().isEmpty())
+        {
+            return false;
+        }
+    }
+
+    return rows.size() > firstDataRow;
+}
+
+QSet<QString> importNames(const QList<QStringList> &rows, int firstDataRow, int nameColumn)
+{
+    QSet<QString> names;
+    for (int row = firstDataRow; row < rows.size(); ++row)
+    {
+        const QString displayName = cellText(rows, row, nameColumn).trimmed();
+        const QString cleanName = displayName.startsWith(CustomIncrSign) ? displayName.mid(1) : displayName;
+        if (!cleanName.isEmpty() && QRegularExpression(NameRegExp()).match(cleanName).hasMatch())
+        {
+            names.insert(CustomIncrSign + cleanName);
+        }
+    }
+
+    return names;
+}
+
+bool validateFormula(const QString &formula, VContainer *data, const QSet<QString> &availableImportNames,
+                     QString *status)
+{
+    if (data == nullptr)
+    {
+        return true;
+    }
+
+    QHash<QString, QSharedPointer<VInternalVariable>> variables = *data->DataVariables();
+    for (const QString &name : availableImportNames)
+    {
+        if (!variables.contains(name))
+        {
+            variables.insert(name, QSharedPointer<VInternalVariable>(new CustomVariable(data, name, 0, 0, QStringLiteral("0"), true)));
+        }
+    }
+
+    try
+    {
+        QScopedPointer<Calculator> cal(new Calculator());
+        const qreal result = cal->EvalFormula(&variables, formula);
+        if (qIsInf(result) || qIsNaN(result))
+        {
+            *status = QObject::tr("Invalid result");
+            return false;
+        }
+    }
+    catch (qmu::QmuParserError &error)
+    {
+        *status = QObject::tr("Parser error: %1").arg(error.GetMsg());
+        return false;
+    }
+
+    return true;
+}
+}
+
+bool looksLikeHeader(const QList<QStringList> &rows)
+{
+    return hasHeader(rows);
 }
 
 int columnByHeader(const QList<QStringList> &rows, const QStringList &needles, int fallback)
@@ -244,15 +321,20 @@ QList<ImportedVariable> parseImportedVariables(const QString &text, VContainer *
 
     const QList<QStringList> rows = parseSeparatedText(text, detectCsvSeparator(text));
     const int firstDataRow = looksLikeHeader(rows) ? 1 : 0;
+    const bool header = looksLikeHeader(rows);
     const int columns = columnCount(rows);
     const int nameColumn = columnByHeader(rows, QStringList() << QStringLiteral("name"), 0);
-    const int valueColumn = columnByHeader(rows, QStringList() << QStringLiteral("value") << QStringLiteral("calculated"), 1);
-    const int formulaColumn = columnByHeader(rows, QStringList() << QStringLiteral("formula"), columns > 2 ? 2 : -1);
-    const int unitColumn = columnByHeader(rows, QStringList() << QStringLiteral("unit"), -1);
-    const int descriptionColumn = columnByHeader(rows, QStringList() << QStringLiteral("description"), columns > 3 ? 3 : -1);
+    const bool exportedTable = !header && looksLikeExportedTable(rows, firstDataRow);
+    const int valueColumn = columnByHeader(rows, QStringList() << QStringLiteral("value") << QStringLiteral("calculated"),
+                                           exportedTable ? 1 : -1);
+    const int formulaColumn = columnByHeader(rows, QStringList() << QStringLiteral("formula"),
+                                             exportedTable ? 2 : !header && columns > 1 ? 1 : -1);
+    const int descriptionColumn = columnByHeader(rows, QStringList() << QStringLiteral("description"),
+                                                 !exportedTable && !header && columns > 2 ? 2 : -1);
     const QMap<QString, QSharedPointer<CustomVariable>> existing = data != nullptr
             ? data->variablesData()
             : QMap<QString, QSharedPointer<CustomVariable>>();
+    const QSet<QString> availableImportNames = importNames(rows, firstDataRow, nameColumn);
     QSet<QString> seen;
 
     for (int row = firstDataRow; row < rows.size(); ++row)
@@ -282,25 +364,23 @@ QList<ImportedVariable> parseImportedVariables(const QString &text, VContainer *
         else
         {
             const QString rawFormula = formulaColumn >= 0 ? cellText(rows, row, formulaColumn).trimmed() : QString();
-            QString valueText = valueColumn >= 0 ? cellText(rows, row, valueColumn).trimmed() : QString();
             Unit valueUnit = targetUnit;
             qreal value = 0;
+            QString formulaToValidate;
 
-            if (unitColumn >= 0 && parseUnit(cellText(rows, row, unitColumn), &valueUnit) && parseNumber(valueText, &value))
+            if (rawFormula.isEmpty() && valueColumn >= 0)
             {
-                valueText = cNumber(value);
-            }
-            else if (splitValueAndUnit(valueText, &value, &valueUnit))
-            {
-                valueText = cNumber(value);
+                imported.status = QObject::tr("Missing formula");
             }
 
-            if (!rawFormula.isEmpty() && !splitValueAndUnit(rawFormula, &value, &valueUnit))
+            if (!imported.status.isEmpty())
             {
-                imported.formula = rawFormula;
+                imported.valid = false;
             }
-            else if (!valueText.isEmpty())
+            else if (!rawFormula.isEmpty() && splitValueAndUnit(rawFormula, &value, &valueUnit))
             {
+                const QString valueText = cNumber(value);
+                formulaToValidate = valueText;
                 if (valueUnit == targetUnit)
                 {
                     imported.formula = valueText;
@@ -312,15 +392,35 @@ QList<ImportedVariable> parseImportedVariables(const QString &text, VContainer *
                     imported.formula = QStringLiteral("%1 * %2").arg(valueText, convertName);
                 }
             }
+            else if (!rawFormula.isEmpty() && valueUnit != targetUnit)
+            {
+                formulaToValidate = rawFormula;
+                const QString convertName = unitConvertVariableName(valueUnit, targetUnit);
+                convertVariables->insert(convertName);
+                imported.formula = QStringLiteral("(%1) * %2").arg(rawFormula, convertName);
+            }
+            else if (!rawFormula.isEmpty())
+            {
+                formulaToValidate = rawFormula;
+                imported.formula = rawFormula;
+            }
             else
             {
-                imported.formula = QStringLiteral("0");
+                imported.status = QObject::tr("Missing formula");
             }
 
-            imported.valid = true;
-            imported.exists = existing.contains(imported.name);
-            imported.status = imported.exists ? QObject::tr("Update") : QObject::tr("Add");
-            seen.insert(imported.name);
+            if (imported.status.isEmpty() && !validateFormula(formulaToValidate, data, availableImportNames, &imported.status))
+            {
+                imported.valid = false;
+            }
+
+            if (imported.status.isEmpty())
+            {
+                imported.valid = true;
+                imported.exists = existing.contains(imported.name);
+                imported.status = imported.exists ? QObject::tr("Update") : QObject::tr("Add");
+                seen.insert(imported.name);
+            }
         }
 
         result.append(imported);

--- a/src/app/seamly2d/dialogs/dialogvariablesimport.cpp
+++ b/src/app/seamly2d/dialogs/dialogvariablesimport.cpp
@@ -1,0 +1,331 @@
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   dialogvariablesimport.cpp
+//  @brief  Helpers for importing custom variables from CSV-like text.
+//---------------------------------------------------------------------------------------------------------------------
+
+#include "dialogvariablesimport.h"
+
+#include "../ifc/ifcdef.h"
+#include "../qmuparser/qmudef.h"
+#include "../vpatterndb/vcontainer.h"
+#include "../vpatterndb/variables/custom_variable.h"
+
+#include <QFile>
+#include <QRegularExpression>
+
+namespace DialogVariablesImport
+{
+QString unitConvertVariableName(Unit from, Unit to)
+{
+    return QStringLiteral("%1%2to%3").arg(CustomIncrSign, UnitsToStr(from), UnitsToStr(to));
+}
+
+bool parseUnit(const QString &text, Unit *unit)
+{
+    const QString normalized = text.trimmed().toLower();
+    if (normalized == QLatin1String("mm") || normalized == QObject::tr("millimeters").toLower())
+    {
+        *unit = Unit::Mm;
+        return true;
+    }
+    if (normalized == QLatin1String("cm") || normalized == QObject::tr("centimeters").toLower())
+    {
+        *unit = Unit::Cm;
+        return true;
+    }
+    if (normalized == QLatin1String("in") || normalized == QLatin1String("inch") || normalized == QLatin1String("inches"))
+    {
+        *unit = Unit::Inch;
+        return true;
+    }
+    return false;
+}
+
+namespace
+{
+QChar detectCsvSeparator(const QString &text)
+{
+    const QString firstLine = text.section(QLatin1Char('\n'), 0, 0);
+    QChar separator = QLatin1Char(',');
+    int bestCount = firstLine.count(separator);
+
+    const QList<QChar> candidates = QList<QChar>() << QLatin1Char(';') << QLatin1Char('\t') << QLatin1Char(':');
+    for (const QChar candidate : candidates)
+    {
+        const int count = firstLine.count(candidate);
+        if (count > bestCount)
+        {
+            separator = candidate;
+            bestCount = count;
+        }
+    }
+
+    return separator;
+}
+
+QList<QStringList> parseSeparatedText(const QString &text, QChar separator)
+{
+    QList<QStringList> rows;
+    QStringList row;
+    QString field;
+    QChar quote;
+    bool inQuote = false;
+
+    for (int i = 0; i < text.size(); ++i)
+    {
+        const QChar ch = text.at(i);
+        if (inQuote)
+        {
+            if (ch == quote)
+            {
+                if (i + 1 < text.size() && text.at(i + 1) == quote)
+                {
+                    field.append(ch);
+                    ++i;
+                }
+                else
+                {
+                    inQuote = false;
+                }
+            }
+            else
+            {
+                field.append(ch);
+            }
+            continue;
+        }
+
+        if ((ch == QLatin1Char('"') || ch == QLatin1Char('\'')) && field.trimmed().isEmpty())
+        {
+            quote = ch;
+            inQuote = true;
+            continue;
+        }
+
+        if (ch == separator)
+        {
+            row.append(field.trimmed());
+            field.clear();
+            continue;
+        }
+
+        if (ch == QLatin1Char('\n') || ch == QLatin1Char('\r'))
+        {
+            if (ch == QLatin1Char('\r') && i + 1 < text.size() && text.at(i + 1) == QLatin1Char('\n'))
+            {
+                ++i;
+            }
+
+            row.append(field.trimmed());
+            field.clear();
+            if (!row.isEmpty() && !(row.size() == 1 && row.constFirst().isEmpty()))
+            {
+                rows.append(row);
+            }
+            row.clear();
+            continue;
+        }
+
+        field.append(ch);
+    }
+
+    row.append(field.trimmed());
+    if (!row.isEmpty() && !(row.size() == 1 && row.constFirst().isEmpty()))
+    {
+        rows.append(row);
+    }
+
+    return rows;
+}
+
+QString cellText(const QList<QStringList> &rows, int row, int column)
+{
+    if (row < 0 || row >= rows.size() || column < 0 || column >= rows.at(row).size())
+    {
+        return QString();
+    }
+
+    return rows.at(row).at(column);
+}
+
+int columnCount(const QList<QStringList> &rows)
+{
+    int count = 0;
+    for (const QStringList &row : rows)
+    {
+        count = qMax(count, row.size());
+    }
+
+    return count;
+}
+
+bool parseNumber(const QString &text, qreal *value)
+{
+    bool ok = false;
+    *value = QLocale().toDouble(text.trimmed(), &ok);
+    if (!ok)
+    {
+        *value = QLocale::c().toDouble(text.trimmed(), &ok);
+    }
+    return ok;
+}
+
+bool splitValueAndUnit(const QString &text, qreal *value, Unit *unit)
+{
+    static const QRegularExpression rx(QStringLiteral("^\\s*([+-]?(?:\\d+(?:[\\.,]\\d*)?|[\\.,]\\d+))\\s*([A-Za-z]+)\\s*$"));
+    const QRegularExpressionMatch match = rx.match(text);
+    if (!match.hasMatch())
+    {
+        return false;
+    }
+    return parseNumber(match.captured(1), value) && parseUnit(match.captured(2), unit);
+}
+}
+
+bool looksLikeHeader(const QList<QStringList> &rows)
+{
+    if (rows.isEmpty())
+    {
+        return false;
+    }
+
+    const QString first = cellText(rows, 0, 0).trimmed().toLower();
+    return first == QLatin1String("name") || first == QObject::tr("name").toLower();
+}
+
+int columnByHeader(const QList<QStringList> &rows, const QStringList &needles, int fallback)
+{
+    if (!looksLikeHeader(rows))
+    {
+        return fallback;
+    }
+
+    for (int column = 0; column < columnCount(rows); ++column)
+    {
+        const QString header = cellText(rows, 0, column).trimmed().toLower();
+        for (const QString &needle : needles)
+        {
+            if (header.contains(needle))
+            {
+                return column;
+            }
+        }
+    }
+
+    return fallback;
+}
+
+QString cNumber(qreal value)
+{
+    return QLocale::c().toString(value, 'g', 15);
+}
+
+bool readImportTextFile(const QString &fileName, QString *text, QString *errorString)
+{
+    QFile file(fileName);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+    {
+        if (errorString != nullptr)
+        {
+            *errorString = file.errorString();
+        }
+        return false;
+    }
+
+    *text = QString::fromUtf8(file.readAll());
+    return true;
+}
+
+QList<ImportedVariable> parseImportedVariables(const QString &text, VContainer *data, Unit targetUnit,
+                                               QSet<QString> *convertVariables)
+{
+    QList<ImportedVariable> result;
+    convertVariables->clear();
+
+    const QList<QStringList> rows = parseSeparatedText(text, detectCsvSeparator(text));
+    const int firstDataRow = looksLikeHeader(rows) ? 1 : 0;
+    const int columns = columnCount(rows);
+    const int nameColumn = columnByHeader(rows, QStringList() << QStringLiteral("name"), 0);
+    const int valueColumn = columnByHeader(rows, QStringList() << QStringLiteral("value") << QStringLiteral("calculated"), 1);
+    const int formulaColumn = columnByHeader(rows, QStringList() << QStringLiteral("formula"), columns > 2 ? 2 : -1);
+    const int unitColumn = columnByHeader(rows, QStringList() << QStringLiteral("unit"), -1);
+    const int descriptionColumn = columnByHeader(rows, QStringList() << QStringLiteral("description"), columns > 3 ? 3 : -1);
+    const QMap<QString, QSharedPointer<CustomVariable>> existing = data != nullptr
+            ? data->variablesData()
+            : QMap<QString, QSharedPointer<CustomVariable>>();
+    QSet<QString> seen;
+
+    for (int row = firstDataRow; row < rows.size(); ++row)
+    {
+        ImportedVariable imported;
+        const QString displayName = cellText(rows, row, nameColumn).trimmed();
+        const QString cleanName = displayName.startsWith(CustomIncrSign) ? displayName.mid(1) : displayName;
+        imported.name = CustomIncrSign + cleanName;
+        imported.description = descriptionColumn >= 0 ? cellText(rows, row, descriptionColumn).trimmed() : QString();
+
+        if (cleanName.isEmpty())
+        {
+            imported.status = QObject::tr("Missing name");
+        }
+        else if (!QRegularExpression(NameRegExp()).match(cleanName).hasMatch())
+        {
+            imported.status = QObject::tr("Invalid name");
+        }
+        else if (seen.contains(imported.name))
+        {
+            imported.status = QObject::tr("Duplicate in CSV");
+        }
+        else if (data != nullptr && !existing.contains(imported.name) && !data->IsUnique(imported.name))
+        {
+            imported.status = QObject::tr("Name is already used");
+        }
+        else
+        {
+            const QString rawFormula = formulaColumn >= 0 ? cellText(rows, row, formulaColumn).trimmed() : QString();
+            QString valueText = valueColumn >= 0 ? cellText(rows, row, valueColumn).trimmed() : QString();
+            Unit valueUnit = targetUnit;
+            qreal value = 0;
+
+            if (unitColumn >= 0 && parseUnit(cellText(rows, row, unitColumn), &valueUnit) && parseNumber(valueText, &value))
+            {
+                valueText = cNumber(value);
+            }
+            else if (splitValueAndUnit(valueText, &value, &valueUnit))
+            {
+                valueText = cNumber(value);
+            }
+
+            if (!rawFormula.isEmpty() && !splitValueAndUnit(rawFormula, &value, &valueUnit))
+            {
+                imported.formula = rawFormula;
+            }
+            else if (!valueText.isEmpty())
+            {
+                if (valueUnit == targetUnit)
+                {
+                    imported.formula = valueText;
+                }
+                else
+                {
+                    const QString convertName = unitConvertVariableName(valueUnit, targetUnit);
+                    convertVariables->insert(convertName);
+                    imported.formula = QStringLiteral("%1 * %2").arg(valueText, convertName);
+                }
+            }
+            else
+            {
+                imported.formula = QStringLiteral("0");
+            }
+
+            imported.valid = true;
+            imported.exists = existing.contains(imported.name);
+            imported.status = imported.exists ? QObject::tr("Update") : QObject::tr("Add");
+            seen.insert(imported.name);
+        }
+
+        result.append(imported);
+    }
+
+    return result;
+}
+}

--- a/src/app/seamly2d/dialogs/dialogvariablesimport.h
+++ b/src/app/seamly2d/dialogs/dialogvariablesimport.h
@@ -1,0 +1,37 @@
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   dialogvariablesimport.h
+//  @brief  Helpers for importing custom variables from CSV-like text.
+//---------------------------------------------------------------------------------------------------------------------
+
+#ifndef DIALOG_VARIABLES_IMPORT_H
+#define DIALOG_VARIABLES_IMPORT_H
+
+#include "../vmisc/def.h"
+
+#include <QList>
+#include <QSet>
+#include <QString>
+
+class VContainer;
+
+namespace DialogVariablesImport
+{
+struct ImportedVariable
+{
+    QString name;
+    QString formula;
+    QString description;
+    QString status;
+    bool valid = false;
+    bool exists = false;
+};
+
+QString unitConvertVariableName(Unit from, Unit to);
+bool parseUnit(const QString &text, Unit *unit);
+QString cNumber(qreal value);
+bool readImportTextFile(const QString &fileName, QString *text, QString *errorString = nullptr);
+QList<ImportedVariable> parseImportedVariables(const QString &text, VContainer *data, Unit targetUnit,
+                                               QSet<QString> *convertVariables);
+}
+
+#endif // DIALOG_VARIABLES_IMPORT_H


### PR DESCRIPTION
Add support for bulk import custom variables, including formula validation.

The parsing format takes:

* name, formula
* name, formula, description

where the formula support unit conversion to project setting.
 
(from [A Seamly2D Start to Finish tutorial](https://wiki.seamly.io/wiki/UserManual:StartToFinish))
<img width="773" height="618" alt="Selection_22ed1_2026_05_05_13_08_26_01" src="https://github.com/user-attachments/assets/eac4e584-b8d4-4b76-8040-260f2981f391" />


Also support parsing with header:

(from [simple shirt tutorial](https://wiki.seamly.io/wiki/Tutorial_for_making_a_simple_shirt_(test)))
<img width="780" height="585" alt="Selection_df435_2026_05_05_13_07_19_01" src="https://github.com/user-attachments/assets/a774a0e3-bd4c-45a1-93d3-5711e39932fb" />
