### PR TITLE
BUG: Fix normalize angle routine

### DIFF
--- a/src/libs/vmisc/def.cpp
+++ b/src/libs/vmisc/def.cpp
@@ -32,6 +32,7 @@
 
 #include "vabstractapplication.h"
 
+#include <qnumeric.h>
 #include <QApplication>
 #include <QChar>
 #include <QColor>
@@ -54,6 +55,7 @@
 #include <QRgb>
 #include <QString>
 #include <QtDebug>
+#include <QtMath>
 #include <QPixmapCache>
 #include <QGraphicsItem>
 #include <QDesktopServices>
@@ -343,6 +345,22 @@ QMarginsF UnitConvertor(const QMarginsF &margins, const Unit &from, const Unit &
     return QMarginsF(left, top, right, bottom);
 }
 
+// Normalizes any number to an arbitrary range
+// by assuming the range wraps around when going below min or above max
+qreal normalize(const qreal value, const qreal start, const qreal end)
+{
+    // check if value is not start && is evenly divisble by end value
+    if (qFabs(value) != start && std::fmod(qFabs(value), end) < 1e-9)
+    {
+        return end;
+    }
+
+    const qreal range       = end - start   ;   //
+    const qreal offsetValue = value - start ;   // value relative to 0
+
+    // add start to reset back to start of original range
+    return (offsetValue - (floor(offsetValue / range) * range)) + start ;
+}
 
 //---------------------------------------------------------------------------------------------------------------------
 QStringList SupportedLocales()

--- a/src/libs/vmisc/def.h
+++ b/src/libs/vmisc/def.h
@@ -587,6 +587,8 @@ Q_REQUIRED_RESULT double FromPixel(double pix, const Unit &unit);
 Q_REQUIRED_RESULT qreal UnitConvertor(qreal value, const Unit &from, const Unit &to);
 Q_REQUIRED_RESULT QMarginsF UnitConvertor(const QMarginsF &margins, const Unit &from, const Unit &to);
 
+qreal normalize(const qreal value, const qreal start, const qreal end);
+
 void InitLanguages(QComboBox *combobox);
 Q_REQUIRED_RESULT QStringList SupportedLocales();
 
@@ -778,6 +780,5 @@ inline QList<T> convertToList(const C<T> &set)
 {
     return QList<T>(set.begin(), set.end());
 }
-
 
 #endif // DEF_H

--- a/src/libs/vpatterndb/vformula.cpp
+++ b/src/libs/vpatterndb/vformula.cpp
@@ -1,54 +1,50 @@
-/***************************************************************************
- **  @file   vformula.cpp
- **  @author Douglas S Caskey
- **  @date   17 Sep, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+// @file   vformula.cpp
+// @author Douglas S Caskey
+// @date   14 May, 2026
+//
+// @copyright
+// Copyright (C) 2017 - 2026 Seamly, LLC
+// https://github.com/fashionfreedom/seamly2d
+//
+// @brief
+// Seamly2D is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Seamly2D is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
 
-/************************************************************************
- **
- **  @file   vformula.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   28 8, 2014
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2014 Valentina project
- **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//
+//  @file   vformula.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   28 Aug, 2014
+//
+//  @copyright
+//  Copyright (C) 2014 Valentina project.
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published
+//  by the Free Software Foundation, either version 3 of the License,
+//  or (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #include "vformula.h"
 
@@ -69,22 +65,28 @@
 //VFormula
 //---------------------------------------------------------------------------------------------------------------------
 VFormula::VFormula()
-    :formula(QString()), value(tr("Error")), checkZero(true), data(nullptr), toolId(NULL_ID),
-      postfix(QString()), _error(true), dValue(0)
+    : m_formula(QString())
+    , m_valueStr(tr("Error"))
+    , m_checkZero(true)
+    , m_data(nullptr)
+    , m_toolId(NULL_ID)
+    , m_postfix(QString())
+    , m_error(true)
+    , m_value(0)
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
 VFormula::VFormula(const QString &formula, const VContainer *container)
-    : formula(qApp->translateVariables()->FormulaToUser(formula, qApp->Settings()->getOsSeparator())),
-      value(tr("Error")),
-      checkZero(true),
-      data(container),
-      toolId(NULL_ID),
-      postfix(QString()),
-      _error(true),
-      dValue(0)
+    : m_formula(qApp->translateVariables()->FormulaToUser(formula, qApp->Settings()->getOsSeparator()))
+    , m_valueStr(tr("Error"))
+    , m_checkZero(true)
+    , m_data(container)
+    , m_toolId(NULL_ID)
+    , m_postfix(QString())
+    , m_error(true)
+    , m_value(0)
 {
-    this->formula.replace("\n", " ");// Replace line return with spaces for calc if exist
+    m_formula.replace("\n", " ");// Replace line return with spaces for calc if exist
     Eval();
 }
 
@@ -95,32 +97,37 @@ VFormula &VFormula::operator=(const VFormula &formula)
     {
         return *this;
     }
-    this->formula = formula.GetFormula();
-    this->value = formula.getStringValue();
-    this->checkZero = formula.getCheckZero();
-    this->data = formula.getData();
-    this->toolId = formula.getToolId();
-    this->postfix = formula.getPostfix();
-    this->_error = formula.error();
-    this->dValue = formula.getDoubleValue();
+    m_formula   = formula.GetFormula();
+    m_valueStr  = formula.getStringValue();
+    m_checkZero = formula.getCheckZero();
+    m_data      = formula.getData();
+    m_toolId    = formula.getToolId();
+    m_postfix   = formula.getPostfix();
+    m_error     = formula.error();
+    m_value     = formula.getDoubleValue();
     return *this;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 VFormula::VFormula(const VFormula &formula)
-    :formula(formula.GetFormula()), value(formula.getStringValue()), checkZero(formula.getCheckZero()),
-      data(formula.getData()), toolId(formula.getToolId()), postfix(formula.getPostfix()), _error(formula.error()),
-      dValue(formula.getDoubleValue())
+    : m_formula(formula.GetFormula())
+    , m_valueStr(formula.getStringValue())
+    , m_checkZero(formula.getCheckZero())
+    , m_data(formula.getData())
+    , m_toolId(formula.getToolId())
+    , m_postfix(formula.getPostfix())
+    , m_error(formula.error())
+    , m_value(formula.getDoubleValue())
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
 bool VFormula::operator==(const VFormula &formula) const
 {
     bool isEqual = false;
-    if (this->formula == formula.GetFormula() && this->value == formula.getStringValue() &&
-        this->checkZero == formula.getCheckZero() && this->data == formula.getData() &&
-        this->toolId == formula.getToolId() && this->postfix == formula.getPostfix() &&
-        this->_error == formula.error() && VFuzzyComparePossibleNulls(this->dValue, formula.getDoubleValue()))
+    if (m_formula == formula.GetFormula() && m_valueStr == formula.getStringValue() &&
+        m_checkZero == formula.getCheckZero() && m_data == formula.getData() &&
+        m_toolId == formula.getToolId() && m_postfix == formula.getPostfix() &&
+        m_error == formula.error() && VFuzzyComparePossibleNulls(m_value, formula.getDoubleValue()))
     {
         isEqual = true;
     }
@@ -137,28 +144,28 @@ QString VFormula::GetFormula(FormulaType type) const
 {
     if (type == FormulaType::ToUser)
     {
-        return formula;
+        return m_formula;
     }
     else
     {
-        return qApp->translateVariables()->TryFormulaFromUser(formula, qApp->Settings()->getOsSeparator());
+        return qApp->translateVariables()->TryFormulaFromUser(m_formula, qApp->Settings()->getOsSeparator());
     }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VFormula::SetFormula(const QString &value, FormulaType type)
+void VFormula::SetFormula(const QString &text, FormulaType type)
 {
-    if (formula != value)
+    if (m_formula != text)
     {
         if (type == FormulaType::ToUser)
         {
-            formula = qApp->translateVariables()->FormulaToUser(value, qApp->Settings()->getOsSeparator());
+            m_formula = qApp->translateVariables()->FormulaToUser(text, qApp->Settings()->getOsSeparator());
         }
         else
         {
-            formula = value;
+            m_formula = text;
         }
-        formula.replace("\n", " ");// Replace line return with spaces for calc if exist
+        m_formula.replace("\n", " ");// Replace line return with spaces for calc if exist
         Eval();
     }
 }
@@ -166,27 +173,27 @@ void VFormula::SetFormula(const QString &value, FormulaType type)
 //---------------------------------------------------------------------------------------------------------------------
 QString VFormula::getStringValue() const
 {
-    return value;
+    return m_valueStr;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 qreal VFormula::getDoubleValue() const
 {
-    return dValue;
+    return m_value;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 bool VFormula::getCheckZero() const
 {
-    return checkZero;
+    return m_checkZero;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void VFormula::setCheckZero(bool value)
 {
-    if (checkZero != value)
+    if (m_checkZero != value)
     {
-        checkZero = value;
+        m_checkZero = value;
         Eval();
     }
 }
@@ -194,15 +201,15 @@ void VFormula::setCheckZero(bool value)
 //---------------------------------------------------------------------------------------------------------------------
 const VContainer *VFormula::getData() const
 {
-    return data;
+    return m_data;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void VFormula::setData(const VContainer *value)
 {
-    if (data != value && value != nullptr)
+    if (m_data != value && value != nullptr)
     {
-        data = value;
+        m_data = value;
         Eval();
     }
 }
@@ -210,27 +217,27 @@ void VFormula::setData(const VContainer *value)
 //---------------------------------------------------------------------------------------------------------------------
 quint32 VFormula::getToolId() const
 {
-    return toolId;
+    return m_toolId;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void VFormula::setToolId(const quint32 &value)
 {
-    toolId = value;
+    m_toolId = value;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 QString VFormula::getPostfix() const
 {
-    return postfix;
+    return m_postfix;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VFormula::setPostfix(const QString &value)
+void VFormula::setPostfix(const QString &text)
 {
-    if (postfix != value)
+    if (m_postfix != text)
     {
-        postfix = value;
+        m_postfix = text;
         Eval();
     }
 }
@@ -238,7 +245,7 @@ void VFormula::setPostfix(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 bool VFormula::error() const
 {
-    return _error;
+    return m_error;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -250,64 +257,56 @@ int VFormula::FormulaTypeId()
 //---------------------------------------------------------------------------------------------------------------------
 void VFormula::Eval()
 {
-    if (data == nullptr)
+    if (m_data == nullptr)
     {
         return;
     }
-    if (formula.isEmpty())
+    if (m_formula.isEmpty())
     {
-        value = tr("Error");
-        _error = true;
-        dValue = 0;
+        m_valueStr = tr("Error");
+        m_error = true;
+        m_value = 0;
     }
     else
     {
         try
         {
             QScopedPointer<Calculator> cal(new Calculator());
-            QString expression = qApp->translateVariables()->FormulaFromUser(formula, qApp->Settings()->getOsSeparator());
-            qreal result = cal->EvalFormula(data->DataVariables(), expression);
+            QString expression = qApp->translateVariables()->FormulaFromUser(m_formula, qApp->Settings()->getOsSeparator());
+            qreal result = cal->EvalFormula(m_data->DataVariables(), expression);
 
             if (qIsInf(result) || qIsNaN(result))
             {
-                value = tr("Error");
-                _error = true;
-                dValue = 0;
+                m_valueStr = tr("Error");
+                m_error = true;
+                m_value = 0;
             }
             else
             {
                 //if result equal 0
-                if (checkZero && qFuzzyIsNull(result))
+                if (m_checkZero && qFuzzyIsNull(result))
                 {
-                    value = QString("0");
-                    _error = true;
-                    dValue = 0;
+                    m_valueStr = QString("0");
+                    m_error = true;
+                    m_value = 0;
                 }
                 else
                 {
-                    if (postfix == degreeSymbol)
+                    if (m_postfix == degreeSymbol)
                     {
-                        qreal value = result - 360.0 * qFloor(result / 360.0);
-                        if (result != 0.0 && value == 360.0)
-                        {
-                            result = 360.0;
-                        }
-                        else
-                        {
-                            result = value;
-                        }
+                        result = normalize(result, 0.0, 360.0);
                     }
-                    dValue = result;
-                    value = QString(qApp->LocaleToString(result) + " " + postfix);
-                    _error = false;
+                    m_value = result;
+                    m_valueStr = QString(qApp->LocaleToString(result) + " " + m_postfix);
+                    m_error = false;
                 }
             }
         }
         catch (qmu::QmuParserError &error)
         {
-            value = tr("Error");
-            _error = true;
-            dValue = 0;
+            m_valueStr = tr("Error");
+            m_error = true;
+            m_value = 0;
             qDebug() << "\nMath parser error:\n"
                        << "--------------------------------------\n"
                        << "Message:     " << error.GetMsg()  << "\n"

--- a/src/libs/vpatterndb/vformula.cpp
+++ b/src/libs/vpatterndb/vformula.cpp
@@ -287,7 +287,15 @@ void VFormula::Eval()
                 {
                     if (postfix == degreeSymbol)
                     {
-                        result = result - 360.0 * qFloor(result / 360.0);
+                        qreal value = result - 360.0 * qFloor(result / 360.0);
+                        if (result != 0.0 && value == 360.0)
+                        {
+                            result = 360.0;
+                        }
+                        else
+                        {
+                            result = value;
+                        }
                     }
                     dValue = result;
                     value = QString(qApp->LocaleToString(result) + " " + postfix);

--- a/src/libs/vpatterndb/vformula.h
+++ b/src/libs/vpatterndb/vformula.h
@@ -1,53 +1,50 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+// @file   vformula.h
+// @author Douglas S Caskey
+// @date   14 May, 2026
+//
+// @copyright
+// Copyright (C) 2017 - 2026 Seamly, LLC
+// https://github.com/fashionfreedom/seamly2d
+//
+// @brief
+// Seamly2D is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Seamly2D is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
 
- ************************************************************************
- **
- **  @file   vformula.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   28 8, 2014
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//
+//  @file   vformula.h
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   28 Aug, 2014
+//
+//  @copyright
+//  Copyright (C) 2014 Valentina project.
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published
+//  by the Free Software Foundation, either version 3 of the License,
+//  or (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #ifndef VFORMULA_H
 #define VFORMULA_H
@@ -72,40 +69,38 @@ public:
     bool operator==(const VFormula &formula) const;
     bool operator!=(const VFormula &formula) const;
 
-    QString GetFormula(FormulaType type = FormulaType::ToUser) const;
-    void SetFormula(const QString &value, FormulaType type = FormulaType::ToUser);
+    QString           GetFormula(FormulaType type = FormulaType::ToUser) const;
+    void              SetFormula(const QString &text, FormulaType type = FormulaType::ToUser);
 
-    QString getStringValue() const;
-    qreal   getDoubleValue() const;
+    QString           getStringValue() const;
+    qreal             getDoubleValue() const;
 
-    bool getCheckZero() const;
-    void setCheckZero(bool value);
+    bool              getCheckZero() const;
+    void              setCheckZero(bool value);
 
     const VContainer *getData() const;
-    void setData(const VContainer *value);
+    void              setData(const VContainer *value);
 
-    quint32 getToolId() const;
-    void setToolId(const quint32 &value);
+    quint32           getToolId() const;
+    void              setToolId(const quint32 &value);
 
-    QString getPostfix() const;
-    void setPostfix(const QString &value);
+    QString           getPostfix() const;
+    void              setPostfix(const QString &text);
 
-    bool error() const;
+    bool              error() const;
 
-    static int FormulaTypeId();
-    void Eval();
-    
+    static int        FormulaTypeId();
+    void              Eval();
+
 private:
-    QString formula;
-    QString value;
-    bool checkZero;
-    const VContainer *data;
-    quint32 toolId;
-    QString postfix;
-    bool _error;
-    qreal dValue;
-
-
+    QString           m_formula;
+    QString           m_valueStr;
+    bool              m_checkZero;
+    const VContainer *m_data;
+    quint32           m_toolId;
+    QString           m_postfix;
+    bool              m_error;
+    qreal             m_value;
 };
 Q_DECLARE_METATYPE(VFormula)
 

--- a/src/libs/vtools/dialogs/tools/dialogtool.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogtool.cpp
@@ -80,6 +80,7 @@
 #include <QWidget>
 #include <Qt>
 #include <QtDebug>
+#include <QtMath>
 #include <new>
 #include <QBuffer>
 #include <QFont>
@@ -870,7 +871,7 @@ qreal DialogTool::Eval(const QString &text, bool &flag, QLabel *label, const QSt
                 {
                     if (postfix == degreeSymbol)
                     {
-                        result = normalize(result, 0, 360);
+                        result = normalize(result, 0.0, 360.0);
                     }
                     label->setText(qApp->LocaleToString(result) + " " +postfix);
                     flag = true;
@@ -902,11 +903,17 @@ qreal DialogTool::Eval(const QString &text, bool &flag, QLabel *label, const QSt
 // by assuming the range wraps around when going below min or above max
 qreal DialogTool::normalize( const qreal value, const qreal start, const qreal end )
 {
-  const qreal range       = end - start   ;   //
-  const qreal offsetValue = value - start ;   // value relative to 0
+    // check if value is evenly divisble by end value
+    if (qFabs(value) != start && std::fmod(qFabs(value), end) < 1e-9)
+    {
+        return end;
+    }
 
-  return ( offsetValue - ( floor( offsetValue / range ) * range ) ) + start ;
-  // + start to reset back to start of original range
+    const qreal range       = end - start   ;   //
+    const qreal offsetValue = value - start ;   // value relative to 0
+
+    // add start to reset back to start of original range
+    return ( offsetValue - ( floor( offsetValue / range ) * range ) ) + start ;
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogtool.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogtool.cpp
@@ -92,6 +92,7 @@
 #include "../vgeometry/vpointf.h"
 #include "../vgeometry/vabstractcurve.h"
 #include "../vgeometry/vgobject.h"
+#include "../vmisc/def.h"
 #include "../vmisc/vabstractapplication.h"
 #include "../vmisc/vcommonsettings.h"
 #include "../vpatterndb/calculator.h"
@@ -897,23 +898,6 @@ qreal DialogTool::Eval(const QString &text, bool &flag, QLabel *label, const QSt
     }
     CheckState(); // Disable Ok and Apply buttons if something wrong.
     return result;
-}
-
-// Normalizes any number to an arbitrary range
-// by assuming the range wraps around when going below min or above max
-qreal DialogTool::normalize( const qreal value, const qreal start, const qreal end )
-{
-    // check if value is evenly divisble by end value
-    if (qFabs(value) != start && std::fmod(qFabs(value), end) < 1e-9)
-    {
-        return end;
-    }
-
-    const qreal range       = end - start   ;   //
-    const qreal offsetValue = value - start ;   // value relative to 0
-
-    // add start to reset back to start of original range
-    return ( offsetValue - ( floor( offsetValue / range ) * range ) ) + start ;
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogtool.h
+++ b/src/libs/vtools/dialogs/tools/dialogtool.h
@@ -260,8 +260,6 @@ protected:
     qreal            Eval(const QString &text, bool &flag, QLabel *label, const QString &postfix,
                           bool checkZero = true, bool checkLessThanZero = false);
 
-    qreal            normalize(const qreal value, const qreal start, const qreal end) ;
-
     void             setCurrentPointId(QComboBox *box, const quint32 &value,
                                        FillComboBox rule = FillComboBox::NoChildren,
                                        const quint32 &ch1 = NULL_ID, const quint32 &ch2 = NULL_ID) const;

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp
@@ -171,8 +171,8 @@ VToolArc* VToolArc::Create(const quint32 _id, const quint32 &center, QString &ra
 
     calcRadius = qApp->toPixel(CheckFormula(_id, radius, data));
 
-    calcF1 = CheckFormula(_id, f1, data);
-    calcF2 = CheckFormula(_id, f2, data);
+    calcF1 = normalize(CheckFormula(_id, f1, data), 0.0, 360.0);
+    calcF2 = normalize(CheckFormula(_id, f2, data), 0.0, 360.0);
 
     const VPointF c = *data->GeometricObject<VPointF>(center);
     VArc *arc = new VArc(c, calcRadius, radius, calcF1, f1, calcF2, f2 );

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp
@@ -176,9 +176,9 @@ VToolEllipticalArc* VToolEllipticalArc::Create(const quint32 _id, const quint32 
     calcRadius1 = qApp->toPixel(CheckFormula(_id, radius1, data));
     calcRadius2 = qApp->toPixel(CheckFormula(_id, radius2, data));
 
-    calcF1 = CheckFormula(_id, f1, data);
-    calcF2 = CheckFormula(_id, f2, data);
-    calcRotationAngle = CheckFormula(_id, rotationAngle, data);
+    calcF1 = normalize(CheckFormula(_id, f1, data), 0.0, 360.0);
+    calcF2 = normalize(CheckFormula(_id, f2, data), 0.0, 360.0);
+    calcRotationAngle = normalize(CheckFormula(_id, rotationAngle, data), 0.0, 360.0);
 
     const VPointF c = *data->GeometricObject<VPointF>(center);
     VEllipticalArc *elArc = new VEllipticalArc(c, calcRadius1, calcRadius2, radius1, radius2, calcF1, f1, calcF2, f2,

--- a/src/libs/vtools/visualization/path/vistoolarc.cpp
+++ b/src/libs/vtools/visualization/path/vistoolarc.cpp
@@ -99,10 +99,12 @@ void VisToolArc::setRadius(const QString &expression)
 void VisToolArc::setF1(const QString &expression)
 {
     f1 = FindVal(expression, Visualization::data->DataVariables());
+    f1 = normalize(f1, 0.0, 360.0);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void VisToolArc::setF2(const QString &expression)
 {
     f2 = FindVal(expression, Visualization::data->DataVariables());
+    f2 = normalize(f2, 0.0, 360.0);
 }

--- a/src/libs/vtools/visualization/path/vistoolellipticalarc.cpp
+++ b/src/libs/vtools/visualization/path/vistoolellipticalarc.cpp
@@ -78,16 +78,19 @@ void VisToolEllipticalArc::setRadius2(const QString &expression)
 void VisToolEllipticalArc::setF1(const QString &expression)
 {
     f1 = FindVal(expression, Visualization::data->DataVariables());
+    f1 = normalize(f1, 0.0, 360.0);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void VisToolEllipticalArc::setF2(const QString &expression)
 {
     f2 = FindVal(expression, Visualization::data->DataVariables());
+    f2 = normalize(f2, 0.0, 360.0);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void VisToolEllipticalArc::setRotationAngle(const QString &expression)
 {
     rotationAngle = FindVal(expression, Visualization::data->DataVariables());
+    rotationAngle = normalize(rotationAngle, 0.0, 360.0);
 }


### PR DESCRIPTION
This PR fixes the normalize() angle routine which prevents the use of 360 degs in the Arc - Radius and Angles, and Arc - Elliptical tools. 

It should be noted that the (existing) normalize() routine is generic and can normalize any (real) value between a given start and end range. It's can be more useful than hardcoding a routine just to normalize an angle between 0 and 360. 

- Fixes the normalize() routine so that when the (end) angle = 360 it returns 360 and not 0 - which technically is the same angle, but doesn't work with the Arcs as the 2 angles can not be equal or would be no arc. For ex: an arc from 0 to 0 degrees would result in no arc. 
- Moves the normalize() routine to def.cpp so it can be used globally. 
- Additionally normalizes the angles in the Arc & Elliptical Arc tool and visual classes so these tools with normalized angles display properly.  
- Refactor the vformula cpp & h files with style changes. Mainly renaming the class members with the m_ prefix which besides standardizing the code, eliminates the need for the use of this->. 

closes issue #1571 