### PR TITLE
ci: pin to macos-15 to avoid breaking in June

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
 
   macos:
     name: 'macOS: Build'
-    runs-on: macos-26
+    runs-on: macos-15  # pin to macos-15 due to https://qt-project.atlassian.net/browse/QTBUG-137687
     needs: version
     env:
       VERSION_NUMBER: ${{ needs.version.outputs.version_number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
 
   macos:
     name: 'macOS: Build'
-    runs-on: macos-latest
+    runs-on: macos-26
     needs: version
     env:
       VERSION_NUMBER: ${{ needs.version.outputs.version_number }}

--- a/.github/workflows/feat-ci.yml
+++ b/.github/workflows/feat-ci.yml
@@ -124,7 +124,7 @@ jobs:
 
   macos:
     name: 'macOS: Build'
-    runs-on: macos-latest
+    runs-on: macos-15  # pin to macos-15 due to https://qt-project.atlassian.net/browse/QTBUG-137687
     needs: version
     env:
       VERSION_NUMBER: ${{ needs.version.outputs.version_number }}


### PR DESCRIPTION
macos-26 becomes detault in June (https://github.com/actions/runner-images/issues/14167), but Qt 6.5.3 does not support building with it. See https://qt-project.atlassian.net/browse/QTBUG-137687