### PR TITLE
BUG: fix name error in fx dialog

### DIFF
--- a/src/libs/vtools/dialogs/support/edit_formula_dialog.cpp
+++ b/src/libs/vtools/dialogs/support/edit_formula_dialog.cpp
@@ -249,7 +249,7 @@ void EditFormulaDialog::valueChanged(int row)
         case VariableTab::Measurements:
         {
             const QString name = qApp->translateVariables()->VarFromUser(item->text());
-            const QSharedPointer<MeasurementVariable> measurement = data->getVariable<MeasurementVariable>(item->text());
+            const QSharedPointer<MeasurementVariable> measurement = data->getVariable<MeasurementVariable>(name);
 
             setInfo(item->text(), *data->DataVariables()->value(name)->GetValue(),
                     UnitsToStr(qApp->patternUnit(), true), tr("Measurement"),


### PR DESCRIPTION
This PR fixes the critical error in the fx Editor when using a non English language. 

It replaces an argument of item->text(), which is the translated name of a measurement, with "name", the untranslated name of the measurement which the  getVariable() container class function expects. 

closes iss #1562 