### PR TITLE
feat: Auto-Smooth (Hobby) and Curve Length for cubic Bézier curves

### DIFF
--- a/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
+++ b/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
@@ -2020,6 +2020,12 @@ void VToolOptionsPropertyBrowser::changeDataToolSpline(VPE::VProperty *property)
             tool->SetAutoSmooth(enumVal.toInt() == 1);
             break;
         }
+        case 64: // AttrLengthMode (not yet functional)
+        {
+            const QVariant enumVal = property->data(VPE::VProperty::DPC_Data, Qt::EditRole);
+            tool->SetLengthMode(enumVal.toInt());
+            break;
+        }
         default:
             qWarning() << "Unknown property type. id = "<<id;
             break;
@@ -2080,6 +2086,12 @@ void VToolOptionsPropertyBrowser::changeDataToolCubicBezier(VPE::VProperty *prop
         {
             const QVariant enumVal = property->data(VPE::VProperty::DPC_Data, Qt::EditRole);
             tool->SetAutoSmooth(enumVal.toInt() == 1);
+            break;
+        }
+        case 64: // AttrLengthMode (not yet functional)
+        {
+            const QVariant enumVal = property->data(VPE::VProperty::DPC_Data, Qt::EditRole);
+            tool->SetLengthMode(enumVal.toInt());
             break;
         }
         default:
@@ -2888,6 +2900,8 @@ void VToolOptionsPropertyBrowser::showOptionsToolSpline(QGraphicsItem *item)
     addPropertyLabel(tr("Options"), AttrName);
     addPropertyEnum(tr("Smooth curve:"), {tr("No"), tr("Yes")},
                     tool->GetAutoSmooth() ? 1 : 0, AttrAutoSmooth);
+    addPropertyEnum(tr("Adjust length:"), {tr("Off"), tr("Start"), tr("End"), tr("Both")},
+                    tool->GetLengthMode(), AttrLengthMode);
 
     VFormula curveLen(tool->GetTargetLength(), tool->getData());
     curveLen.setCheckZero(false);
@@ -2919,6 +2933,8 @@ void VToolOptionsPropertyBrowser::showOptionsToolCubicBezier(QGraphicsItem *item
     addPropertyLabel(tr("Options"), AttrName);
     addPropertyEnum(tr("Smooth curve:"), {tr("No"), tr("Yes")},
                     tool->GetAutoSmooth() ? 1 : 0, AttrAutoSmooth);
+    addPropertyEnum(tr("Adjust length:"), {tr("Off"), tr("Start"), tr("End"), tr("Both")},
+                    tool->GetLengthMode(), AttrLengthMode);
 
     VFormula curveLen(tool->GetTargetLength(), tool->getData());
     curveLen.setCheckZero(false);
@@ -3881,6 +3897,11 @@ void VToolOptionsPropertyBrowser::updateOptionsToolSpline()
     {
         idToProperty[AttrAutoSmooth]->setValue(tool->GetAutoSmooth() ? 1 : 0);
     }
+
+    if (idToProperty.contains(AttrLengthMode))
+    {
+        idToProperty[AttrLengthMode]->setValue(tool->GetLengthMode());
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -3930,6 +3951,11 @@ void VToolOptionsPropertyBrowser::updateOptionsToolCubicBezier()
     if (idToProperty.contains(AttrAutoSmooth))
     {
         idToProperty[AttrAutoSmooth]->setValue(tool->GetAutoSmooth() ? 1 : 0);
+    }
+
+    if (idToProperty.contains(AttrLengthMode))
+    {
+        idToProperty[AttrLengthMode]->setValue(tool->GetLengthMode());
     }
 }
 
@@ -4280,6 +4306,7 @@ QStringList VToolOptionsPropertyBrowser::propertiesList() const
                                             << AttrLineWeight                     /* 60 */
                                             << AttrObjName                        /* 61 */
                                             << AttrDirection                      /* 62 */
-                                            << AttrAutoSmooth;                    /* 63 */
+                                            << AttrAutoSmooth                     /* 63 */
+                                            << AttrLengthMode;                    /* 64 */
     return attr;
 }

--- a/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
+++ b/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
@@ -2012,6 +2012,14 @@ void VToolOptionsPropertyBrowser::changeDataToolSpline(VPE::VProperty *property)
         case 60: // AttrLineWeight
             tool->setLineWeight(value.toString());
             break;
+        case 4: // AttrLength — curve length formula (not yet functional)
+            break;
+        case 63: // AttrAutoSmooth
+        {
+            const QVariant enumVal = property->data(VPE::VProperty::DPC_Data, Qt::EditRole);
+            tool->SetAutoSmooth(enumVal.toInt() == 1);
+            break;
+        }
         default:
             qWarning() << "Unknown property type. id = "<<id;
             break;
@@ -2066,6 +2074,14 @@ void VToolOptionsPropertyBrowser::changeDataToolCubicBezier(VPE::VProperty *prop
             spline.SetP4(point);
             tool->setSpline(spline);
             break;
+        case 4: // AttrLength — curve length formula (not yet functional)
+            break;
+        case 63: // AttrAutoSmooth
+        {
+            const QVariant enumVal = property->data(VPE::VProperty::DPC_Data, Qt::EditRole);
+            tool->SetAutoSmooth(enumVal.toInt() == 1);
+            break;
+        }
         default:
             qWarning() << "Unknown property type. id = "<<id;
             break;
@@ -3860,6 +3876,11 @@ void VToolOptionsPropertyBrowser::updateOptionsToolSpline()
         const qint32 index = VPE::LineWeightProperty::indexOfLineWeight(lineWeightList(), tool->getLineWeight());
         idToProperty[AttrLineWeight]->setValue(index);
     }
+
+    if (idToProperty.contains(AttrAutoSmooth))
+    {
+        idToProperty[AttrAutoSmooth]->setValue(tool->GetAutoSmooth() ? 1 : 0);
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -3904,6 +3925,11 @@ void VToolOptionsPropertyBrowser::updateOptionsToolCubicBezier()
         const qint32 index = VPE::VObjectProperty::indexOfObject(getObjectList(tool, GOType::Point),
                                                                                spl.GetP4().name());
         idToProperty[AttrPoint4]->setValue(index);
+    }
+
+    if (idToProperty.contains(AttrAutoSmooth))
+    {
+        idToProperty[AttrAutoSmooth]->setValue(tool->GetAutoSmooth() ? 1 : 0);
     }
 }
 

--- a/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
+++ b/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
@@ -2012,8 +2012,26 @@ void VToolOptionsPropertyBrowser::changeDataToolSpline(VPE::VProperty *property)
         case 60: // AttrLineWeight
             tool->setLineWeight(value.toString());
             break;
-        case 4: // AttrLength — curve length formula (not yet functional)
+        case 4: // AttrLength — curve length formula
+        {
+            const VFormula f = value.value<VFormula>();
+            if (!f.error())
+            {
+                // Raise the mode BEFORE persisting the length. The length attribute is
+                // only written when lengthMode > 0, and each setter triggers a LiteParse
+                // round-trip that would otherwise reset m_targetLength back to empty.
+                if (tool->GetLengthMode() == 0)
+                {
+                    tool->SetLengthMode(3);
+                    if (idToProperty.contains(AttrLengthMode))
+                    {
+                        idToProperty[AttrLengthMode]->setValue(3);
+                    }
+                }
+                tool->SetTargetLength(f.GetFormula(FormulaType::FromUser));
+            }
             break;
+        }
         case 63: // AttrAutoSmooth
         {
             const QVariant enumVal = property->data(VPE::VProperty::DPC_Data, Qt::EditRole);
@@ -2080,8 +2098,26 @@ void VToolOptionsPropertyBrowser::changeDataToolCubicBezier(VPE::VProperty *prop
             spline.SetP4(point);
             tool->setSpline(spline);
             break;
-        case 4: // AttrLength — curve length formula (not yet functional)
+        case 4: // AttrLength — curve length formula
+        {
+            const VFormula f = value.value<VFormula>();
+            if (!f.error())
+            {
+                // Raise the mode BEFORE persisting the length. The length attribute is
+                // only written when lengthMode > 0, and each setter triggers a LiteParse
+                // round-trip that would otherwise reset m_targetLength back to empty.
+                if (tool->GetLengthMode() == 0)
+                {
+                    tool->SetLengthMode(3);
+                    if (idToProperty.contains(AttrLengthMode))
+                    {
+                        idToProperty[AttrLengthMode]->setValue(3);
+                    }
+                }
+                tool->SetTargetLength(f.GetFormula(FormulaType::FromUser));
+            }
             break;
+        }
         case 63: // AttrAutoSmooth
         {
             const QVariant enumVal = property->data(VPE::VProperty::DPC_Data, Qt::EditRole);

--- a/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
+++ b/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
@@ -640,6 +640,16 @@ void VToolOptionsPropertyBrowser::addPropertyLabel(const QString &propertyName, 
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+void VToolOptionsPropertyBrowser::addPropertyEnum(const QString &propertyName, const QStringList &options,
+                                                   int currentIndex, const QString &propertyAttribute)
+{
+    VPE::VEnumProperty *property = new VPE::VEnumProperty(propertyName);
+    property->setLiterals(options);
+    property->setValue(currentIndex);
+    addProperty(property, propertyAttribute);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 template<class Tool>
 void VToolOptionsPropertyBrowser::addPropertyCrossPoint(Tool *tool, const QString &propertyName)
 {
@@ -2859,6 +2869,16 @@ void VToolOptionsPropertyBrowser::showOptionsToolSpline(QGraphicsItem *item)
     angle2.setPostfix(degreeSymbol);
     addPropertyFormula(tr("C2: angle:"), angle2, AttrAngle2);
 
+    addPropertyLabel(tr("Options"), AttrName);
+    addPropertyEnum(tr("Smooth curve:"), {tr("No"), tr("Yes")},
+                    tool->GetAutoSmooth() ? 1 : 0, AttrAutoSmooth);
+
+    VFormula curveLen(tool->GetTargetLength(), tool->getData());
+    curveLen.setCheckZero(false);
+    curveLen.setToolId(tool->getId());
+    curveLen.setPostfix(UnitsToStr(qApp->patternUnit()));
+    addPropertyFormula(tr("Curve length:"), curveLen, AttrLength);
+
     addPropertyLabel(tr("Attributes"), AttrName);
     addPropertyLineColor(tool, tr("Color:"), AttrColor);
     addPropertyCurveLineType(tool, tr("Linetype:"));
@@ -2879,6 +2899,16 @@ void VToolOptionsPropertyBrowser::showOptionsToolCubicBezier(QGraphicsItem *item
     addObjectProperty(tool, spl.GetP2().name(), tr("Second point:"), AttrPoint2, GOType::Point);
     addObjectProperty(tool, spl.GetP3().name(), tr("Third point:"),  AttrPoint3, GOType::Point);
     addObjectProperty(tool, spl.GetP4().name(), tr("Fourth point:"), AttrPoint4, GOType::Point);
+
+    addPropertyLabel(tr("Options"), AttrName);
+    addPropertyEnum(tr("Smooth curve:"), {tr("No"), tr("Yes")},
+                    tool->GetAutoSmooth() ? 1 : 0, AttrAutoSmooth);
+
+    VFormula curveLen(tool->GetTargetLength(), tool->getData());
+    curveLen.setCheckZero(false);
+    curveLen.setToolId(tool->getId());
+    curveLen.setPostfix(UnitsToStr(qApp->patternUnit()));
+    addPropertyFormula(tr("Curve length:"), curveLen, AttrLength);
 
     addPropertyLabel(tr("Attributes"), AttrName);
     addPropertyLineColor(tool, tr("Color:"), AttrColor);
@@ -4223,6 +4253,7 @@ QStringList VToolOptionsPropertyBrowser::propertiesList() const
                                             << AttrPenStyle                       /* 59 */
                                             << AttrLineWeight                     /* 60 */
                                             << AttrObjName                        /* 61 */
-                                            << AttrDirection;                     /* 62 */
+                                            << AttrDirection                      /* 62 */
+                                            << AttrAutoSmooth;                    /* 63 */
     return attr;
 }

--- a/src/app/seamly2d/core/vtooloptionspropertybrowser.h
+++ b/src/app/seamly2d/core/vtooloptionspropertybrowser.h
@@ -186,6 +186,8 @@ private:
                                     const QString &propertyAttribute);
 
     void addPropertyLabel(const QString &propertyName, const QString &propertyAttribute);
+    void addPropertyEnum(const QString &propertyName, const QStringList &options,
+                         int currentIndex, const QString &propertyAttribute);
 
     QStringList propertiesList() const;
 

--- a/src/app/seamly2d/xml/vpattern.cpp
+++ b/src/app/seamly2d/xml/vpattern.cpp
@@ -2528,8 +2528,10 @@ void VPattern::ParseToolCubicBezier(VMainGraphicsScene *scene, const QDomElement
         spline->setLineWeight(lineWeight);
 
         const bool autoSmooth = (domElement.attribute(AttrAutoSmooth) == QStringLiteral("true"));
+        const int lengthMode = domElement.attribute(AttrLengthMode, QStringLiteral("0")).toInt();
+        const QString targetLength = domElement.attribute(AttrLength, QString());
 
-        VToolCubicBezier::Create(id, spline, autoSmooth, scene, this, data, parse, Source::FromFile);
+        VToolCubicBezier::Create(id, spline, autoSmooth, lengthMode, targetLength, scene, this, data, parse, Source::FromFile);
     }
     catch (const VExceptionBadId &error)
     {

--- a/src/app/seamly2d/xml/vpattern.cpp
+++ b/src/app/seamly2d/xml/vpattern.cpp
@@ -2454,8 +2454,11 @@ void VPattern::ParseToolSpline(VMainGraphicsScene *scene, QDomElement &domElemen
         const QString lineWeight = GetParametrString(domElement, AttrLineWeight, DefaultLineWeight);
         const quint32 duplicate  = GetParametrUInt(domElement,   AttrDuplicate,  "0");
 
+        const bool autoSmooth = (domElement.attribute(AttrAutoSmooth) == QStringLiteral("true"));
+
         VToolSpline *spl = VToolSpline::Create(id, point1, point4, a1, a2, l1, l2, duplicate, color, penStyle,
-                                               lineWeight, scene, this, data, parse, Source::FromFile);
+                                               lineWeight, scene, this, data, parse, Source::FromFile,
+                                               autoSmooth);
 
         if (spl != nullptr)
         {
@@ -2524,7 +2527,9 @@ void VPattern::ParseToolCubicBezier(VMainGraphicsScene *scene, const QDomElement
         spline->SetPenStyle(penStyle);
         spline->setLineWeight(lineWeight);
 
-        VToolCubicBezier::Create(id, spline, scene, this, data, parse, Source::FromFile);
+        const bool autoSmooth = (domElement.attribute(AttrAutoSmooth) == QStringLiteral("true"));
+
+        VToolCubicBezier::Create(id, spline, autoSmooth, scene, this, data, parse, Source::FromFile);
     }
     catch (const VExceptionBadId &error)
     {

--- a/src/app/seamly2d/xml/vpattern.cpp
+++ b/src/app/seamly2d/xml/vpattern.cpp
@@ -2455,10 +2455,12 @@ void VPattern::ParseToolSpline(VMainGraphicsScene *scene, QDomElement &domElemen
         const quint32 duplicate  = GetParametrUInt(domElement,   AttrDuplicate,  "0");
 
         const bool autoSmooth = (domElement.attribute(AttrAutoSmooth) == QStringLiteral("true"));
+        const int lengthMode = domElement.attribute(AttrLengthMode, QStringLiteral("0")).toInt();
+        const QString targetLength = domElement.attribute(AttrLength, QString());
 
         VToolSpline *spl = VToolSpline::Create(id, point1, point4, a1, a2, l1, l2, duplicate, color, penStyle,
                                                lineWeight, scene, this, data, parse, Source::FromFile,
-                                               autoSmooth);
+                                               autoSmooth, lengthMode, targetLength);
 
         if (spl != nullptr)
         {

--- a/src/libs/ifc/ifcdef.cpp
+++ b/src/libs/ifc/ifcdef.cpp
@@ -109,6 +109,7 @@ const QString AttrAngle1      = QStringLiteral("angle1");
 const QString AttrAngle2      = QStringLiteral("angle2");
 const QString AttrLength1     = QStringLiteral("length1");
 const QString AttrLength2     = QStringLiteral("length2");
+const QString AttrAutoSmooth  = QStringLiteral("autoSmooth");
 const QString AttrP1Line      = QStringLiteral("p1Line");
 const QString AttrP2Line      = QStringLiteral("p2Line");
 const QString AttrP1Line1     = QStringLiteral("p1Line1");

--- a/src/libs/ifc/ifcdef.cpp
+++ b/src/libs/ifc/ifcdef.cpp
@@ -110,6 +110,7 @@ const QString AttrAngle2      = QStringLiteral("angle2");
 const QString AttrLength1     = QStringLiteral("length1");
 const QString AttrLength2     = QStringLiteral("length2");
 const QString AttrAutoSmooth  = QStringLiteral("autoSmooth");
+const QString AttrLengthMode  = QStringLiteral("lengthMode");
 const QString AttrP1Line      = QStringLiteral("p1Line");
 const QString AttrP2Line      = QStringLiteral("p2Line");
 const QString AttrP1Line1     = QStringLiteral("p1Line1");

--- a/src/libs/ifc/ifcdef.h
+++ b/src/libs/ifc/ifcdef.h
@@ -130,6 +130,7 @@ extern const QString AttrRotationAngle;
 extern const QString AttrLength1;
 extern const QString AttrLength2;
 extern const QString AttrAutoSmooth;
+extern const QString AttrLengthMode;
 extern const QString AttrP1Line;
 extern const QString AttrP2Line;
 extern const QString AttrP1Line1;

--- a/src/libs/ifc/ifcdef.h
+++ b/src/libs/ifc/ifcdef.h
@@ -129,6 +129,7 @@ extern const QString AttrAngle2;
 extern const QString AttrRotationAngle;
 extern const QString AttrLength1;
 extern const QString AttrLength2;
+extern const QString AttrAutoSmooth;
 extern const QString AttrP1Line;
 extern const QString AttrP2Line;
 extern const QString AttrP1Line1;

--- a/src/libs/ifc/schema.qrc
+++ b/src/libs/ifc/schema.qrc
@@ -62,5 +62,6 @@
         <file>schema/pattern/v0.7.1.xsd</file>
         <file>schema/pattern/v0.7.2.xsd</file>
         <file>schema/pattern/v0.7.3.xsd</file>
+        <file>schema/pattern/v0.7.4.xsd</file>
     </qresource>
 </RCC>

--- a/src/libs/ifc/schema/pattern/v0.7.4.xsd
+++ b/src/libs/ifc/schema/pattern/v0.7.4.xsd
@@ -321,6 +321,7 @@
                           <xs:attribute name="lineWeight" type="lineWeights"/>
                           <xs:attribute name="duplicate" type="xs:unsignedInt"/>
                           <xs:attribute name="autoSmooth" type="xs:boolean"/>
+                          <xs:attribute name="lengthMode" type="xs:unsignedInt"/>
                         </xs:complexType>
                       </xs:element>
                     </xs:choice>

--- a/src/libs/ifc/schema/pattern/v0.7.4.xsd
+++ b/src/libs/ifc/schema/pattern/v0.7.4.xsd
@@ -1,0 +1,1049 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+  <!-- XML Schema Generated from XML Document-->
+  <xs:element name="pattern">
+    <xs:complexType>
+      <xs:sequence minOccurs="1" maxOccurs="unbounded">
+        <xs:element name="version" type="formatVersion"/>
+        <xs:element name="unit" type="units"/>
+        <xs:element name="image" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string">
+                <xs:attribute name="extension" type="imageExtension"/>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="notes" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="gradation" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="heights">
+                <xs:complexType>
+                  <xs:attribute name="all" type="xs:boolean" use="required"/>
+                  <xs:attribute name="h50" type="xs:boolean"/>
+                  <xs:attribute name="h56" type="xs:boolean"/>
+                  <xs:attribute name="h62" type="xs:boolean"/>
+                  <xs:attribute name="h68" type="xs:boolean"/>
+                  <xs:attribute name="h74" type="xs:boolean"/>
+                  <xs:attribute name="h80" type="xs:boolean"/>
+                  <xs:attribute name="h86" type="xs:boolean"/>
+                  <xs:attribute name="h92" type="xs:boolean"/>
+                  <xs:attribute name="h98" type="xs:boolean"/>
+                  <xs:attribute name="h104" type="xs:boolean"/>
+                  <xs:attribute name="h110" type="xs:boolean"/>
+                  <xs:attribute name="h116" type="xs:boolean"/>
+                  <xs:attribute name="h122" type="xs:boolean"/>
+                  <xs:attribute name="h128" type="xs:boolean"/>
+                  <xs:attribute name="h134" type="xs:boolean"/>
+                  <xs:attribute name="h140" type="xs:boolean"/>
+                  <xs:attribute name="h146" type="xs:boolean"/>
+                  <xs:attribute name="h152" type="xs:boolean"/>
+                  <xs:attribute name="h158" type="xs:boolean"/>
+                  <xs:attribute name="h164" type="xs:boolean"/>
+                  <xs:attribute name="h170" type="xs:boolean"/>
+                  <xs:attribute name="h176" type="xs:boolean"/>
+                  <xs:attribute name="h182" type="xs:boolean"/>
+                  <xs:attribute name="h188" type="xs:boolean"/>
+                  <xs:attribute name="h194" type="xs:boolean"/>
+                  <xs:attribute name="h200" type="xs:boolean"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="sizes">
+                <xs:complexType>
+                  <xs:attribute name="all" type="xs:boolean" use="required"/>
+                  <xs:attribute name="s22" type="xs:boolean"/>
+                  <xs:attribute name="s24" type="xs:boolean"/>
+                  <xs:attribute name="s26" type="xs:boolean"/>
+                  <xs:attribute name="s28" type="xs:boolean"/>
+                  <xs:attribute name="s30" type="xs:boolean"/>
+                  <xs:attribute name="s32" type="xs:boolean"/>
+                  <xs:attribute name="s34" type="xs:boolean"/>
+                  <xs:attribute name="s36" type="xs:boolean"/>
+                  <xs:attribute name="s38" type="xs:boolean"/>
+                  <xs:attribute name="s40" type="xs:boolean"/>
+                  <xs:attribute name="s42" type="xs:boolean"/>
+                  <xs:attribute name="s44" type="xs:boolean"/>
+                  <xs:attribute name="s46" type="xs:boolean"/>
+                  <xs:attribute name="s48" type="xs:boolean"/>
+                  <xs:attribute name="s50" type="xs:boolean"/>
+                  <xs:attribute name="s52" type="xs:boolean"/>
+                  <xs:attribute name="s54" type="xs:boolean"/>
+                  <xs:attribute name="s56" type="xs:boolean"/>
+                  <xs:attribute name="s58" type="xs:boolean"/>
+                  <xs:attribute name="s60" type="xs:boolean"/>
+                  <xs:attribute name="s62" type="xs:boolean"/>
+                  <xs:attribute name="s64" type="xs:boolean"/>
+                  <xs:attribute name="s66" type="xs:boolean"/>
+                  <xs:attribute name="s68" type="xs:boolean"/>
+                  <xs:attribute name="s70" type="xs:boolean"/>
+                  <xs:attribute name="s72" type="xs:boolean"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="custom" type="xs:boolean"/>
+            <xs:attribute name="defHeight" type="baseHeight"/>
+            <xs:attribute name="defSize" type="baseSize"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="patternName" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="patternNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="company" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="customer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="patternLabel" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="line" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:attribute name="text" type="xs:string" use="required"/>
+                  <xs:attribute name="bold" type="xs:boolean"/>
+                  <xs:attribute name="italic" type="xs:boolean"/>
+                  <xs:attribute name="alignment" type="alignmentType"/>
+                  <xs:attribute name="sfIncrement" type="xs:unsignedInt"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="dateFormat" type="xs:string"/>
+            <xs:attribute name="timeFormat" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="measurements" type="xs:string"/>
+        <xs:element name="variables" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+              <xs:element name="variable" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:attribute name="description" type="xs:string" use="required"/>
+                  <xs:attribute name="name" type="shortName" use="required"/>
+                  <xs:attribute name="formula" type="xs:string" use="required"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+          <xs:unique name="variableName">
+            <xs:selector xpath="variable"/>
+            <xs:field xpath="@name"/>
+          </xs:unique>
+        </xs:element>
+        <xs:element name="draftBlock" minOccurs="1" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="calculation" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                      <xs:element name="point" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="x" type="xs:double"/>
+                          <xs:attribute name="y" type="xs:double"/>
+                          <xs:attribute name="mx" type="xs:double"/>
+                          <xs:attribute name="my" type="xs:double"/>
+                          <xs:attribute name="type" type="xs:string"/>
+                          <xs:attribute name="name" type="shortName"/>
+                          <xs:attribute name="firstPoint" type="xs:unsignedInt"/>
+                          <xs:attribute name="secondPoint" type="xs:unsignedInt"/>
+                          <xs:attribute name="thirdPoint" type="xs:unsignedInt"/>
+                          <xs:attribute name="basePoint" type="xs:unsignedInt"/>
+                          <xs:attribute name="pShoulder" type="xs:unsignedInt"/>
+                          <xs:attribute name="p1Line" type="xs:unsignedInt"/>
+                          <xs:attribute name="p2Line" type="xs:unsignedInt"/>
+                          <xs:attribute name="length" type="xs:string"/>
+                          <xs:attribute name="angle" type="xs:string"/>
+                          <xs:attribute name="lineType" type="linePenStyle"/>
+                          <xs:attribute name="lineWeight" type="lineWeights"/>
+                          <xs:attribute name="splinePath" type="xs:unsignedInt"/>
+                          <xs:attribute name="spline" type="xs:unsignedInt"/>
+                          <xs:attribute name="p1Line1" type="xs:unsignedInt"/>
+                          <xs:attribute name="p1Line2" type="xs:unsignedInt"/>
+                          <xs:attribute name="p2Line1" type="xs:unsignedInt"/>
+                          <xs:attribute name="p2Line2" type="xs:unsignedInt"/>
+                          <xs:attribute name="center" type="xs:unsignedInt"/>
+                          <xs:attribute name="radius" type="xs:string"/>
+                          <xs:attribute name="axisP1" type="xs:unsignedInt"/>
+                          <xs:attribute name="axisP2" type="xs:unsignedInt"/>
+                          <xs:attribute name="arc" type="xs:unsignedInt"/>
+                          <xs:attribute name="elArc" type="xs:unsignedInt"/>
+                          <xs:attribute name="curve" type="xs:unsignedInt"/>
+                          <xs:attribute name="curve1" type="xs:unsignedInt"/>
+                          <xs:attribute name="curve2" type="xs:unsignedInt"/>
+                          <xs:attribute name="lineColor" type="colors"/>
+                          <xs:attribute name="color" type="colors"/>
+                          <xs:attribute name="firstArc" type="xs:unsignedInt"/>
+                          <xs:attribute name="secondArc" type="xs:unsignedInt"/>
+                          <xs:attribute name="crossPoint" type="crossType"/>
+                          <xs:attribute name="vCrossPoint" type="crossType"/>
+                          <xs:attribute name="hCrossPoint" type="crossType"/>
+                          <xs:attribute name="c1Center" type="xs:unsignedInt"/>
+                          <xs:attribute name="c2Center" type="xs:unsignedInt"/>
+                          <xs:attribute name="c1Radius" type="xs:string"/>
+                          <xs:attribute name="c2Radius" type="xs:string"/>
+                          <xs:attribute name="cRadius" type="xs:string"/>
+                          <xs:attribute name="tangent" type="xs:unsignedInt"/>
+                          <xs:attribute name="cCenter" type="xs:unsignedInt"/>
+                          <xs:attribute name="name1" type="shortName"/>
+                          <xs:attribute name="mx1" type="xs:double"/>
+                          <xs:attribute name="my1" type="xs:double"/>
+                          <xs:attribute name="name2" type="shortName"/>
+                          <xs:attribute name="mx2" type="xs:double"/>
+                          <xs:attribute name="my2" type="xs:double"/>
+                          <xs:attribute name="point1" type="xs:unsignedInt"/>
+                          <xs:attribute name="point2" type="xs:unsignedInt"/>
+                          <xs:attribute name="dartP1" type="xs:unsignedInt"/>
+                          <xs:attribute name="dartP2" type="xs:unsignedInt"/>
+                          <xs:attribute name="dartP3" type="xs:unsignedInt"/>
+                          <xs:attribute name="baseLineP1" type="xs:unsignedInt"/>
+                          <xs:attribute name="baseLineP2" type="xs:unsignedInt"/>
+                          <xs:attribute name="showPointName" type="xs:boolean"/>
+                          <xs:attribute name="showPointName1" type="xs:boolean"/>
+                          <xs:attribute name="showPointName2" type="xs:boolean"/>
+                          <xs:attribute name="direction" type="directionType"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="line" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="firstPoint" type="xs:unsignedInt"/>
+                          <xs:attribute name="secondPoint" type="xs:unsignedInt"/>
+                          <xs:attribute name="lineType" type="linePenStyle"/>
+                          <xs:attribute name="lineWeight" type="lineWeights"/>
+                          <xs:attribute name="lineColor" type="colors"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="operation" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="source" minOccurs="1" maxOccurs="1">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="item" minOccurs="1" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                      <xs:attribute name="idObject" type="xs:unsignedInt" use="required"/>
+                                      <xs:attribute name="alias" type="xs:string"/>
+                                      <xs:attribute name="color" type="colors"/>
+                                      <xs:attribute name="lineType" type="linePenStyle"/>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+                            <xs:element name="destination" minOccurs="1" maxOccurs="1">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="item" minOccurs="1" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                      <xs:attribute name="idObject" type="xs:unsignedInt" use="required"/>
+                                      <xs:attribute name="mx" type="xs:double"/>
+                                      <xs:attribute name="my" type="xs:double"/>
+                                      <xs:attribute name="showPointName" type="xs:boolean"/>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:sequence>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="center" type="xs:unsignedInt"/>
+                          <xs:attribute name="angle" type="xs:string"/>
+                          <xs:attribute name="rotationAngle" type="xs:string"/>
+                          <xs:attribute name="length" type="xs:string"/>
+                          <xs:attribute name="suffix" type="xs:string"/>
+                          <xs:attribute name="type" type="xs:string" use="required"/>
+                          <xs:attribute name="p1Line" type="xs:unsignedInt"/>
+                          <xs:attribute name="p2Line" type="xs:unsignedInt"/>
+                          <xs:attribute name="axisType" type="axisType"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="arc" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:attribute name="angle1" type="xs:string"/>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="angle2" type="xs:string"/>
+                          <xs:attribute name="radius" type="xs:string"/>
+                          <xs:attribute name="center" type="xs:unsignedInt"/>
+                          <xs:attribute name="type" type="xs:string"/>
+                          <xs:attribute name="color" type="colors"/>
+                          <xs:attribute name="penStyle" type="curvePenStyle"/>
+                          <xs:attribute name="lineWeight" type="lineWeights"/>
+                          <xs:attribute name="length" type="xs:string"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="elArc" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:attribute name="angle1" type="xs:string"/>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="angle2" type="xs:string"/>
+                          <xs:attribute name="rotationAngle" type="xs:string"/>
+                          <xs:attribute name="radius1" type="xs:string"/>
+                          <xs:attribute name="radius2" type="xs:string"/>
+                          <xs:attribute name="center" type="xs:unsignedInt"/>
+                          <xs:attribute name="type" type="xs:string"/>
+                          <xs:attribute name="color" type="colors"/>
+                          <xs:attribute name="penStyle" type="curvePenStyle"/>
+                          <xs:attribute name="lineWeight" type="lineWeights"/>
+                          <xs:attribute name="length" type="xs:string"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="spline" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="pathPoint" minOccurs="0" maxOccurs="unbounded">
+                              <xs:complexType>
+                                <xs:attribute name="kAsm2" type="xs:string"/>
+                                <xs:attribute name="pSpline" type="xs:unsignedInt"/>
+                                <xs:attribute name="angle" type="xs:string"/>
+                                <xs:attribute name="angle1" type="xs:string"/>
+                                <xs:attribute name="angle2" type="xs:string"/>
+                                <xs:attribute name="length1" type="xs:string"/>
+                                <xs:attribute name="length2" type="xs:string"/>
+                                <xs:attribute name="kAsm1" type="xs:string"/>
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:sequence>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="kCurve" type="xs:double"/>
+                          <xs:attribute name="type" type="xs:string"/>
+                          <xs:attribute name="kAsm1" type="xs:double"/>
+                          <xs:attribute name="kAsm2" type="xs:double"/>
+                          <xs:attribute name="angle1" type="xs:string"/>
+                          <xs:attribute name="angle2" type="xs:string"/>
+                          <xs:attribute name="length" type="xs:string"/>
+                          <xs:attribute name="length1" type="xs:string"/>
+                          <xs:attribute name="length2" type="xs:string"/>
+                          <xs:attribute name="point1" type="xs:unsignedInt"/>
+                          <xs:attribute name="point2" type="xs:unsignedInt"/>
+                          <xs:attribute name="point3" type="xs:unsignedInt"/>
+                          <xs:attribute name="point4" type="xs:unsignedInt"/>
+                          <xs:attribute name="color" type="colors"/>
+                          <xs:attribute name="penStyle" type="curvePenStyle"/>
+                          <xs:attribute name="lineWeight" type="lineWeights"/>
+                          <xs:attribute name="duplicate" type="xs:unsignedInt"/>
+                          <xs:attribute name="autoSmooth" type="xs:boolean"/>
+                        </xs:complexType>
+                      </xs:element>
+                    </xs:choice>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="modeling" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                      <xs:element name="point" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="idObject" type="xs:unsignedInt"/>
+                          <xs:attribute name="mx" type="xs:double"/>
+                          <xs:attribute name="my" type="xs:double"/>
+                          <xs:attribute name="type" type="xs:string"/>
+                          <xs:attribute name="idTool" type="xs:unsignedInt"/>
+                          <xs:attribute name="inUse" type="xs:boolean"/>
+                          <xs:attribute name="showPointName" type="xs:boolean"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="arc" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="idObject" type="xs:unsignedInt"/>
+                          <xs:attribute name="type" type="xs:string"/>
+                          <xs:attribute name="idTool" type="xs:unsignedInt"/>
+                          <xs:attribute name="inUse" type="xs:boolean"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="elArc" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="idObject" type="xs:unsignedInt"/>
+                          <xs:attribute name="type" type="xs:string"/>
+                          <xs:attribute name="idTool" type="xs:unsignedInt"/>
+                          <xs:attribute name="inUse" type="xs:boolean"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="spline" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="idObject" type="xs:unsignedInt"/>
+                          <xs:attribute name="type" type="xs:string"/>
+                          <xs:attribute name="idTool" type="xs:unsignedInt"/>
+                          <xs:attribute name="inUse" type="xs:boolean"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="path" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="nodes" minOccurs="1" maxOccurs="1">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="node" minOccurs="1" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                      <xs:attribute name="type" type="xs:string" use="required"/>
+                                      <xs:attribute name="idObject" type="xs:unsignedInt" use="required"/>
+                                      <xs:attribute name="reverse" type="xs:unsignedInt"/>
+                                      <xs:attribute name="excluded" type="xs:boolean"/>
+                                      <xs:attribute name="before" type="xs:double"/>
+                                      <xs:attribute name="after" type="xs:double"/>
+                                      <xs:attribute name="angle" type="nodeAngle"/>
+                                      <xs:attribute name="notch" type="xs:boolean"/>
+                                      <xs:attribute name="notchType" type="notchTypes"/>
+                                      <xs:attribute name="notchSubtype" type="notchSubtypes"/>
+                                      <xs:attribute name="showNotch" type="xs:boolean"/>
+                                      <xs:attribute name="showSecondNotch" type="xs:boolean"/>
+                                      <xs:attribute name="notchAngle" type="xs:double"/>
+                                      <xs:attribute name="notchLength" type="xs:double"/>
+                                      <xs:attribute name="notchWidth" type="xs:double"/>
+                                      <xs:attribute name="notchCount" type="xs:unsignedInt"/>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:sequence>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="type" type="piecePathType"/>
+                          <xs:attribute name="idTool" type="xs:unsignedInt"/>
+                          <xs:attribute name="inUse" type="xs:boolean"/>
+                          <xs:attribute name="name" type="xs:string"/>
+                          <xs:attribute name="lineColor" type="colors"/>
+                          <xs:attribute name="lineType" type="curvePenStyle"/>
+                          <xs:attribute name="lineWeight" type="lineWeights"/>
+                          <xs:attribute name="cut" type="xs:boolean"/>
+                          <xs:attribute name="extendStartPoint" type="xs:boolean"/>
+                          <xs:attribute name="extendEndPoint" type="xs:boolean"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="tools" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="unionPiece" minOccurs="2" maxOccurs="2">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="nodes" minOccurs="1" maxOccurs="1">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="node" minOccurs="1" maxOccurs="unbounded">
+                                          <xs:complexType>
+                                            <xs:attribute name="type" type="xs:string" use="required"/>
+                                            <xs:attribute name="idObject" type="xs:unsignedInt" use="required"/>
+                                            <xs:attribute name="reverse" type="xs:unsignedInt"/>
+                                            <xs:attribute name="excluded" type="xs:boolean"/>
+                                            <xs:attribute name="before" type="xs:string"/>
+                                            <xs:attribute name="after" type="xs:string"/>
+                                            <xs:attribute name="angle" type="nodeAngle"/>
+                                            <xs:attribute name="notch" type="xs:boolean"/>
+                                            <xs:attribute name="notchType" type="notchTypes"/>
+                                            <xs:attribute name="notchSubtype" type="notchSubtypes"/>
+                                            <xs:attribute name="showNotch" type="xs:boolean"/>
+                                            <xs:attribute name="showSecondNotch" type="xs:boolean"/>
+                                            <xs:attribute name="notchAngle" type="xs:double"/>
+                                            <xs:attribute name="notchLength" type="xs:double"/>
+                                            <xs:attribute name="notchWidth" type="xs:double"/>
+                                            <xs:attribute name="notchCount" type="xs:unsignedInt"/>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                  <xs:element name="csa" minOccurs="0" maxOccurs="1">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="record" minOccurs="1" maxOccurs="unbounded">
+                                          <xs:complexType>
+                                            <xs:attribute name="start" type="xs:unsignedInt"/>
+                                            <xs:attribute name="path" type="xs:unsignedInt" use="required"/>
+                                            <xs:attribute name="end" type="xs:unsignedInt"/>
+                                            <xs:attribute name="reverse" type="xs:boolean"/>
+                                            <xs:attribute name="includeAs" type="piecePathIncludeType"/>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                  <xs:element name="iPaths" minOccurs="0" maxOccurs="1">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="record" minOccurs="1" maxOccurs="unbounded">
+                                          <xs:complexType>
+                                            <xs:attribute name="path" type="xs:unsignedInt" use="required"/>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                  <xs:element name="anchors" minOccurs="0" maxOccurs="1">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="record" type="xs:unsignedInt" minOccurs="1" maxOccurs="unbounded"/>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+                            <xs:element name="children" minOccurs="1" maxOccurs="1">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="nodes" minOccurs="0" maxOccurs="1">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="child" type="xs:unsignedInt" minOccurs="1" maxOccurs="unbounded"/>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                  <xs:element name="csa" minOccurs="0" maxOccurs="1">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="child" type="xs:unsignedInt" minOccurs="0" maxOccurs="unbounded"/>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                  <xs:element name="iPaths" minOccurs="0" maxOccurs="1">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="child" type="xs:unsignedInt" minOccurs="0" maxOccurs="unbounded"/>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                  <xs:element name="anchors" minOccurs="0" maxOccurs="1">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="child" type="xs:unsignedInt" minOccurs="0" maxOccurs="unbounded"/>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:sequence>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="type" type="xs:string"/>
+                          <xs:attribute name="indexD1" type="xs:unsignedInt"/>
+                          <xs:attribute name="indexD2" type="xs:unsignedInt"/>
+                          <xs:attribute name="inUse" type="xs:boolean"/>
+                        </xs:complexType>
+                      </xs:element>
+                    </xs:choice>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="pieces" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="piece" minOccurs="0" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="data" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="line" minOccurs="0" maxOccurs="unbounded">
+				                  <xs:complexType>
+				                  <xs:attribute name="text" type="xs:string" use="required"/>
+				                  <xs:attribute name="bold" type="xs:boolean"/>
+				                  <xs:attribute name="italic" type="xs:boolean"/>
+				                  <xs:attribute name="alignment" type="alignmentType"/>
+				                  <xs:attribute name="sfIncrement" type="xs:unsignedInt"/>
+				                  </xs:complexType>
+			                    </xs:element>
+                              </xs:sequence>
+                              <xs:attribute name="letter" type="xs:string"/>
+                              <xs:attribute name="annotation" type="xs:string"/>
+                              <xs:attribute name="orientation" type="xs:string"/>
+                              <xs:attribute name="rotationWay" type="xs:string"/>
+                              <xs:attribute name="tilt" type="xs:string"/>
+                              <xs:attribute name="foldPosition" type="xs:string"/>
+                              <xs:attribute name="visible" type="xs:boolean"/>
+                              <xs:attribute name="onFold" type="xs:boolean"/>
+                              <xs:attribute name="fontSize" type="xs:unsignedInt"/>
+                              <xs:attribute name="mx" type="xs:double"/>
+                              <xs:attribute name="my" type="xs:double"/>
+                              <xs:attribute name="width" type="xs:string"/>
+                              <xs:attribute name="height" type="xs:string"/>
+                              <xs:attribute name="rotation" type="xs:string"/>
+                              <xs:attribute name="centerAnchor" type="xs:unsignedInt"/>
+                              <xs:attribute name="topLeftAnchor" type="xs:unsignedInt"/>
+                              <xs:attribute name="quantity" type="xs:unsignedInt"/>
+                              <xs:attribute name="bottomRightAnchor" type="xs:unsignedInt"/>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="patternInfo" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:attribute name="visible" type="xs:boolean"/>
+                              <xs:attribute name="fontSize" type="xs:unsignedInt"/>
+                              <xs:attribute name="mx" type="xs:double"/>
+                              <xs:attribute name="my" type="xs:double"/>
+                              <xs:attribute name="width" type="xs:string"/>
+                              <xs:attribute name="height" type="xs:string"/>
+                              <xs:attribute name="rotation" type="xs:string"/>
+                              <xs:attribute name="centerAnchor" type="xs:unsignedInt"/>
+                              <xs:attribute name="topLeftAnchor" type="xs:unsignedInt"/>
+                              <xs:attribute name="bottomRightAnchor" type="xs:unsignedInt"/>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="grainline" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:attribute name="visible" type="xs:boolean"/>
+                              <xs:attribute name="mx" type="xs:double"/>
+                              <xs:attribute name="my" type="xs:double"/>
+                              <xs:attribute name="length" type="xs:string"/>
+                              <xs:attribute name="rotation" type="xs:string"/>
+                              <xs:attribute name="arrows" type="arrowType"/>
+                              <xs:attribute name="arrowLength" type="xs:string"/>
+                              <xs:attribute name="centerAnchor" type="xs:unsignedInt"/>
+                              <xs:attribute name="topAnchor" type="xs:unsignedInt"/>
+                              <xs:attribute name="bottomAnchor" type="xs:unsignedInt"/>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="nodes" minOccurs="1" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="node" minOccurs="1" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:attribute name="type" type="xs:string" use="required"/>
+                                    <xs:attribute name="idObject" type="xs:unsignedInt" use="required"/>
+                                    <xs:attribute name="reverse" type="xs:unsignedInt"/>
+                                    <xs:attribute name="excluded" type="xs:boolean"/>
+                                    <xs:attribute name="before" type="xs:string"/>
+                                    <xs:attribute name="after" type="xs:string"/>
+                                    <xs:attribute name="angle" type="nodeAngle"/>
+                                    <xs:attribute name="mx" type="xs:double"/>
+                                    <xs:attribute name="my" type="xs:double"/>
+                                    <xs:attribute name="notch" type="xs:boolean"/>
+                                    <xs:attribute name="notchType" type="notchTypes"/>
+                                    <xs:attribute name="notchSubtype" type="notchSubtypes"/>
+                                    <xs:attribute name="showNotch" type="xs:boolean"/>
+                                    <xs:attribute name="showSecondNotch" type="xs:boolean"/>
+                                    <xs:attribute name="notchAngle" type="xs:double"/>
+                                    <xs:attribute name="notchLength" type="xs:double"/>
+                                    <xs:attribute name="notchWidth" type="xs:double"/>
+                                    <xs:attribute name="notchCount" type="xs:unsignedInt"/>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="csa" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="record" minOccurs="1" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:attribute name="start" type="xs:unsignedInt"/>
+                                    <xs:attribute name="path" type="xs:unsignedInt" use="required"/>
+                                    <xs:attribute name="end" type="xs:unsignedInt"/>
+                                    <xs:attribute name="reverse" type="xs:boolean"/>
+                                    <xs:attribute name="includeAs" type="piecePathIncludeType"/>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="iPaths" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="record" minOccurs="1" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:attribute name="path" type="xs:unsignedInt" use="required"/>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="anchors" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="record" type="xs:unsignedInt" minOccurs="0" maxOccurs="unbounded"/>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                        <xs:attribute name="version" type="pieceVersion"/>
+                        <xs:attribute name="mx" type="xs:double"/>
+                        <xs:attribute name="my" type="xs:double"/>
+                        <xs:attribute name="name" type="xs:string"/>
+                        <xs:attribute name="color" type="xs:string"/>
+                        <xs:attribute name="fill" type="xs:string"/>
+                        <xs:attribute name="inLayout" type="xs:boolean"/>
+                        <xs:attribute name="forbidFlipping" type="xs:boolean"/>
+                        <xs:attribute name="width" type="xs:string"/>
+                        <xs:attribute name="seamAllowance" type="xs:boolean"/>
+                        <xs:attribute name="seamAllowanceBuiltIn" type="xs:boolean"/>
+                        <xs:attribute name="united" type="xs:boolean"/>
+                        <xs:attribute name="closed" type="xs:unsignedInt"/>
+                        <xs:attribute name="hideMainPath" type="xs:boolean"/>
+                        <xs:attribute name="locked" type="xs:boolean"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="groups" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                  <xs:sequence>
+                      <xs:element name="group" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="item" minOccurs="0" maxOccurs="unbounded">
+                              <xs:complexType>
+                                <xs:attribute name="object" type="xs:unsignedInt"/>
+                                <xs:attribute name="tool" type="xs:unsignedInt"/>
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:sequence>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="name" type="xs:string"/>
+                          <xs:attribute name="visible" type="xs:boolean"/>
+                          <xs:attribute name="locked" type="xs:boolean"/>
+                          <xs:attribute name="groupColor" type="colors"/>
+                          <xs:attribute name="lineType" type="linePenStyle"/>
+                          <xs:attribute name="lineWeight" type="lineWeights"/>
+                        </xs:complexType>
+                      </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="images" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="image" minOccurs="0" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                        <xs:attribute name="name" type="xs:string" use="required"/>
+                        <xs:attribute name="src" type="xs:string" use="required"/>
+                        <xs:attribute name="width" type="xs:double" use="required"/>
+                        <xs:attribute name="height" type="xs:double" use="required"/>
+                        <xs:attribute name="aspectRatio" type="xs:boolean" use="required"/>
+                        <xs:attribute name="rotation" type="xs:double" use="required"/>
+                        <xs:attribute name="xPos" type="xs:double" use="required"/>
+                        <xs:attribute name="yPos" type="xs:double" use="required"/>
+                        <xs:attribute name="locked" type="xs:boolean" use="required"/>
+                        <xs:attribute name="units" type="xs:string" use="required"/>
+                        <xs:attribute name="opacity" type="xs:double" use="required"/>
+                        <xs:attribute name="order" type="xs:double" use="required"/>
+                        <xs:attribute name="xOffset" type="xs:double" use="required"/>
+                        <xs:attribute name="yOffset" type="xs:double" use="required"/>
+                        <xs:attribute name="basepoint" type="xs:unsignedInt" use="required"/>
+                        <xs:attribute name="visible" type="xs:boolean" use="required"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="readOnly" type="xs:boolean"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:simpleType name="shortName">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="([^\p{Nd}\\\p{Zs}*\\/&amp;|!&lt;&gt;^&#10;\()\-−+.,٫, ٬.’=?:;'\\&quot;]){1,1}([^\\\p{Zs}*\\/&amp;|!&lt;&gt;^&#10;\()\-−+.,٫, ٬.’=?:;\\&quot;]){0,}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="units">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="mm"/>
+      <xs:enumeration value="cm"/>
+      <xs:enumeration value="inch"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="measurementsTypes">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="standard"/>
+      <xs:enumeration value="individual"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="formatVersion">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(0|([1-9][0-9]*))\.(0|([1-9][0-9]*))\.(0|([1-9][0-9]*))"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="imageExtension">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="PNG"/>
+      <xs:enumeration value="JPG"/>
+      <xs:enumeration value="BMP"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="colors">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="byGroup"/>
+      <xs:enumeration value="black"/>
+      <xs:enumeration value="green"/>
+      <xs:enumeration value="blue"/>
+      <xs:enumeration value="darkRed"/>
+      <xs:enumeration value="darkGreen"/>
+      <xs:enumeration value="darkBlue"/>
+      <xs:enumeration value="yellow"/>
+      <xs:enumeration value="lightsalmon"/>
+      <xs:enumeration value="goldenrod"/>
+      <xs:enumeration value="orange"/>
+      <xs:enumeration value="deeppink"/>
+      <xs:enumeration value="violet"/>
+      <xs:enumeration value="darkviolet"/>
+      <xs:enumeration value="mediumseagreen"/>
+      <xs:enumeration value="lime"/>
+      <xs:enumeration value="deepskyblue"/>
+      <xs:enumeration value="cornflowerblue"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="linePenStyle">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="byGroup"/>
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="solidLine"/>
+      <xs:enumeration value="dashLine"/>
+      <xs:enumeration value="dotLine"/>
+      <xs:enumeration value="dashDotLine"/>
+      <xs:enumeration value="dashDotDotLine"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="curvePenStyle">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="solidLine"/>
+      <xs:enumeration value="dashLine"/>
+      <xs:enumeration value="dotLine"/>
+      <xs:enumeration value="dashDotLine"/>
+      <xs:enumeration value="dashDotDotLine"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="lineWeights">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="byGroup"/>
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="0.05"/>
+      <xs:enumeration value="0.09"/>
+      <xs:enumeration value="0.13"/>
+      <xs:enumeration value="0.15"/>
+      <xs:enumeration value="0.18"/>
+      <xs:enumeration value="0.35"/>
+      <xs:enumeration value="0.2"/>
+      <xs:enumeration value="0.25"/>
+      <xs:enumeration value="0.3"/>
+      <xs:enumeration value="0.35"/>
+      <xs:enumeration value="0.4"/>
+      <xs:enumeration value="0.5"/>
+      <xs:enumeration value="0.53"/>
+      <xs:enumeration value="0.6"/>
+      <xs:enumeration value="0.7"/>
+      <xs:enumeration value="0.8"/>
+      <xs:enumeration value="0.9"/>
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="1.06"/>
+      <xs:enumeration value="1.2"/>
+      <xs:enumeration value="1.4"/>
+      <xs:enumeration value="1.58"/>
+      <xs:enumeration value="2"/>
+      <xs:enumeration value="2.11"/>
+      <xs:enumeration value="3"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="baseHeight">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="50"/>
+      <xs:enumeration value="56"/>
+      <xs:enumeration value="62"/>
+      <xs:enumeration value="68"/>
+      <xs:enumeration value="74"/>
+      <xs:enumeration value="80"/>
+      <xs:enumeration value="86"/>
+      <xs:enumeration value="92"/>
+      <xs:enumeration value="98"/>
+      <xs:enumeration value="104"/>
+      <xs:enumeration value="110"/>
+      <xs:enumeration value="116"/>
+      <xs:enumeration value="122"/>
+      <xs:enumeration value="128"/>
+      <xs:enumeration value="134"/>
+      <xs:enumeration value="140"/>
+      <xs:enumeration value="146"/>
+      <xs:enumeration value="152"/>
+      <xs:enumeration value="158"/>
+      <xs:enumeration value="164"/>
+      <xs:enumeration value="170"/>
+      <xs:enumeration value="176"/>
+      <xs:enumeration value="182"/>
+      <xs:enumeration value="188"/>
+      <xs:enumeration value="194"/>
+      <xs:enumeration value="200"/>
+      <xs:enumeration value="500"/>
+      <xs:enumeration value="560"/>
+      <xs:enumeration value="620"/>
+      <xs:enumeration value="680"/>
+      <xs:enumeration value="740"/>
+      <xs:enumeration value="800"/>
+      <xs:enumeration value="860"/>
+      <xs:enumeration value="920"/>
+      <xs:enumeration value="980"/>
+      <xs:enumeration value="1040"/>
+      <xs:enumeration value="1100"/>
+      <xs:enumeration value="1160"/>
+      <xs:enumeration value="1220"/>
+      <xs:enumeration value="1280"/>
+      <xs:enumeration value="1340"/>
+      <xs:enumeration value="1400"/>
+      <xs:enumeration value="1460"/>
+      <xs:enumeration value="1520"/>
+      <xs:enumeration value="1580"/>
+      <xs:enumeration value="1640"/>
+      <xs:enumeration value="1700"/>
+      <xs:enumeration value="1760"/>
+      <xs:enumeration value="1820"/>
+      <xs:enumeration value="1880"/>
+      <xs:enumeration value="1940"/>
+      <xs:enumeration value="2000"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="baseSize">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="22"/>
+      <xs:enumeration value="24"/>
+      <xs:enumeration value="26"/>
+      <xs:enumeration value="28"/>
+      <xs:enumeration value="30"/>
+      <xs:enumeration value="32"/>
+      <xs:enumeration value="34"/>
+      <xs:enumeration value="36"/>
+      <xs:enumeration value="38"/>
+      <xs:enumeration value="40"/>
+      <xs:enumeration value="42"/>
+      <xs:enumeration value="44"/>
+      <xs:enumeration value="46"/>
+      <xs:enumeration value="48"/>
+      <xs:enumeration value="50"/>
+      <xs:enumeration value="52"/>
+      <xs:enumeration value="54"/>
+      <xs:enumeration value="56"/>
+      <xs:enumeration value="58"/>
+      <xs:enumeration value="60"/>
+      <xs:enumeration value="62"/>
+      <xs:enumeration value="64"/>
+      <xs:enumeration value="66"/>
+      <xs:enumeration value="68"/>
+      <xs:enumeration value="70"/>
+      <xs:enumeration value="72"/>
+      <xs:enumeration value="220"/>
+      <xs:enumeration value="240"/>
+      <xs:enumeration value="260"/>
+      <xs:enumeration value="280"/>
+      <xs:enumeration value="300"/>
+      <xs:enumeration value="320"/>
+      <xs:enumeration value="340"/>
+      <xs:enumeration value="360"/>
+      <xs:enumeration value="380"/>
+      <xs:enumeration value="400"/>
+      <xs:enumeration value="420"/>
+      <xs:enumeration value="440"/>
+      <xs:enumeration value="460"/>
+      <xs:enumeration value="480"/>
+      <xs:enumeration value="500"/>
+      <xs:enumeration value="520"/>
+      <xs:enumeration value="540"/>
+      <xs:enumeration value="560"/>
+      <xs:enumeration value="580"/>
+      <xs:enumeration value="600"/>
+      <xs:enumeration value="620"/>
+      <xs:enumeration value="640"/>
+      <xs:enumeration value="660"/>
+      <xs:enumeration value="680"/>
+      <xs:enumeration value="700"/>
+      <xs:enumeration value="720"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="crossType">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="2"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="axisType">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="2"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="arrowType">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="0"/>
+      <!--Both-->
+      <xs:enumeration value="1"/>
+      <!--Front-->
+      <xs:enumeration value="2"/>
+      <!--Rear-->
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="pieceVersion">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="1"/>
+      <!--Old version-->
+      <xs:enumeration value="2"/>
+      <!--New version-->
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="nodeAngle">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="0"/>
+      <!--by length-->
+      <xs:enumeration value="1"/>
+      <!--by points intersections-->
+      <xs:enumeration value="2"/>
+      <!--by second edge symmetry-->
+      <xs:enumeration value="3"/>
+      <!--by first edge symmetry-->
+      <xs:enumeration value="4"/>
+      <!--by first edge right angle-->
+      <xs:enumeration value="5"/>
+      <!--by first edge right angle-->
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="piecePathType">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="1"/>
+      <!--custom seam allowance-->
+      <xs:enumeration value="2"/>
+      <!--internal path-->
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="piecePathIncludeType">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="0"/>
+      <!--as main path-->
+      <xs:enumeration value="1"/>
+      <!--as custom seam allowance-->
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="notchTypes">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="slit"/>
+      <xs:enumeration value="tNotch"/>
+      <xs:enumeration value="uNotch"/>
+      <xs:enumeration value="vInternal"/>
+      <xs:enumeration value="vExternal"/>
+      <xs:enumeration value="castle"/>
+      <xs:enumeration value="diamond"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="notchSubtypes">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="straightforward"/>
+      <xs:enumeration value="bisector"/>
+      <xs:enumeration value="intersection"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="alignmentType">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="0"/><!--default (no aligns)-->
+      <xs:enumeration value="1"/><!--aligns with the left edge-->
+      <xs:enumeration value="2"/><!--aligns with the right edge-->
+      <xs:enumeration value="4"/><!--Centers horizontally in the available space-->
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="directionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="forward"/>
+      <xs:enumeration value="backward"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/src/libs/ifc/xml/vpatternconverter.cpp
+++ b/src/libs/ifc/xml/vpatternconverter.cpp
@@ -82,8 +82,8 @@ Q_LOGGING_CATEGORY(PatternConverter, "patternConverter")
  */
 
 const QString VPatternConverter::PatternMinVerStr = QStringLiteral("0.1.0");
-const QString VPatternConverter::PatternMaxVerStr = QStringLiteral("0.7.3");
-const QString VPatternConverter::CurrentSchema    = QStringLiteral("://schema/pattern/v0.7.3.xsd");
+const QString VPatternConverter::PatternMaxVerStr = QStringLiteral("0.7.4");
+const QString VPatternConverter::CurrentSchema    = QStringLiteral("://schema/pattern/v0.7.4.xsd");
 
 //VPatternConverter::PatternMinVer; // <== DON'T FORGET TO UPDATE TOO!!!!
 //VPatternConverter::PatternMaxVer; // <== DON'T FORGET TO UPDATE TOO!!!!
@@ -344,7 +344,9 @@ QString VPatternConverter::getSchema(int ver) const
         case (0x000702):
             return QStringLiteral("://schema/pattern/v0.7.2.xsd");;
         case (0x000703):
-            qCDebug(PatternConverter, "Current schema - ://schema/pattern/v0.7.3.xsd");
+            return QStringLiteral("://schema/pattern/v0.7.3.xsd");
+        case (0x000704):
+            qCDebug(PatternConverter, "Current schema - ://schema/pattern/v0.7.4.xsd");
             return CurrentSchema;
         default:
             InvalidVersion(ver);
@@ -547,6 +549,10 @@ void VPatternConverter::applyPatches()
             ValidateXML(getSchema(0x000703), m_convertedFileName);
             V_FALLTHROUGH
         case (0x000703):
+            toVersion0_7_4();
+            ValidateXML(getSchema(0x000704), m_convertedFileName);
+            V_FALLTHROUGH
+        case (0x000704):
             break;
         default:
             InvalidVersion(m_ver);
@@ -565,7 +571,7 @@ void VPatternConverter::downgradeToCurrentMaxVersion()
 bool VPatternConverter::isReadOnly() const
 {
     // Check if attribute readOnly was not changed in file format
-    Q_STATIC_ASSERT_X(VPatternConverter::PatternMaxVer == CONVERTER_VERSION_CHECK(0, 7, 3),
+    Q_STATIC_ASSERT_X(VPatternConverter::PatternMaxVer == CONVERTER_VERSION_CHECK(0, 7, 4),
                       "Check attribute readOnly.");
 
     // Possibly in future attribute readOnly will change position etc.
@@ -1428,6 +1434,16 @@ void VPatternConverter::toVersion0_7_3()
     Q_STATIC_ASSERT_X(VPatternConverter::PatternMinVer < CONVERTER_VERSION_CHECK(0, 7, 3),
                       "Time to refactor the code.");
     setVersion(QStringLiteral("0.7.3"));
+    Save();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VPatternConverter::toVersion0_7_4()
+{
+    // TODO. Delete if minimal supported version is 0.7.4
+    Q_STATIC_ASSERT_X(VPatternConverter::PatternMinVer < CONVERTER_VERSION_CHECK(0, 7, 4),
+                      "Time to refactor the code.");
+    setVersion(QStringLiteral("0.7.4"));
     Save();
 }
 

--- a/src/libs/ifc/xml/vpatternconverter.h
+++ b/src/libs/ifc/xml/vpatternconverter.h
@@ -75,7 +75,7 @@ public:
     static const QString PatternMaxVerStr;
     static const QString CurrentSchema;
     static constexpr const int PatternMinVer = CONVERTER_VERSION_CHECK(0, 1, 0);
-    static constexpr const int PatternMaxVer = CONVERTER_VERSION_CHECK(0, 7, 3);
+    static constexpr const int PatternMaxVer = CONVERTER_VERSION_CHECK(0, 7, 4);
 
 protected:
     virtual int     minVer() const override;
@@ -141,6 +141,7 @@ private:
     void          toVersion0_7_1();
     void          toVersion0_7_2();
     void          toVersion0_7_3();
+    void          toVersion0_7_4();
 
     void          TagUnitToV0_2_0();
     void          TagIncrementToV0_2_0();

--- a/src/libs/vgeometry/vabstractcubicbezier.cpp
+++ b/src/libs/vgeometry/vabstractcubicbezier.cpp
@@ -655,3 +655,144 @@ QPair<qreal, qreal> VAbstractCubicBezier::HobbyHandleLengths(const QPointF &p1, 
 
     return {c1, c2};
 }
+
+//---------------------------------------------------------------------------------------------------------------------
+qreal VAbstractCubicBezier::CubicBezierLengthGL(const QPointF &p1, const QPointF &p2,
+                                                 const QPointF &p3, const QPointF &p4)
+{
+    static const qreal t[] = {0.01985071506835568, 0.10166676129318664,
+                               0.23723379504183550, 0.40828267875217509,
+                               0.59171732124782494, 0.76276620495816450,
+                               0.89833323870681336, 0.98014928493164430};
+    static const qreal w[] = {0.05061426814518813, 0.11119051722668723,
+                               0.15685332293894364, 0.18134189168918099,
+                               0.18134189168918099, 0.15685332293894364,
+                               0.11119051722668723, 0.05061426814518813};
+    qreal len = 0.0;
+    for (int i = 0; i < 8; ++i)
+    {
+        const qreal s = t[i];
+        const qreal q = 1.0 - s;
+        const QPointF d = 3.0 * (p2 - p1) * (q * q)
+                        + 6.0 * (p3 - p2) * (q * s)
+                        + 3.0 * (p4 - p3) * (s * s);
+        len += w[i] * qSqrt(d.x() * d.x() + d.y() * d.y());
+    }
+    return len;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+// Secant solver: find handle lengths (c1, c2) such that the arc length of
+// the cubic Bezier equals targetPx.
+//
+// mode: 1=vary start only, 2=vary end only, 3=vary both proportionally
+QPair<qreal, qreal> VAbstractCubicBezier::SolveHandleLengths(
+    const QPointF &p1, const QPointF &p4,
+    qreal angle1Deg, qreal angle2Deg,
+    qreal baseC1, qreal baseC2,
+    qreal targetPx, int mode)
+{
+    const qreal eps = ToPixel(0.05, Unit::Mm);
+
+    if (baseC1 <= 0.0 && baseC2 <= 0.0)
+    {
+        return {baseC1, baseC2};
+    }
+
+    const qreal a1rad = qDegreesToRadians(angle1Deg);
+    const qreal a2rad = qDegreesToRadians(angle2Deg);
+    const qreal cos1 = qCos(a1rad), sin1 = qSin(a1rad);
+    const qreal cos2 = qCos(a2rad), sin2 = qSin(a2rad);
+
+    auto curveLen = [&](qreal scale) -> qreal
+    {
+        qreal c1 = baseC1;
+        qreal c2 = baseC2;
+        if (mode == 1)
+        {
+            c1 = baseC1 * scale;
+        }
+        else if (mode == 2)
+        {
+            c2 = baseC2 * scale;
+        }
+        else
+        {
+            c1 = baseC1 * scale;
+            c2 = baseC2 * scale;
+        }
+        return CubicBezierLengthGL(p1,
+                                   p1 + QPointF(c1 * cos1, -c1 * sin1),
+                                   p4 + QPointF(c2 * cos2, -c2 * sin2),
+                                   p4);
+    };
+
+    const qreal minLen = curveLen(0.0);
+    if (targetPx <= minLen)
+    {
+        return {0.0, 0.0};
+    }
+
+    qreal hi = 1.0;
+    qreal f_hi = curveLen(hi) - targetPx;
+    for (int guard = 0; guard < 64 && f_hi < 0.0; ++guard)
+    {
+        hi *= 2.0;
+        f_hi = curveLen(hi) - targetPx;
+    }
+
+    qreal x0 = 0.0,  f0 = minLen - targetPx;
+    qreal x1 = hi,    f1 = f_hi;
+
+    for (int i = 0; i < 10; ++i)
+    {
+        if (qAbs(f1 - f0) < 1e-12)
+        {
+            break;
+        }
+        qreal xn = x1 - f1 * (x1 - x0) / (f1 - f0);
+        if (xn < 0.0)
+        {
+            xn = x1 * 0.5;
+        }
+        const qreal fn = curveLen(xn) - targetPx;
+        if (qAbs(fn) < eps)
+        {
+            qreal c1 = baseC1;
+            qreal c2 = baseC2;
+            if (mode == 1)
+            {
+                c1 = baseC1 * xn;
+            }
+            else if (mode == 2)
+            {
+                c2 = baseC2 * xn;
+            }
+            else
+            {
+                c1 = baseC1 * xn;
+                c2 = baseC2 * xn;
+            }
+            return {c1, c2};
+        }
+        x0 = x1; f0 = f1;
+        x1 = xn; f1 = fn;
+    }
+
+    qreal c1 = baseC1;
+    qreal c2 = baseC2;
+    if (mode == 1)
+    {
+        c1 = baseC1 * x1;
+    }
+    else if (mode == 2)
+    {
+        c2 = baseC2 * x1;
+    }
+    else
+    {
+        c1 = baseC1 * x1;
+        c2 = baseC2 * x1;
+    }
+    return {c1, c2};
+}

--- a/src/libs/vgeometry/vabstractcubicbezier.cpp
+++ b/src/libs/vgeometry/vabstractcubicbezier.cpp
@@ -55,6 +55,7 @@
 #include <QMessageLogger>
 #include <QPoint>
 #include <QtDebug>
+#include <QtMath>
 
 #include "../vmisc/def.h"
 #include "../vmisc/vmath.h"
@@ -599,4 +600,58 @@ qreal VAbstractCubicBezier::LengthT(qreal t) const
     const QPointF p1234 = seg123_234.p2();
 
     return LengthBezier ( static_cast<QPointF>(GetP1()), p12, p123, p1234);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+QPair<qreal, qreal> VAbstractCubicBezier::HobbyHandleLengths(const QPointF &p1, const QPointF &p4,
+                                                              qreal angle1Deg, qreal angle2Deg)
+{
+    const QLineF chord(p1, p4);
+    const qreal d = chord.length();
+
+    if (qFuzzyIsNull(d))
+    {
+        return {0.0, 0.0};
+    }
+
+    const qreal chordRad = qDegreesToRadians(chord.angle());
+    qreal theta = qDegreesToRadians(angle1Deg) - chordRad;
+    qreal phi   = qDegreesToRadians(angle2Deg) - qDegreesToRadians(chord.angle() + 180.0);
+
+    const qreal twoPi = 2.0 * M_PI;
+    while (theta >  M_PI)
+    {
+        theta -= twoPi;
+    }
+    while (theta < -M_PI)
+    {
+        theta += twoPi;
+    }
+    while (phi >  M_PI)
+    {
+        phi -= twoPi;
+    }
+    while (phi < -M_PI)
+    {
+        phi += twoPi;
+    }
+
+    const qreal sq2   = qSqrt(2.0);
+    const qreal sqrt5 = qSqrt(5.0);
+    const qreal cA    = 0.5 * (sqrt5 - 1.0);
+    const qreal cB    = 0.5 * (3.0 - sqrt5);
+
+    auto velocity = [&](qreal a, qreal b) -> qreal
+    {
+        const qreal num = 2.0 + sq2 * (qSin(a) - qSin(b) / 16.0)
+                                    * (qSin(b) - qSin(a) / 16.0)
+                                    * (qCos(a) - qCos(b));
+        const qreal den = 3.0 * (1.0 + cA * qCos(a) + cB * qCos(b));
+        return (qAbs(den) > 1e-9) ? num / den : (1.0 / 3.0);
+    };
+
+    const qreal c1 = qBound(1e-4, velocity(theta, phi) * d, d * 8.0);
+    const qreal c2 = qBound(1e-4, velocity(phi, theta) * d, d * 8.0);
+
+    return {c1, c2};
 }

--- a/src/libs/vgeometry/vabstractcubicbezier.cpp
+++ b/src/libs/vgeometry/vabstractcubicbezier.cpp
@@ -805,8 +805,8 @@ QPair<qreal, qreal> VAbstractCubicBezier::SolveHandleLengths(
 //---------------------------------------------------------------------------------------------------------------------
 // Combined auto-smooth + curve-length: instead of scaling the finished Hobby
 // handles linearly, vary the Hobby tension parameter so the curve keeps its
-// natural Hobby shape at the found tension. Arc length decreases monotonically
-// as tension increases.
+// natural Hobby shape at the found tension. Uses secant method with bracket
+// search, same approach as SolveHandleLengths.
 //
 // mode: 1=vary start tension (rho), 2=vary end tension (sigma), 3=both equally
 QPair<qreal, qreal> VAbstractCubicBezier::SolveHobbyTension(
@@ -875,24 +875,28 @@ QPair<qreal, qreal> VAbstractCubicBezier::SolveHobbyTension(
         }
     }
 
-    qreal tau = 1.0;
-    for (int i = 0; i < 40; ++i)
+    qreal x0 = lo,  f0 = lenForTau(lo) - targetPx;
+    qreal x1 = hi,  f1 = lenForTau(hi) - targetPx;
+
+    for (int i = 0; i < 10; ++i)
     {
-        tau = 0.5 * (lo + hi);
-        const qreal f = lenForTau(tau) - targetPx;
-        if (qAbs(f) < eps)
+        if (qAbs(f1 - f0) < 1e-12)
         {
             break;
         }
-        if (f > 0.0)
+        qreal xn = x1 - f1 * (x1 - x0) / (f1 - f0);
+        if (xn <= lo || xn >= hi)
         {
-            lo = tau;
+            xn = 0.5 * (lo + hi);
         }
-        else
+        const qreal fn = lenForTau(xn) - targetPx;
+        if (qAbs(fn) < eps)
         {
-            hi = tau;
+            return handlesForTau(xn);
         }
+        x0 = x1; f0 = f1;
+        x1 = xn; f1 = fn;
     }
 
-    return handlesForTau(tau);
+    return handlesForTau(x1);
 }

--- a/src/libs/vgeometry/vabstractcubicbezier.cpp
+++ b/src/libs/vgeometry/vabstractcubicbezier.cpp
@@ -604,7 +604,8 @@ qreal VAbstractCubicBezier::LengthT(qreal t) const
 
 //---------------------------------------------------------------------------------------------------------------------
 QPair<qreal, qreal> VAbstractCubicBezier::HobbyHandleLengths(const QPointF &p1, const QPointF &p4,
-                                                              qreal angle1Deg, qreal angle2Deg)
+                                                              qreal angle1Deg, qreal angle2Deg,
+                                                              qreal tensionStart, qreal tensionEnd)
 {
     const QLineF chord(p1, p4);
     const qreal d = chord.length();
@@ -650,8 +651,12 @@ QPair<qreal, qreal> VAbstractCubicBezier::HobbyHandleLengths(const QPointF &p1, 
         return (qAbs(den) > 1e-9) ? num / den : (1.0 / 3.0);
     };
 
-    const qreal c1 = qBound(1e-4, velocity(theta, phi) * d, d * 8.0);
-    const qreal c2 = qBound(1e-4, velocity(phi, theta) * d, d * 8.0);
+    // Hobby tension divides the velocity: higher tension -> shorter handles
+    // (curve held tighter to the chord), lower tension -> longer, bulgier handles.
+    const qreal tauStart = (tensionStart > 1e-6) ? tensionStart : 1e-6;
+    const qreal tauEnd   = (tensionEnd   > 1e-6) ? tensionEnd   : 1e-6;
+    const qreal c1 = qBound(1e-4, velocity(theta, phi) * d / tauStart, d * 8.0);
+    const qreal c2 = qBound(1e-4, velocity(phi, theta) * d / tauEnd,   d * 8.0);
 
     return {c1, c2};
 }
@@ -795,4 +800,99 @@ QPair<qreal, qreal> VAbstractCubicBezier::SolveHandleLengths(
         c2 = baseC2 * x1;
     }
     return {c1, c2};
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+// Combined auto-smooth + curve-length: instead of scaling the finished Hobby
+// handles linearly, vary the Hobby tension parameter so the curve keeps its
+// natural Hobby shape at the found tension. Arc length decreases monotonically
+// as tension increases.
+//
+// mode: 1=vary start tension (rho), 2=vary end tension (sigma), 3=both equally
+QPair<qreal, qreal> VAbstractCubicBezier::SolveHobbyTension(
+    const QPointF &p1, const QPointF &p4,
+    qreal angle1Deg, qreal angle2Deg,
+    qreal targetPx, int mode)
+{
+    const qreal eps = ToPixel(0.05, Unit::Mm);
+    const qreal a1rad = qDegreesToRadians(angle1Deg);
+    const qreal a2rad = qDegreesToRadians(angle2Deg);
+    const qreal cos1 = qCos(a1rad), sin1 = qSin(a1rad);
+    const qreal cos2 = qCos(a2rad), sin2 = qSin(a2rad);
+
+    auto handlesForTau = [&](qreal tau) -> QPair<qreal, qreal>
+    {
+        qreal tauStart = 1.0, tauEnd = 1.0;
+        if (mode == 1)
+        {
+            tauStart = tau;
+        }
+        else if (mode == 2)
+        {
+            tauEnd = tau;
+        }
+        else
+        {
+            tauStart = tau;
+            tauEnd = tau;
+        }
+        return HobbyHandleLengths(p1, p4, angle1Deg, angle2Deg, tauStart, tauEnd);
+    };
+
+    auto lenForTau = [&](qreal tau) -> qreal
+    {
+        const QPair<qreal, qreal> h = handlesForTau(tau);
+        const QPointF c1pt = p1 + QPointF(h.first  * cos1, -h.first  * sin1);
+        const QPointF c2pt = p4 + QPointF(h.second * cos2, -h.second * sin2);
+        return CubicBezierLengthGL(p1, c1pt, c2pt, p4);
+    };
+
+    const qreal lenAt1 = lenForTau(1.0);
+    if (qAbs(lenAt1 - targetPx) < eps)
+    {
+        return handlesForTau(1.0);
+    }
+
+    qreal lo, hi;
+    if (lenAt1 > targetPx)
+    {
+        // curve too long -> need higher tension to shorten it
+        lo = 1.0;
+        hi = 2.0;
+        for (int g = 0; g < 64 && lenForTau(hi) > targetPx; ++g)
+        {
+            hi *= 2.0;
+        }
+    }
+    else
+    {
+        // curve too short -> need lower tension to lengthen it
+        hi = 1.0;
+        lo = 0.5;
+        for (int g = 0; g < 64 && lenForTau(lo) < targetPx; ++g)
+        {
+            lo *= 0.5;
+        }
+    }
+
+    qreal tau = 1.0;
+    for (int i = 0; i < 40; ++i)
+    {
+        tau = 0.5 * (lo + hi);
+        const qreal f = lenForTau(tau) - targetPx;
+        if (qAbs(f) < eps)
+        {
+            break;
+        }
+        if (f > 0.0)
+        {
+            lo = tau;
+        }
+        else
+        {
+            hi = tau;
+        }
+    }
+
+    return handlesForTau(tau);
 }

--- a/src/libs/vgeometry/vabstractcubicbezier.h
+++ b/src/libs/vgeometry/vabstractcubicbezier.h
@@ -86,7 +86,8 @@ public:
     qreal LengthT(qreal t) const;
 
     static QPair<qreal, qreal> HobbyHandleLengths(const QPointF &p1, const QPointF &p4,
-                                                    qreal angle1Deg, qreal angle2Deg);
+                                                    qreal angle1Deg, qreal angle2Deg,
+                                                    qreal tensionStart = 1.0, qreal tensionEnd = 1.0);
 
     static qreal CubicBezierLengthGL(const QPointF &p1, const QPointF &p2,
                                       const QPointF &p3, const QPointF &p4);
@@ -95,6 +96,10 @@ public:
                                                     qreal angle1Deg, qreal angle2Deg,
                                                     qreal baseC1, qreal baseC2,
                                                     qreal targetPx, int mode);
+
+    static QPair<qreal, qreal> SolveHobbyTension(const QPointF &p1, const QPointF &p4,
+                                                   qreal angle1Deg, qreal angle2Deg,
+                                                   qreal targetPx, int mode);
 
 protected:
     virtual void CreateName() override;

--- a/src/libs/vgeometry/vabstractcubicbezier.h
+++ b/src/libs/vgeometry/vabstractcubicbezier.h
@@ -53,6 +53,7 @@
 #define VABSTRACTCUBICBEZIER_H
 
 #include <qcompilerdetection.h>
+#include <QPair>
 #include <QPointF>
 #include <QString>
 #include <QVector>
@@ -83,6 +84,9 @@ public:
 
     qreal GetParmT(qreal length) const;
     qreal LengthT(qreal t) const;
+
+    static QPair<qreal, qreal> HobbyHandleLengths(const QPointF &p1, const QPointF &p4,
+                                                    qreal angle1Deg, qreal angle2Deg);
 
 protected:
     virtual void CreateName() override;

--- a/src/libs/vgeometry/vabstractcubicbezier.h
+++ b/src/libs/vgeometry/vabstractcubicbezier.h
@@ -88,6 +88,14 @@ public:
     static QPair<qreal, qreal> HobbyHandleLengths(const QPointF &p1, const QPointF &p4,
                                                     qreal angle1Deg, qreal angle2Deg);
 
+    static qreal CubicBezierLengthGL(const QPointF &p1, const QPointF &p2,
+                                      const QPointF &p3, const QPointF &p4);
+
+    static QPair<qreal, qreal> SolveHandleLengths(const QPointF &p1, const QPointF &p4,
+                                                    qreal angle1Deg, qreal angle2Deg,
+                                                    qreal baseC1, qreal baseC2,
+                                                    qreal targetPx, int mode);
+
 protected:
     virtual void CreateName() override;
 

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp
@@ -53,17 +53,23 @@
 #include <QComboBox>
 #include <QLabel>
 #include <QLineEdit>
+#include <QPlainTextEdit>
 #include <QPointer>
+#include <QPushButton>
 #include <new>
 
 #include "../../tools/vabstracttool.h"
 #include "../ifc/ifcdef.h"
 #include "../../visualization/path/vistoolcubicbezier.h"
 #include "../../visualization/visualization.h"
+#include "../support/edit_formula_dialog.h"
 #include "../vgeometry/vpointf.h"
+#include "../vmisc/vabstractapplication.h"
+#include "../vmisc/vcommonsettings.h"
 #include "../vpatterndb/vcontainer.h"
 #include "dialogtool.h"
 #include "ui_dialogcubicbezier.h"
+#include "vtranslatevars.h"
 
 //---------------------------------------------------------------------------------------------------------------------
 DialogCubicBezier::DialogCubicBezier(const VContainer *data, const quint32 &toolId, QWidget *parent)
@@ -119,6 +125,7 @@ DialogCubicBezier::DialogCubicBezier(const VContainer *data, const quint32 &tool
     connect(ui->comboBoxP3, &QComboBox::currentTextChanged, this, &DialogCubicBezier::PointNameChanged);
     connect(ui->comboBoxP4, &QComboBox::currentTextChanged, this, &DialogCubicBezier::PointNameChanged);
 
+    connect(ui->toolButtonExprCurveLength, &QPushButton::clicked, this, &DialogCubicBezier::FXCurveLength);
     connect(ui->comboBoxLengthMode, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &DialogCubicBezier::updateCurveLengthEnabled);
     connect(ui->plainTextEditCurveLength, &QPlainTextEdit::textChanged, this, [this]()
     {
@@ -172,6 +179,37 @@ void DialogCubicBezier::SetLengthMode(int value)
 QString DialogCubicBezier::GetTargetLength() const
 {
     return ui->plainTextEditCurveLength->toPlainText().trimmed();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void DialogCubicBezier::SetTargetLength(const QString &formula)
+{
+    if (formula.isEmpty())
+    {
+        return;
+    }
+    const QString f = qApp->translateVariables()->FormulaToUser(formula, qApp->Settings()->getOsSeparator());
+    ui->plainTextEditCurveLength->blockSignals(true);
+    ui->plainTextEditCurveLength->setPlainText(f);
+    ui->plainTextEditCurveLength->blockSignals(false);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void DialogCubicBezier::FXCurveLength()
+{
+    auto dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
+    dialog->setWindowTitle(tr("Edit curve length"));
+    QString lengthF = qApp->translateVariables()->TryFormulaFromUser(ui->plainTextEditCurveLength->toPlainText(),
+                                                         qApp->Settings()->getOsSeparator());
+    dialog->SetFormula(lengthF);
+    dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));
+    if (dialog->exec() == QDialog::Accepted)
+    {
+        lengthF = qApp->translateVariables()->FormulaToUser(dialog->GetFormula(), qApp->Settings()->getOsSeparator());
+        ui->plainTextEditCurveLength->setPlainText(lengthF);
+        MoveCursorToEnd(ui->plainTextEditCurveLength);
+    }
+    delete dialog;
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp
@@ -57,6 +57,7 @@
 #include <new>
 
 #include "../../tools/vabstracttool.h"
+#include "../ifc/ifcdef.h"
 #include "../../visualization/path/vistoolcubicbezier.h"
 #include "../../visualization/visualization.h"
 #include "../vgeometry/vpointf.h"
@@ -118,6 +119,16 @@ DialogCubicBezier::DialogCubicBezier(const VContainer *data, const quint32 &tool
     connect(ui->comboBoxP3, &QComboBox::currentTextChanged, this, &DialogCubicBezier::PointNameChanged);
     connect(ui->comboBoxP4, &QComboBox::currentTextChanged, this, &DialogCubicBezier::PointNameChanged);
 
+    connect(ui->comboBoxLengthMode, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &DialogCubicBezier::updateCurveLengthEnabled);
+    connect(ui->plainTextEditCurveLength, &QPlainTextEdit::textChanged, this, [this]()
+    {
+        if (ui->comboBoxLengthMode->currentIndex() == 0)
+        {
+            ui->comboBoxLengthMode->setCurrentIndex(3);
+        }
+    });
+    updateCurveLengthEnabled();
+
     vis = new VisToolCubicBezier(data);
 }
 
@@ -146,6 +157,24 @@ void DialogCubicBezier::SetAutoSmooth(bool value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+int DialogCubicBezier::GetLengthMode() const
+{
+    return ui->comboBoxLengthMode->currentIndex();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void DialogCubicBezier::SetLengthMode(int value)
+{
+    ui->comboBoxLengthMode->setCurrentIndex(value);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void DialogCubicBezier::updateCurveLengthEnabled()
+{
+    Q_UNUSED(0)
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 void DialogCubicBezier::SetSpline(const VCubicBezier &spline)
 {
     spl = spline;
@@ -156,6 +185,13 @@ void DialogCubicBezier::SetSpline(const VCubicBezier &spline)
     setCurrentPointId(ui->comboBoxP4, spl.GetP4().id());
 
     ui->lineEditSplineName->setText(qApp->translateVariables()->VarToUser(spl.name()));
+
+    const QString curLen = QString::number(qApp->fromPixel(spl.GetLength()));
+    const QString unit = UnitsToStr(qApp->patternUnit(), true);
+    ui->plainTextEditCurveLength->blockSignals(true);
+    ui->plainTextEditCurveLength->setPlainText(curLen);
+    ui->plainTextEditCurveLength->blockSignals(false);
+    ui->labelResultCurveLength->setText(curLen + QLatin1Char(' ') + unit);
 
     auto path = qobject_cast<VisToolCubicBezier *>(vis);
     SCASSERT(path != nullptr)

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp
@@ -69,6 +69,8 @@ DialogCubicBezier::DialogCubicBezier(const VContainer *data, const quint32 &tool
     : DialogTool(data, toolId, parent)
     , ui(new Ui::DialogCubicBezier)
     , spl()
+    , m_computedSpl()
+    , m_hasComputedSpl(false)
     , newDuplicate(-1)
 {
     ui->setupUi(this);
@@ -162,6 +164,14 @@ void DialogCubicBezier::SetSpline(const VCubicBezier &spline)
     path->setObject2Id(spl.GetP2().id());
     path->setObject3Id(spl.GetP3().id());
     path->setObject4Id(spl.GetP4().id());
+    path->setShowPoints(static_cast<QPointF>(spl.GetP1()),
+                        static_cast<QPointF>(spl.GetP2()),
+                        static_cast<QPointF>(spl.GetP3()),
+                        static_cast<QPointF>(spl.GetP4()));
+    path->SetMode(Mode::Show);
+
+    m_computedSpl = spline;
+    m_hasComputedSpl = true;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -334,6 +344,14 @@ void DialogCubicBezier::SaveData()
     path->setObject2Id(p2->id());
     path->setObject3Id(p3->id());
     path->setObject4Id(p4->id());
+
+    // Preview the final geometry: the Hobby-computed spline when auto-smooth is on,
+    // otherwise the spline built directly from the selected canvas points.
+    const VCubicBezier &preview = (GetAutoSmooth() && m_hasComputedSpl) ? m_computedSpl : spl;
+    path->setShowPoints(static_cast<QPointF>(preview.GetP1()),
+                        static_cast<QPointF>(preview.GetP2()),
+                        static_cast<QPointF>(preview.GetP3()),
+                        static_cast<QPointF>(preview.GetP4()));
     path->SetMode(Mode::Show);
     path->RefreshGeometry();
 }

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp
@@ -132,6 +132,18 @@ VCubicBezier DialogCubicBezier::GetSpline() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+bool DialogCubicBezier::GetAutoSmooth() const
+{
+    return ui->comboBoxAutoSmooth->currentIndex() == 1;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void DialogCubicBezier::SetAutoSmooth(bool value)
+{
+    ui->comboBoxAutoSmooth->setCurrentIndex(value ? 1 : 0);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 void DialogCubicBezier::SetSpline(const VCubicBezier &spline)
 {
     spl = spline;

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp
@@ -169,6 +169,12 @@ void DialogCubicBezier::SetLengthMode(int value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+QString DialogCubicBezier::GetTargetLength() const
+{
+    return ui->plainTextEditCurveLength->toPlainText().trimmed();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 void DialogCubicBezier::updateCurveLengthEnabled()
 {
     Q_UNUSED(0)

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.h
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.h
@@ -81,6 +81,9 @@ public:
     VCubicBezier  GetSpline() const;
     void          SetSpline(const VCubicBezier &spline);
 
+    bool          GetAutoSmooth() const;
+    void          SetAutoSmooth(bool value);
+
     QString       getPenStyle() const;
     void          setPenStyle(const QString &value);
 

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.h
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.h
@@ -88,6 +88,7 @@ public:
     void          SetLengthMode(int value);
 
     QString       GetTargetLength() const;
+    void          SetTargetLength(const QString &formula);
 
     QString       getPenStyle() const;
     void          setPenStyle(const QString &value);
@@ -109,6 +110,9 @@ protected:
      * @brief SaveData Put dialog data in local variables
      */
     virtual void  SaveData() override;
+
+private slots:
+    void          FXCurveLength();
 
 private:
     Q_DISABLE_COPY(DialogCubicBezier)

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.h
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.h
@@ -84,6 +84,9 @@ public:
     bool          GetAutoSmooth() const;
     void          SetAutoSmooth(bool value);
 
+    int           GetLengthMode() const;
+    void          SetLengthMode(int value);
+
     QString       getPenStyle() const;
     void          setPenStyle(const QString &value);
 
@@ -96,6 +99,7 @@ public:
 public slots:
     virtual void  ChosenObject(quint32 id, const SceneObject &type) override;
     virtual void  PointNameChanged() override;
+    void          updateCurveLengthEnabled();
 
 protected:
     virtual void  ShowVisualization() override;

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.h
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.h
@@ -87,6 +87,8 @@ public:
     int           GetLengthMode() const;
     void          SetLengthMode(int value);
 
+    QString       GetTargetLength() const;
+
     QString       getPenStyle() const;
     void          setPenStyle(const QString &value);
 

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.h
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.h
@@ -110,6 +110,8 @@ private:
 
     /** @brief spl spline */
     VCubicBezier  spl;
+    VCubicBezier  m_computedSpl;
+    bool          m_hasComputedSpl;
 
     qint32        newDuplicate;
 

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.ui
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.ui
@@ -340,6 +340,68 @@
        </layout>
       </item>
       <item>
+       <layout class="QHBoxLayout" name="hLayoutLengthMode">
+        <item>
+         <widget class="QLabel" name="labelLengthMode">
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>9</pointsize>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Adjust length:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="comboBoxLengthMode">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>9</pointsize>
+            <bold>false</bold>
+           </font>
+          </property>
+          <item>
+           <property name="text">
+            <string>Off</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Start</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>End</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Both</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
        <layout class="QHBoxLayout" name="hLayoutCurveLenLabel">
         <item>
          <widget class="QLabel" name="labelEditCurveLength">

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.ui
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.ui
@@ -304,7 +304,7 @@
            </font>
           </property>
           <property name="text">
-           <string>Auto-Smooth:</string>
+           <string>Smooth curve:</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.ui
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>350</width>
-    <height>380</height>
+    <height>520</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -267,6 +267,209 @@
             <pointsize>9</pointsize>
             <bold>false</bold>
            </font>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="options_GroupBox">
+     <property name="font">
+      <font>
+       <pointsize>9</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="title">
+      <string>Options</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_opts">
+      <item>
+       <layout class="QHBoxLayout" name="hLayoutAutoSmooth">
+        <item>
+         <widget class="QLabel" name="labelAutoSmooth">
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>9</pointsize>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Auto-Smooth:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="comboBoxAutoSmooth">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>9</pointsize>
+            <bold>false</bold>
+           </font>
+          </property>
+          <item>
+           <property name="text">
+            <string>No</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Yes</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="hLayoutCurveLenLabel">
+        <item>
+         <widget class="QLabel" name="labelEditCurveLength">
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>9</pointsize>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Curve length:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelResultCurveLength">
+          <property name="minimumSize">
+           <size>
+            <width>85</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>9</pointsize>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string notr="true">_</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="hSpacerCurveLen">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>10</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QToolButton" name="toolButtonExprCurveLength">
+          <property name="toolTip">
+           <string>Formula wizard</string>
+          </property>
+          <property name="text">
+           <string notr="true">...</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../../vmisc/share/resources/icon.qrc">
+            <normaloff>:/icon/24x24/fx.png</normaloff>:/icon/24x24/fx.png</iconset>
+          </property>
+          <property name="iconSize">
+           <size>
+            <width>24</width>
+            <height>24</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="hLayoutCurveLenEdit">
+        <item>
+         <widget class="QPushButton" name="pushButtonGrowCurveLength">
+          <property name="maximumSize">
+           <size>
+            <width>18</width>
+            <height>18</height>
+           </size>
+          </property>
+          <property name="text">
+           <string notr="true"/>
+          </property>
+          <property name="icon">
+           <iconset theme="go-down">
+            <normaloff>.</normaloff>.</iconset>
+          </property>
+          <property name="iconSize">
+           <size>
+            <width>16</width>
+            <height>16</height>
+           </size>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPlainTextEdit" name="plainTextEditCurveLength">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>28</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>9</pointsize>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="tabChangesFocus">
+           <bool>true</bool>
+          </property>
+          <property name="toolTip">
+           <string>Curve arc length formula (applied if filled)</string>
           </property>
          </widget>
         </item>

--- a/src/libs/vtools/dialogs/tools/dialogspline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogspline.cpp
@@ -622,6 +622,18 @@ VSpline DialogSpline::GetSpline() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+bool DialogSpline::GetAutoSmooth() const
+{
+    return ui->comboBoxAutoSmooth->currentIndex() == 1;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void DialogSpline::SetAutoSmooth(bool value)
+{
+    ui->comboBoxAutoSmooth->setCurrentIndex(value ? 1 : 0);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 void DialogSpline::SetSpline(const VSpline &spline)
 {
     spl = spline;

--- a/src/libs/vtools/dialogs/tools/dialogspline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogspline.cpp
@@ -167,6 +167,7 @@ DialogSpline::DialogSpline(const VContainer *data, const quint32 &toolId, QWidge
     connect(ui->toolButtonExprAngle2, &QPushButton::clicked, this, &DialogSpline::FXAngle2);
     connect(ui->toolButtonExprLength1, &QPushButton::clicked, this, &DialogSpline::FXLength1);
     connect(ui->toolButtonExprLength2, &QPushButton::clicked, this, &DialogSpline::FXLength2);
+    connect(ui->toolButtonExprCurveLength, &QPushButton::clicked, this, &DialogSpline::FXCurveLength);
 
     connect(ui->plainTextEditAngle1F, &QPlainTextEdit::textChanged, this, &DialogSpline::Angle1Changed);
     connect(ui->plainTextEditAngle2F, &QPlainTextEdit::textChanged, this, &DialogSpline::Angle2Changed);
@@ -433,6 +434,24 @@ void DialogSpline::FXLength2()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+void DialogSpline::FXCurveLength()
+{
+    auto dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
+    dialog->setWindowTitle(tr("Edit curve length"));
+    QString lengthF = qApp->translateVariables()->TryFormulaFromUser(ui->plainTextEditCurveLength->toPlainText(),
+                                                         qApp->Settings()->getOsSeparator());
+    dialog->SetFormula(lengthF);
+    dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));
+    if (dialog->exec() == QDialog::Accepted)
+    {
+        lengthF = qApp->translateVariables()->FormulaToUser(dialog->GetFormula(), qApp->Settings()->getOsSeparator());
+        ui->plainTextEditCurveLength->setPlainText(lengthF);
+        MoveCursorToEnd(ui->plainTextEditCurveLength);
+    }
+    delete dialog;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 const QSharedPointer<VPointF> DialogSpline::GetP1() const
 {
     return data->GeometricObject<VPointF>(getCurrentObjectId(ui->comboBoxP1));
@@ -660,6 +679,19 @@ void DialogSpline::SetLengthMode(int value)
 QString DialogSpline::GetTargetLength() const
 {
     return ui->plainTextEditCurveLength->toPlainText().trimmed();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void DialogSpline::SetTargetLength(const QString &formula)
+{
+    if (formula.isEmpty())
+    {
+        return;
+    }
+    const QString f = qApp->translateVariables()->FormulaToUser(formula, qApp->Settings()->getOsSeparator());
+    ui->plainTextEditCurveLength->blockSignals(true);
+    ui->plainTextEditCurveLength->setPlainText(f);
+    ui->plainTextEditCurveLength->blockSignals(false);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogspline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogspline.cpp
@@ -66,6 +66,7 @@
 
 #include "../../tools/vabstracttool.h"
 #include "../../visualization/visualization.h"
+#include "../ifc/ifcdef.h"
 #include "../../visualization/path/vistoolspline.h"
 #include "../ifc/xml/vdomdocument.h"
 #include "../support/edit_formula_dialog.h"
@@ -176,6 +177,16 @@ DialogSpline::DialogSpline(const VContainer *data, const quint32 &toolId, QWidge
     connect(ui->pushButtonGrowAngle2, &QPushButton::clicked, this, &DialogSpline::DeployAngle2TextEdit);
     connect(ui->pushButtonGrowLength1, &QPushButton::clicked, this, &DialogSpline::DeployLength1TextEdit);
     connect(ui->pushButtonGrowLength2, &QPushButton::clicked, this, &DialogSpline::DeployLength2TextEdit);
+
+    connect(ui->comboBoxLengthMode, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &DialogSpline::updateCurveLengthEnabled);
+    connect(ui->plainTextEditCurveLength, &QPlainTextEdit::textChanged, this, [this]()
+    {
+        if (ui->comboBoxLengthMode->currentIndex() == 0)
+        {
+            ui->comboBoxLengthMode->setCurrentIndex(3);
+        }
+    });
+    updateCurveLengthEnabled();
 
     vis = new VisToolSpline(data);
     auto path = qobject_cast<VisToolSpline *>(vis);
@@ -634,6 +645,24 @@ void DialogSpline::SetAutoSmooth(bool value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+int DialogSpline::GetLengthMode() const
+{
+    return ui->comboBoxLengthMode->currentIndex();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void DialogSpline::SetLengthMode(int value)
+{
+    ui->comboBoxLengthMode->setCurrentIndex(value);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void DialogSpline::updateCurveLengthEnabled()
+{
+    Q_UNUSED(0)
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 void DialogSpline::SetSpline(const VSpline &spline)
 {
     spl = spline;
@@ -657,6 +686,13 @@ void DialogSpline::SetSpline(const VSpline &spline)
     ui->plainTextEditLength1F->setPlainText(length1F);
     ui->plainTextEditLength2F->setPlainText(length2F);
     ui->lineEditSplineName->setText(qApp->translateVariables()->VarToUser(spl.name()));
+
+    const QString curLen = QString::number(qApp->fromPixel(spl.GetLength()));
+    const QString unit = UnitsToStr(qApp->patternUnit(), true);
+    ui->plainTextEditCurveLength->blockSignals(true);
+    ui->plainTextEditCurveLength->setPlainText(curLen);
+    ui->plainTextEditCurveLength->blockSignals(false);
+    ui->labelResultCurveLength->setText(curLen + QLatin1Char(' ') + unit);
 
     auto path = qobject_cast<VisToolSpline *>(vis);
     SCASSERT(path != nullptr)

--- a/src/libs/vtools/dialogs/tools/dialogspline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogspline.cpp
@@ -657,6 +657,12 @@ void DialogSpline::SetLengthMode(int value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+QString DialogSpline::GetTargetLength() const
+{
+    return ui->plainTextEditCurveLength->toPlainText().trimmed();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 void DialogSpline::updateCurveLengthEnabled()
 {
     Q_UNUSED(0)

--- a/src/libs/vtools/dialogs/tools/dialogspline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogspline.cpp
@@ -668,6 +668,11 @@ void DialogSpline::SetSpline(const VSpline &spline)
     path->SetKAsm1(spl.GetKasm1());
     path->SetKAsm2(spl.GetKasm2());
     path->SetKCurve(spl.GetKcurve());
+    path->setShowPoints(static_cast<QPointF>(spl.GetP1()),
+                        static_cast<QPointF>(spl.GetP2()),
+                        static_cast<QPointF>(spl.GetP3()),
+                        static_cast<QPointF>(spl.GetP4()));
+    path->SetMode(Mode::Show);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogspline.h
+++ b/src/libs/vtools/dialogs/tools/dialogspline.h
@@ -83,6 +83,9 @@ public:
     VSpline       GetSpline() const;
     void          SetSpline(const VSpline &spline);
 
+    bool          GetAutoSmooth() const;
+    void          SetAutoSmooth(bool value);
+
     QString       getPenStyle() const;
     void          setPenStyle(const QString &value);
 

--- a/src/libs/vtools/dialogs/tools/dialogspline.h
+++ b/src/libs/vtools/dialogs/tools/dialogspline.h
@@ -89,6 +89,8 @@ public:
     int           GetLengthMode() const;
     void          SetLengthMode(int value);
 
+    QString       GetTargetLength() const;
+
     QString       getPenStyle() const;
     void          setPenStyle(const QString &value);
 

--- a/src/libs/vtools/dialogs/tools/dialogspline.h
+++ b/src/libs/vtools/dialogs/tools/dialogspline.h
@@ -90,6 +90,7 @@ public:
     void          SetLengthMode(int value);
 
     QString       GetTargetLength() const;
+    void          SetTargetLength(const QString &formula);
 
     QString       getPenStyle() const;
     void          setPenStyle(const QString &value);
@@ -130,6 +131,7 @@ private slots:
     void          FXAngle2();
     void          FXLength1();
     void          FXLength2();
+    void          FXCurveLength();
 
 private:
     Q_DISABLE_COPY(DialogSpline)

--- a/src/libs/vtools/dialogs/tools/dialogspline.h
+++ b/src/libs/vtools/dialogs/tools/dialogspline.h
@@ -86,6 +86,9 @@ public:
     bool          GetAutoSmooth() const;
     void          SetAutoSmooth(bool value);
 
+    int           GetLengthMode() const;
+    void          SetLengthMode(int value);
+
     QString       getPenStyle() const;
     void          setPenStyle(const QString &value);
 
@@ -99,6 +102,7 @@ public slots:
     virtual void  ChosenObject(quint32 id, const SceneObject &type) override;
     virtual void  PointNameChanged() override;
     virtual void  ShowDialog(bool click) override;
+    void          updateCurveLengthEnabled();
 
 protected:
     virtual void  CheckState() final;

--- a/src/libs/vtools/dialogs/tools/dialogspline.ui
+++ b/src/libs/vtools/dialogs/tools/dialogspline.ui
@@ -477,6 +477,68 @@
            </layout>
           </item>
           <item>
+           <layout class="QHBoxLayout" name="hLayoutLengthMode">
+            <item>
+             <widget class="QLabel" name="labelLengthMode">
+              <property name="minimumSize">
+               <size>
+                <width>100</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Adjust length:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="comboBoxLengthMode">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+                <bold>false</bold>
+               </font>
+              </property>
+              <item>
+               <property name="text">
+                <string>Off</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Start</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>End</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Both</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
            <layout class="QHBoxLayout" name="hLayoutCurveLenLabel">
             <item>
              <widget class="QLabel" name="labelEditCurveLength">

--- a/src/libs/vtools/dialogs/tools/dialogspline.ui
+++ b/src/libs/vtools/dialogs/tools/dialogspline.ui
@@ -441,7 +441,7 @@
                </font>
               </property>
               <property name="text">
-               <string>Auto-Smooth:</string>
+               <string>Smooth curve:</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/libs/vtools/dialogs/tools/dialogspline.ui
+++ b/src/libs/vtools/dialogs/tools/dialogspline.ui
@@ -412,6 +412,209 @@
          </layout>
         </widget>
        </item>
+       <item>
+        <widget class="QGroupBox" name="options_GroupBox">
+         <property name="font">
+          <font>
+           <pointsize>9</pointsize>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="title">
+          <string>Options</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_opts">
+          <item>
+           <layout class="QHBoxLayout" name="hLayoutAutoSmooth">
+            <item>
+             <widget class="QLabel" name="labelAutoSmooth">
+              <property name="minimumSize">
+               <size>
+                <width>100</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Auto-Smooth:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="comboBoxAutoSmooth">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+                <bold>false</bold>
+               </font>
+              </property>
+              <item>
+               <property name="text">
+                <string>No</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Yes</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="hLayoutCurveLenLabel">
+            <item>
+             <widget class="QLabel" name="labelEditCurveLength">
+              <property name="minimumSize">
+               <size>
+                <width>100</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Curve length:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="labelResultCurveLength">
+              <property name="minimumSize">
+               <size>
+                <width>85</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string notr="true">_</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="hSpacerCurveLen">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>10</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QToolButton" name="toolButtonExprCurveLength">
+              <property name="toolTip">
+               <string>Formula wizard</string>
+              </property>
+              <property name="text">
+               <string notr="true">...</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../../vmisc/share/resources/icon.qrc">
+                <normaloff>:/icon/24x24/fx.png</normaloff>:/icon/24x24/fx.png</iconset>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>24</width>
+                <height>24</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="hLayoutCurveLenEdit">
+            <item>
+             <widget class="QPushButton" name="pushButtonGrowCurveLength">
+              <property name="maximumSize">
+               <size>
+                <width>18</width>
+                <height>18</height>
+               </size>
+              </property>
+              <property name="text">
+               <string notr="true"/>
+              </property>
+              <property name="icon">
+               <iconset theme="go-down">
+                <normaloff>.</normaloff>.</iconset>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>16</width>
+                <height>16</height>
+               </size>
+              </property>
+              <property name="flat">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPlainTextEdit" name="plainTextEditCurveLength">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>28</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="tabChangesFocus">
+               <bool>true</bool>
+              </property>
+              <property name="toolTip">
+               <string>Curve arc length formula (applied if filled)</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
       </layout>
      </item>
      <item>

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
@@ -272,11 +272,24 @@ void VToolCubicBezier::SetAutoSmooth(bool value)
 //---------------------------------------------------------------------------------------------------------------------
 QString VToolCubicBezier::GetTargetLength() const
 {
-    return QString();
+    const auto spl = VAbstractTool::data.GeometricObject<VCubicBezier>(m_id);
+    return QString::number(qApp->fromPixel(spl->GetLength()));
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void VToolCubicBezier::SetTargetLength(const QString &value)
+{
+    Q_UNUSED(value)
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+int VToolCubicBezier::GetLengthMode() const
+{
+    return 0;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VToolCubicBezier::SetLengthMode(int value)
 {
     Q_UNUSED(value)
 }

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
@@ -110,10 +110,13 @@ static void applyHobbyToSpline(VCubicBezier *spline, const VContainer *data,
 
 //---------------------------------------------------------------------------------------------------------------------
 VToolCubicBezier::VToolCubicBezier(VAbstractPattern *doc, VContainer *data, quint32 id,
-                                   bool autoSmooth,
+                                   bool autoSmooth, int lengthMode,
+                                   const QString &targetLength,
                                    const Source &typeCreation, QGraphicsItem *parent)
     : VAbstractSpline(doc, data, id, parent)
     , m_autoSmooth(autoSmooth)
+    , m_lengthMode(lengthMode)
+    , m_targetLength(targetLength)
     , m_p2Id(0)
     , m_p3Id(0)
 {
@@ -136,6 +139,7 @@ void VToolCubicBezier::setDialog()
     const auto spl = VAbstractTool::data.GeometricObject<VCubicBezier>(m_id);
     dialogTool->SetSpline(*spl);
     dialogTool->SetAutoSmooth(m_autoSmooth);
+    dialogTool->SetLengthMode(m_lengthMode);
     dialogTool->setLineColor(spl->getLineColor());
     dialogTool->setPenStyle(spl->GetPenStyle());
     dialogTool->setLineWeight(spl->getLineWeight());
@@ -154,8 +158,10 @@ VToolCubicBezier *VToolCubicBezier::Create(QSharedPointer<DialogTool> dialog, VM
     spline->SetPenStyle(dialogTool->getPenStyle());
     spline->setLineWeight(dialogTool->getLineWeight());
     const bool autoSmooth = dialogTool->GetAutoSmooth();
+    const int lengthMode = dialogTool->GetLengthMode();
+    const QString targetLength = dialogTool->GetTargetLength();
 
-    auto spl = Create(0, spline, autoSmooth, scene, doc, data, Document::FullParse, Source::FromGui);
+    auto spl = Create(0, spline, autoSmooth, lengthMode, targetLength, scene, doc, data, Document::FullParse, Source::FromGui);
 
     if (spl != nullptr)
     {
@@ -166,7 +172,8 @@ VToolCubicBezier *VToolCubicBezier::Create(QSharedPointer<DialogTool> dialog, VM
 
 //---------------------------------------------------------------------------------------------------------------------
 VToolCubicBezier *VToolCubicBezier::Create(const quint32 _id, VCubicBezier *spline,
-                                           bool autoSmooth,
+                                           bool autoSmooth, int lengthMode,
+                                           const QString &targetLength,
                                            VMainGraphicsScene *scene,
                                            VAbstractPattern *doc, VContainer *data,
                                            const Document &parse, const Source &typeCreation)
@@ -198,7 +205,7 @@ VToolCubicBezier *VToolCubicBezier::Create(const quint32 _id, VCubicBezier *spli
     if (parse == Document::FullParse)
     {
         VDrawTool::AddRecord(id, Tool::CubicBezier, doc);
-        auto _spl = new VToolCubicBezier(doc, data, id, autoSmooth, typeCreation);
+        auto _spl = new VToolCubicBezier(doc, data, id, autoSmooth, lengthMode, targetLength, typeCreation);
         scene->addItem(_spl);
         initSplineToolConnections(scene, _spl);
         VAbstractPattern::AddTool(id, _spl);
@@ -272,26 +279,34 @@ void VToolCubicBezier::SetAutoSmooth(bool value)
 //---------------------------------------------------------------------------------------------------------------------
 QString VToolCubicBezier::GetTargetLength() const
 {
-    const auto spl = VAbstractTool::data.GeometricObject<VCubicBezier>(m_id);
-    return QString::number(qApp->fromPixel(spl->GetLength()));
+    if (m_targetLength.isEmpty())
+    {
+        const auto spl = VAbstractTool::data.GeometricObject<VCubicBezier>(m_id);
+        return QString::number(qApp->fromPixel(spl->GetLength()));
+    }
+    return m_targetLength;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void VToolCubicBezier::SetTargetLength(const QString &value)
 {
-    Q_UNUSED(value)
+    m_targetLength = value;
+    QSharedPointer<VGObject> obj = VAbstractTool::data.GetGObject(m_id);
+    SaveOption(obj);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 int VToolCubicBezier::GetLengthMode() const
 {
-    return 0;
+    return m_lengthMode;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void VToolCubicBezier::SetLengthMode(int value)
 {
-    Q_UNUSED(value)
+    m_lengthMode = value;
+    QSharedPointer<VGObject> obj = VAbstractTool::data.GetGObject(m_id);
+    SaveOption(obj);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -320,6 +335,8 @@ void VToolCubicBezier::showContextMenu(QGraphicsSceneContextMenuEvent *event, qu
 void VToolCubicBezier::ReadToolAttributes(const QDomElement &domElement)
 {
     m_autoSmooth = (domElement.attribute(AttrAutoSmooth) == QStringLiteral("true"));
+    m_lengthMode = domElement.attribute(AttrLengthMode, QStringLiteral("0")).toInt();
+    m_targetLength = domElement.attribute(AttrLength, QString());
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -341,6 +358,8 @@ void VToolCubicBezier::SaveDialog(QDomElement &domElement)
 
     const VCubicBezier spl = dialogTool->GetSpline();
     m_autoSmooth = dialogTool->GetAutoSmooth();
+    m_lengthMode = dialogTool->GetLengthMode();
+    m_targetLength = dialogTool->GetTargetLength();
 
     SetSplineAttributes(domElement, spl);
     doc->SetAttribute(domElement, AttrColor,      dialogTool->getLineColor());
@@ -422,5 +441,19 @@ void VToolCubicBezier::SetSplineAttributes(QDomElement &domElement, const VCubic
     else
     {
         domElement.removeAttribute(AttrAutoSmooth);
+    }
+
+    if (m_lengthMode > 0)
+    {
+        doc->SetAttribute(domElement, AttrLengthMode, m_lengthMode);
+        if (!m_targetLength.isEmpty())
+        {
+            doc->SetAttribute(domElement, AttrLength, m_targetLength);
+        }
+    }
+    else
+    {
+        domElement.removeAttribute(AttrLengthMode);
+        domElement.removeAttribute(AttrLength);
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
@@ -53,11 +53,9 @@
 
 #include <QDomElement>
 #include <QLineF>
-#include <QPair>
 #include <QPen>
 #include <QSharedPointer>
 #include <QString>
-#include <QtMath>
 #include <Qt>
 #include <new>
 
@@ -81,60 +79,6 @@
 const QString VToolCubicBezier::ToolType = QStringLiteral("cubicBezier");
 
 //---------------------------------------------------------------------------------------------------------------------
-static QPair<qreal, qreal> hobbyHandleLengths(const VPointF &p1, const VPointF &p4,
-                                               qreal angle1Deg, qreal angle2Deg)
-{
-    const QLineF chord(static_cast<QPointF>(p1), static_cast<QPointF>(p4));
-    const qreal d = chord.length();
-
-    if (qFuzzyIsNull(d))
-    {
-        return {0.0, 0.0};
-    }
-
-    const qreal chordRad = qDegreesToRadians(chord.angle());
-    qreal theta = qDegreesToRadians(angle1Deg) - chordRad;
-    qreal phi   = qDegreesToRadians(angle2Deg) - qDegreesToRadians(chord.angle() + 180.0);
-
-    const qreal twoPi = 2.0 * M_PI;
-    while (theta >  M_PI)
-    {
-        theta -= twoPi;
-    }
-    while (theta < -M_PI)
-    {
-        theta += twoPi;
-    }
-    while (phi >  M_PI)
-    {
-        phi -= twoPi;
-    }
-    while (phi < -M_PI)
-    {
-        phi += twoPi;
-    }
-
-    const qreal sq2   = qSqrt(2.0);
-    const qreal sqrt5 = qSqrt(5.0);
-    const qreal cA    = 0.5 * (sqrt5 - 1.0);
-    const qreal cB    = 0.5 * (3.0 - sqrt5);
-
-    auto velocity = [&](qreal a, qreal b) -> qreal
-    {
-        const qreal num = 2.0 + sq2 * (qSin(a) - qSin(b) / 16.0)
-                                    * (qSin(b) - qSin(a) / 16.0)
-                                    * (qCos(a) - qCos(b));
-        const qreal den = 3.0 * (1.0 + cA * qCos(a) + cB * qCos(b));
-        return (qAbs(den) > 1e-9) ? num / den : (1.0 / 3.0);
-    };
-
-    const qreal c1 = qBound(1e-4, velocity(theta, phi) * d, d * 8.0);
-    const qreal c2 = qBound(1e-4, velocity(phi, theta) * d, d * 8.0);
-
-    return {c1, c2};
-}
-
-//---------------------------------------------------------------------------------------------------------------------
 static void applyHobbyToSpline(VCubicBezier *spline, const VContainer *data,
                                quint32 p2Id, quint32 p3Id)
 {
@@ -146,7 +90,7 @@ static void applyHobbyToSpline(VCubicBezier *spline, const VContainer *data,
     const QLineF h1(static_cast<QPointF>(p1), static_cast<QPointF>(*p2canvas));
     const QLineF h2(static_cast<QPointF>(p4), static_cast<QPointF>(*p3canvas));
 
-    const QPair<qreal, qreal> hobby = hobbyHandleLengths(p1, p4, h1.angle(), h2.angle());
+    const QPair<qreal, qreal> hobby = VAbstractCubicBezier::HobbyHandleLengths(static_cast<QPointF>(p1), static_cast<QPointF>(p4), h1.angle(), h2.angle());
 
     QLineF newH1(static_cast<QPointF>(p1), static_cast<QPointF>(p1) + QPointF(hobby.first, 0.0));
     newH1.setAngle(h1.angle());

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
@@ -52,9 +52,12 @@
 #include "vtoolcubicbezier.h"
 
 #include <QDomElement>
+#include <QLineF>
+#include <QPair>
 #include <QPen>
 #include <QSharedPointer>
 #include <QString>
+#include <QtMath>
 #include <Qt>
 #include <new>
 
@@ -78,12 +81,101 @@
 const QString VToolCubicBezier::ToolType = QStringLiteral("cubicBezier");
 
 //---------------------------------------------------------------------------------------------------------------------
+static QPair<qreal, qreal> hobbyHandleLengths(const VPointF &p1, const VPointF &p4,
+                                               qreal angle1Deg, qreal angle2Deg)
+{
+    const QLineF chord(static_cast<QPointF>(p1), static_cast<QPointF>(p4));
+    const qreal d = chord.length();
+
+    if (qFuzzyIsNull(d))
+    {
+        return {0.0, 0.0};
+    }
+
+    const qreal chordRad = qDegreesToRadians(chord.angle());
+    qreal theta = qDegreesToRadians(angle1Deg) - chordRad;
+    qreal phi   = qDegreesToRadians(angle2Deg) - qDegreesToRadians(chord.angle() + 180.0);
+
+    const qreal twoPi = 2.0 * M_PI;
+    while (theta >  M_PI)
+    {
+        theta -= twoPi;
+    }
+    while (theta < -M_PI)
+    {
+        theta += twoPi;
+    }
+    while (phi >  M_PI)
+    {
+        phi -= twoPi;
+    }
+    while (phi < -M_PI)
+    {
+        phi += twoPi;
+    }
+
+    const qreal sq2   = qSqrt(2.0);
+    const qreal sqrt5 = qSqrt(5.0);
+    const qreal cA    = 0.5 * (sqrt5 - 1.0);
+    const qreal cB    = 0.5 * (3.0 - sqrt5);
+
+    auto velocity = [&](qreal a, qreal b) -> qreal
+    {
+        const qreal num = 2.0 + sq2 * (qSin(a) - qSin(b) / 16.0)
+                                    * (qSin(b) - qSin(a) / 16.0)
+                                    * (qCos(a) - qCos(b));
+        const qreal den = 3.0 * (1.0 + cA * qCos(a) + cB * qCos(b));
+        return (qAbs(den) > 1e-9) ? num / den : (1.0 / 3.0);
+    };
+
+    const qreal c1 = qBound(1e-4, velocity(theta, phi) * d, d * 8.0);
+    const qreal c2 = qBound(1e-4, velocity(phi, theta) * d, d * 8.0);
+
+    return {c1, c2};
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+static void applyHobbyToSpline(VCubicBezier *spline, const VContainer *data,
+                               quint32 p2Id, quint32 p3Id)
+{
+    const VPointF p1 = spline->GetP1();
+    const VPointF p4 = spline->GetP4();
+    const auto p2canvas = data->GeometricObject<VPointF>(p2Id);
+    const auto p3canvas = data->GeometricObject<VPointF>(p3Id);
+
+    const QLineF h1(static_cast<QPointF>(p1), static_cast<QPointF>(*p2canvas));
+    const QLineF h2(static_cast<QPointF>(p4), static_cast<QPointF>(*p3canvas));
+
+    const QPair<qreal, qreal> hobby = hobbyHandleLengths(p1, p4, h1.angle(), h2.angle());
+
+    QLineF newH1(static_cast<QPointF>(p1), static_cast<QPointF>(p1) + QPointF(hobby.first, 0.0));
+    newH1.setAngle(h1.angle());
+    QLineF newH2(static_cast<QPointF>(p4), static_cast<QPointF>(p4) + QPointF(hobby.second, 0.0));
+    newH2.setAngle(h2.angle());
+
+    VPointF newP2(newH1.p2(), p2canvas->name(), p2canvas->mx(), p2canvas->my(),
+                  p2canvas->getIdObject(), p2canvas->getMode());
+    newP2.setId(p2Id);
+    VPointF newP3(newH2.p2(), p3canvas->name(), p3canvas->mx(), p3canvas->my(),
+                  p3canvas->getIdObject(), p3canvas->getMode());
+    newP3.setId(p3Id);
+
+    spline->SetP2(newP2);
+    spline->SetP3(newP3);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 VToolCubicBezier::VToolCubicBezier(VAbstractPattern *doc, VContainer *data, quint32 id,
                                    bool autoSmooth,
                                    const Source &typeCreation, QGraphicsItem *parent)
     : VAbstractSpline(doc, data, id, parent)
     , m_autoSmooth(autoSmooth)
+    , m_p2Id(0)
+    , m_p3Id(0)
 {
+    const auto spl = VAbstractTool::data.GeometricObject<VCubicBezier>(id);
+    m_p2Id = spl->GetP2().id();
+    m_p3Id = spl->GetP3().id();
     m_sceneType = SceneObject::Spline;
 
     this->setFlag(QGraphicsItem::ItemIsFocusable, true);// For keyboard input focus
@@ -135,6 +227,14 @@ VToolCubicBezier *VToolCubicBezier::Create(const quint32 _id, VCubicBezier *spli
                                            VAbstractPattern *doc, VContainer *data,
                                            const Document &parse, const Source &typeCreation)
 {
+    const quint32 origP2Id = spline->GetP2().id();
+    const quint32 origP3Id = spline->GetP3().id();
+
+    if (autoSmooth)
+    {
+        applyHobbyToSpline(spline, data, origP2Id, origP3Id);
+    }
+
     quint32 id = _id;
     if (typeCreation == Source::FromGui)
     {
@@ -260,6 +360,12 @@ void VToolCubicBezier::showContextMenu(QGraphicsSceneContextMenuEvent *event, qu
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+void VToolCubicBezier::ReadToolAttributes(const QDomElement &domElement)
+{
+    m_autoSmooth = (domElement.attribute(AttrAutoSmooth) == QStringLiteral("true"));
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 void VToolCubicBezier::RemoveReferens()
 {
     const auto spl = VAbstractTool::data.GeometricObject<VCubicBezier>(m_id);
@@ -304,12 +410,17 @@ void VToolCubicBezier::SetVisualization()
         SCASSERT(visual != nullptr)
 
         const QSharedPointer<VCubicBezier> spl = VAbstractTool::data.GeometricObject<VCubicBezier>(m_id);
+
         visual->setObject1Id(spl->GetP1().id());
         visual->setObject2Id(spl->GetP2().id());
         visual->setObject3Id(spl->GetP3().id());
         visual->setObject4Id(spl->GetP4().id());
         visual->setLineStyle(lineTypeToPenStyle(spl->GetPenStyle()));
         visual->setLineWeight(spl->getLineWeight());
+        visual->setShowPoints(static_cast<QPointF>(spl->GetP1()),
+                              static_cast<QPointF>(spl->GetP2()),
+                              static_cast<QPointF>(spl->GetP3()),
+                              static_cast<QPointF>(spl->GetP4()));
         visual->SetMode(Mode::Show);
         visual->RefreshGeometry();
     }
@@ -331,8 +442,8 @@ void VToolCubicBezier::SetSplineAttributes(QDomElement &domElement, const VCubic
 
     doc->SetAttribute(domElement, AttrType,    ToolType);
     doc->SetAttribute(domElement, AttrPoint1,  spl.GetP1().id());
-    doc->SetAttribute(domElement, AttrPoint2,  spl.GetP2().id());
-    doc->SetAttribute(domElement, AttrPoint3,  spl.GetP3().id());
+    doc->SetAttribute(domElement, AttrPoint2,  m_p2Id);
+    doc->SetAttribute(domElement, AttrPoint3,  m_p3Id);
     doc->SetAttribute(domElement, AttrPoint4,  spl.GetP4().id());
 
     if (spl.GetDuplicate() > 0)

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
@@ -79,8 +79,10 @@ const QString VToolCubicBezier::ToolType = QStringLiteral("cubicBezier");
 
 //---------------------------------------------------------------------------------------------------------------------
 VToolCubicBezier::VToolCubicBezier(VAbstractPattern *doc, VContainer *data, quint32 id,
+                                   bool autoSmooth,
                                    const Source &typeCreation, QGraphicsItem *parent)
     : VAbstractSpline(doc, data, id, parent)
+    , m_autoSmooth(autoSmooth)
 {
     m_sceneType = SceneObject::Spline;
 
@@ -97,6 +99,7 @@ void VToolCubicBezier::setDialog()
     SCASSERT(dialogTool != nullptr)
     const auto spl = VAbstractTool::data.GeometricObject<VCubicBezier>(m_id);
     dialogTool->SetSpline(*spl);
+    dialogTool->SetAutoSmooth(m_autoSmooth);
     dialogTool->setLineColor(spl->getLineColor());
     dialogTool->setPenStyle(spl->GetPenStyle());
     dialogTool->setLineWeight(spl->getLineWeight());
@@ -114,8 +117,9 @@ VToolCubicBezier *VToolCubicBezier::Create(QSharedPointer<DialogTool> dialog, VM
     spline->setLineColor(dialogTool->getLineColor());
     spline->SetPenStyle(dialogTool->getPenStyle());
     spline->setLineWeight(dialogTool->getLineWeight());
+    const bool autoSmooth = dialogTool->GetAutoSmooth();
 
-    auto spl = Create(0, spline, scene, doc, data, Document::FullParse, Source::FromGui);
+    auto spl = Create(0, spline, autoSmooth, scene, doc, data, Document::FullParse, Source::FromGui);
 
     if (spl != nullptr)
     {
@@ -125,9 +129,11 @@ VToolCubicBezier *VToolCubicBezier::Create(QSharedPointer<DialogTool> dialog, VM
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-VToolCubicBezier *VToolCubicBezier::Create(const quint32 _id, VCubicBezier *spline, VMainGraphicsScene *scene,
-                                           VAbstractPattern *doc, VContainer *data, const Document &parse,
-                                           const Source &typeCreation)
+VToolCubicBezier *VToolCubicBezier::Create(const quint32 _id, VCubicBezier *spline,
+                                           bool autoSmooth,
+                                           VMainGraphicsScene *scene,
+                                           VAbstractPattern *doc, VContainer *data,
+                                           const Document &parse, const Source &typeCreation)
 {
     quint32 id = _id;
     if (typeCreation == Source::FromGui)
@@ -148,13 +154,13 @@ VToolCubicBezier *VToolCubicBezier::Create(const quint32 _id, VCubicBezier *spli
     if (parse == Document::FullParse)
     {
         VDrawTool::AddRecord(id, Tool::CubicBezier, doc);
-        auto _spl = new VToolCubicBezier(doc, data, id, typeCreation);
+        auto _spl = new VToolCubicBezier(doc, data, id, autoSmooth, typeCreation);
         scene->addItem(_spl);
         initSplineToolConnections(scene, _spl);
         VAbstractPattern::AddTool(id, _spl);
         doc->IncrementReferens(spline->GetP1().getIdTool());
-        doc->IncrementReferens(spline->GetP1().getIdTool());
-        doc->IncrementReferens(spline->GetP1().getIdTool());
+        doc->IncrementReferens(spline->GetP2().getIdTool());
+        doc->IncrementReferens(spline->GetP3().getIdTool());
         doc->IncrementReferens(spline->GetP4().getIdTool());
         return _spl;
     }
@@ -208,13 +214,15 @@ void VToolCubicBezier::setSpline(const VCubicBezier &spl)
 //---------------------------------------------------------------------------------------------------------------------
 bool VToolCubicBezier::GetAutoSmooth() const
 {
-    return false;
+    return m_autoSmooth;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void VToolCubicBezier::SetAutoSmooth(bool value)
 {
-    Q_UNUSED(value)
+    m_autoSmooth = value;
+    QSharedPointer<VGObject> obj = VAbstractTool::data.GetGObject(m_id);
+    SaveOption(obj);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -269,6 +277,7 @@ void VToolCubicBezier::SaveDialog(QDomElement &domElement)
     SCASSERT(dialogTool != nullptr)
 
     const VCubicBezier spl = dialogTool->GetSpline();
+    m_autoSmooth = dialogTool->GetAutoSmooth();
 
     SetSplineAttributes(domElement, spl);
     doc->SetAttribute(domElement, AttrColor,      dialogTool->getLineColor());
@@ -336,5 +345,14 @@ void VToolCubicBezier::SetSplineAttributes(QDomElement &domElement, const VCubic
         {
             domElement.removeAttribute(AttrDuplicate);
         }
+    }
+
+    if (m_autoSmooth)
+    {
+        doc->SetAttribute(domElement, AttrAutoSmooth, QStringLiteral("true"));
+    }
+    else
+    {
+        domElement.removeAttribute(AttrAutoSmooth);
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
@@ -79,29 +79,24 @@
 const QString VToolCubicBezier::ToolType = QStringLiteral("cubicBezier");
 
 //---------------------------------------------------------------------------------------------------------------------
-static void applyHobbyToSpline(VCubicBezier *spline, const VContainer *data,
-                               quint32 p2Id, quint32 p3Id)
+// Set the spline's control points from handle lengths (c1, c2) along the given
+// directions, preserving the original canvas point IDs.
+static void setHandlesFromLengths(VCubicBezier *spline, const QPointF &p1pt, const QPointF &p4pt,
+                                  qreal angle1, qreal angle2, qreal c1, qreal c2,
+                                  quint32 p2Id, quint32 p3Id)
 {
-    const VPointF p1 = spline->GetP1();
-    const VPointF p4 = spline->GetP4();
-    const auto p2canvas = data->GeometricObject<VPointF>(p2Id);
-    const auto p3canvas = data->GeometricObject<VPointF>(p3Id);
+    QLineF newH1(p1pt, p1pt + QPointF(c1, 0.0));
+    newH1.setAngle(angle1);
+    QLineF newH2(p4pt, p4pt + QPointF(c2, 0.0));
+    newH2.setAngle(angle2);
 
-    const QLineF h1(static_cast<QPointF>(p1), static_cast<QPointF>(*p2canvas));
-    const QLineF h2(static_cast<QPointF>(p4), static_cast<QPointF>(*p3canvas));
-
-    const QPair<qreal, qreal> hobby = VAbstractCubicBezier::HobbyHandleLengths(static_cast<QPointF>(p1), static_cast<QPointF>(p4), h1.angle(), h2.angle());
-
-    QLineF newH1(static_cast<QPointF>(p1), static_cast<QPointF>(p1) + QPointF(hobby.first, 0.0));
-    newH1.setAngle(h1.angle());
-    QLineF newH2(static_cast<QPointF>(p4), static_cast<QPointF>(p4) + QPointF(hobby.second, 0.0));
-    newH2.setAngle(h2.angle());
-
-    VPointF newP2(newH1.p2(), p2canvas->name(), p2canvas->mx(), p2canvas->my(),
-                  p2canvas->getIdObject(), p2canvas->getMode());
+    const VPointF oldP2 = spline->GetP2();
+    const VPointF oldP3 = spline->GetP3();
+    VPointF newP2(newH1.p2(), oldP2.name(), oldP2.mx(), oldP2.my(),
+                  oldP2.getIdObject(), oldP2.getMode());
     newP2.setId(p2Id);
-    VPointF newP3(newH2.p2(), p3canvas->name(), p3canvas->mx(), p3canvas->my(),
-                  p3canvas->getIdObject(), p3canvas->getMode());
+    VPointF newP3(newH2.p2(), oldP3.name(), oldP3.mx(), oldP3.my(),
+                  oldP3.getIdObject(), oldP3.getMode());
     newP3.setId(p3Id);
 
     spline->SetP2(newP2);
@@ -181,41 +176,55 @@ VToolCubicBezier *VToolCubicBezier::Create(const quint32 _id, VCubicBezier *spli
     const quint32 origP2Id = spline->GetP2().id();
     const quint32 origP3Id = spline->GetP3().id();
 
-    if (autoSmooth)
     {
-        applyHobbyToSpline(spline, data, origP2Id, origP3Id);
-    }
+        const QPointF p1pt = static_cast<QPointF>(spline->GetP1());
+        const QPointF p4pt = static_cast<QPointF>(spline->GetP4());
+        const QLineF h1(p1pt, static_cast<QPointF>(spline->GetP2()));
+        const QLineF h2(p4pt, static_cast<QPointF>(spline->GetP3()));
+        const qreal angle1 = h1.angle();
+        const qreal angle2 = h2.angle();
 
-    if (lengthMode > 0 && !targetLength.isEmpty())
-    {
-        QString tl = targetLength;
-        const qreal targetPx = qApp->toPixel(CheckFormula(_id, tl, data));
-        if (targetPx > 0.0)
+        const bool hasTarget = (lengthMode > 0 && !targetLength.isEmpty());
+        qreal targetPx = 0.0;
+        if (hasTarget)
         {
-            const QPointF p1pt = static_cast<QPointF>(spline->GetP1());
-            const QPointF p2pt = static_cast<QPointF>(spline->GetP2());
-            const QPointF p3pt = static_cast<QPointF>(spline->GetP3());
-            const QPointF p4pt = static_cast<QPointF>(spline->GetP4());
-            const QLineF h1(p1pt, p2pt);
-            const QLineF h2(p4pt, p3pt);
+            QString tl = targetLength;
+            targetPx = qApp->toPixel(CheckFormula(_id, tl, data));
+        }
 
-            const QPair<qreal, qreal> solved = VAbstractCubicBezier::SolveHandleLengths(
-                p1pt, p4pt, h1.angle(), h2.angle(),
-                h1.length(), h2.length(), targetPx, lengthMode);
+        qreal c1 = h1.length();
+        qreal c2 = h2.length();
+        bool modified = false;
 
-            QLineF newH1(p1pt, p1pt + QPointF(solved.first, 0.0));
-            newH1.setAngle(h1.angle());
-            QLineF newH2(p4pt, p4pt + QPointF(solved.second, 0.0));
-            newH2.setAngle(h2.angle());
+        if (autoSmooth && hasTarget && targetPx > 0.0)
+        {
+            // Combined: vary Hobby tension to hit the target length.
+            const QPair<qreal, qreal> s = VAbstractCubicBezier::SolveHobbyTension(
+                p1pt, p4pt, angle1, angle2, targetPx, lengthMode);
+            c1 = s.first;
+            c2 = s.second;
+            modified = true;
+        }
+        else if (autoSmooth)
+        {
+            const QPair<qreal, qreal> s = VAbstractCubicBezier::HobbyHandleLengths(
+                p1pt, p4pt, angle1, angle2);
+            c1 = s.first;
+            c2 = s.second;
+            modified = true;
+        }
+        else if (hasTarget && targetPx > 0.0)
+        {
+            const QPair<qreal, qreal> s = VAbstractCubicBezier::SolveHandleLengths(
+                p1pt, p4pt, angle1, angle2, h1.length(), h2.length(), targetPx, lengthMode);
+            c1 = s.first;
+            c2 = s.second;
+            modified = true;
+        }
 
-            VPointF newP2(newH1.p2(), spline->GetP2().name(), spline->GetP2().mx(),
-                          spline->GetP2().my(), spline->GetP2().getIdObject(), spline->GetP2().getMode());
-            newP2.setId(origP2Id);
-            VPointF newP3(newH2.p2(), spline->GetP3().name(), spline->GetP3().mx(),
-                          spline->GetP3().my(), spline->GetP3().getIdObject(), spline->GetP3().getMode());
-            newP3.setId(origP3Id);
-            spline->SetP2(newP2);
-            spline->SetP3(newP3);
+        if (modified)
+        {
+            setHandlesFromLengths(spline, p1pt, p4pt, angle1, angle2, c1, c2, origP2Id, origP3Id);
         }
     }
 

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
@@ -479,14 +479,20 @@ void VToolCubicBezier::SetSplineAttributes(QDomElement &domElement, const VCubic
     if (m_lengthMode > 0)
     {
         doc->SetAttribute(domElement, AttrLengthMode, m_lengthMode);
-        if (!m_targetLength.isEmpty())
-        {
-            doc->SetAttribute(domElement, AttrLength, m_targetLength);
-        }
     }
     else
     {
         domElement.removeAttribute(AttrLengthMode);
+    }
+
+    // Persist the target length independently of the mode so toggling the mode
+    // Off and back On does not lose the user's entered value.
+    if (!m_targetLength.isEmpty())
+    {
+        doc->SetAttribute(domElement, AttrLength, m_targetLength);
+    }
+    else
+    {
         domElement.removeAttribute(AttrLength);
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
@@ -176,6 +176,12 @@ VToolCubicBezier *VToolCubicBezier::Create(const quint32 _id, VCubicBezier *spli
     const quint32 origP2Id = spline->GetP2().id();
     const quint32 origP3Id = spline->GetP3().id();
 
+    // Mutual-exclusive dispatch: the three handle-computation modes (Hobby,
+    // length-solver, combined tension-solver) each produce a DIFFERENT set of
+    // handle lengths from the SAME inputs. Running them sequentially (Hobby
+    // first, then solver on the result) would feed solver inputs that are
+    // already transformed, producing wrong geometry. The if/else-if ensures
+    // exactly one code-path modifies the handles per Create() call.
     {
         const QPointF p1pt = static_cast<QPointF>(spline->GetP1());
         const QPointF p4pt = static_cast<QPointF>(spline->GetP4());

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
@@ -206,6 +206,30 @@ void VToolCubicBezier::setSpline(const VCubicBezier &spl)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+bool VToolCubicBezier::GetAutoSmooth() const
+{
+    return false;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VToolCubicBezier::SetAutoSmooth(bool value)
+{
+    Q_UNUSED(value)
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+QString VToolCubicBezier::GetTargetLength() const
+{
+    return QString();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VToolCubicBezier::SetTargetLength(const QString &value)
+{
+    Q_UNUSED(value)
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 void VToolCubicBezier::ShowVisualization(bool show)
 {
     ShowToolVisualization<VisToolCubicBezier>(show);

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
@@ -135,6 +135,7 @@ void VToolCubicBezier::setDialog()
     dialogTool->SetSpline(*spl);
     dialogTool->SetAutoSmooth(m_autoSmooth);
     dialogTool->SetLengthMode(m_lengthMode);
+    dialogTool->SetTargetLength(m_targetLength);
     dialogTool->setLineColor(spl->getLineColor());
     dialogTool->setPenStyle(spl->GetPenStyle());
     dialogTool->setLineWeight(spl->getLineWeight());

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
@@ -186,6 +186,39 @@ VToolCubicBezier *VToolCubicBezier::Create(const quint32 _id, VCubicBezier *spli
         applyHobbyToSpline(spline, data, origP2Id, origP3Id);
     }
 
+    if (lengthMode > 0 && !targetLength.isEmpty())
+    {
+        QString tl = targetLength;
+        const qreal targetPx = qApp->toPixel(CheckFormula(_id, tl, data));
+        if (targetPx > 0.0)
+        {
+            const QPointF p1pt = static_cast<QPointF>(spline->GetP1());
+            const QPointF p2pt = static_cast<QPointF>(spline->GetP2());
+            const QPointF p3pt = static_cast<QPointF>(spline->GetP3());
+            const QPointF p4pt = static_cast<QPointF>(spline->GetP4());
+            const QLineF h1(p1pt, p2pt);
+            const QLineF h2(p4pt, p3pt);
+
+            const QPair<qreal, qreal> solved = VAbstractCubicBezier::SolveHandleLengths(
+                p1pt, p4pt, h1.angle(), h2.angle(),
+                h1.length(), h2.length(), targetPx, lengthMode);
+
+            QLineF newH1(p1pt, p1pt + QPointF(solved.first, 0.0));
+            newH1.setAngle(h1.angle());
+            QLineF newH2(p4pt, p4pt + QPointF(solved.second, 0.0));
+            newH2.setAngle(h2.angle());
+
+            VPointF newP2(newH1.p2(), spline->GetP2().name(), spline->GetP2().mx(),
+                          spline->GetP2().my(), spline->GetP2().getIdObject(), spline->GetP2().getMode());
+            newP2.setId(origP2Id);
+            VPointF newP3(newH2.p2(), spline->GetP3().name(), spline->GetP3().mx(),
+                          spline->GetP3().my(), spline->GetP3().getIdObject(), spline->GetP3().getMode());
+            newP3.setId(origP3Id);
+            spline->SetP2(newP2);
+            spline->SetP3(newP3);
+        }
+    }
+
     quint32 id = _id;
     if (typeCreation == Source::FromGui)
     {

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.h
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.h
@@ -99,6 +99,9 @@ public:
     QString              GetTargetLength() const;
     void                 SetTargetLength(const QString &value);
 
+    int                  GetLengthMode() const;
+    void                 SetLengthMode(int value);
+
     virtual void         ShowVisualization(bool show) override;
 
 

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.h
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.h
@@ -75,9 +75,11 @@ public:
 
     static VToolCubicBezier *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene *scene,
                                     VAbstractPattern *doc, VContainer *data);
-    static VToolCubicBezier *Create(const quint32 _id, VCubicBezier *spline, VMainGraphicsScene *scene,
-                                    VAbstractPattern *doc, VContainer *data, const Document &parse,
-                                    const Source &typeCreation);
+    static VToolCubicBezier *Create(const quint32 _id, VCubicBezier *spline,
+                                    bool autoSmooth,
+                                    VMainGraphicsScene *scene,
+                                    VAbstractPattern *doc, VContainer *data,
+                                    const Document &parse, const Source &typeCreation);
                                     
     static const QString ToolType;
     virtual int          type() const override {return Type;}
@@ -114,7 +116,10 @@ private:
     Q_DISABLE_COPY(VToolCubicBezier)
 
                          VToolCubicBezier(VAbstractPattern *doc, VContainer *data, quint32 id,
-                                          const Source &typeCreation, QGraphicsItem * parent = nullptr);
+                                          bool autoSmooth,
+                                          const Source &typeCreation, QGraphicsItem *parent = nullptr);
+
+    bool                 m_autoSmooth;
 
     void                 SetSplineAttributes(QDomElement &domElement, const VCubicBezier &spl);
 };

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.h
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.h
@@ -106,6 +106,7 @@ protected slots:
     virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
     virtual void         RemoveReferens() override;
     virtual void         SaveDialog(QDomElement &domElement) override;
     virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
@@ -120,6 +121,8 @@ private:
                                           const Source &typeCreation, QGraphicsItem *parent = nullptr);
 
     bool                 m_autoSmooth;
+    quint32              m_p2Id;
+    quint32              m_p3Id;
 
     void                 SetSplineAttributes(QDomElement &domElement, const VCubicBezier &spl);
 };

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.h
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.h
@@ -91,6 +91,12 @@ public:
     VCubicBezier         getSpline()const;
     void                 setSpline(const VCubicBezier &spl);
 
+    bool                 GetAutoSmooth() const;
+    void                 SetAutoSmooth(bool value);
+
+    QString              GetTargetLength() const;
+    void                 SetTargetLength(const QString &value);
+
     virtual void         ShowVisualization(bool show) override;
 
 

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.h
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.h
@@ -76,7 +76,8 @@ public:
     static VToolCubicBezier *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene *scene,
                                     VAbstractPattern *doc, VContainer *data);
     static VToolCubicBezier *Create(const quint32 _id, VCubicBezier *spline,
-                                    bool autoSmooth,
+                                    bool autoSmooth, int lengthMode,
+                                    const QString &targetLength,
                                     VMainGraphicsScene *scene,
                                     VAbstractPattern *doc, VContainer *data,
                                     const Document &parse, const Source &typeCreation);
@@ -120,10 +121,13 @@ private:
     Q_DISABLE_COPY(VToolCubicBezier)
 
                          VToolCubicBezier(VAbstractPattern *doc, VContainer *data, quint32 id,
-                                          bool autoSmooth,
+                                          bool autoSmooth, int lengthMode,
+                                          const QString &targetLength,
                                           const Source &typeCreation, QGraphicsItem *parent = nullptr);
 
     bool                 m_autoSmooth;
+    int                  m_lengthMode;
+    QString              m_targetLength;
     quint32              m_p2Id;
     quint32              m_p3Id;
 

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
@@ -249,27 +249,37 @@ VToolSpline *VToolSpline::Create(const quint32 _id, quint32 point1, quint32 poin
     qreal finalLength1 = calcLength1;
     qreal finalLength2 = calcLength2;
 
-    if (autoSmooth)
-    {
-        const QPair<qreal, qreal> hobby = VAbstractCubicBezier::HobbyHandleLengths(
-            static_cast<QPointF>(*p1), static_cast<QPointF>(*p4), calcAngle1, calcAngle2);
-        finalLength1 = hobby.first;
-        finalLength2 = hobby.second;
-    }
-
-    if (lengthMode > 0 && !targetLength.isEmpty())
+    const bool hasTarget = (lengthMode > 0 && !targetLength.isEmpty());
+    qreal targetPx = 0.0;
+    if (hasTarget)
     {
         QString tl = targetLength;
-        const qreal targetPx = qApp->toPixel(CheckFormula(_id, tl, data));
-        if (targetPx > 0.0)
-        {
-            const QPair<qreal, qreal> solved = VAbstractCubicBezier::SolveHandleLengths(
-                static_cast<QPointF>(*p1), static_cast<QPointF>(*p4),
-                calcAngle1, calcAngle2, finalLength1, finalLength2,
-                targetPx, lengthMode);
-            finalLength1 = solved.first;
-            finalLength2 = solved.second;
-        }
+        targetPx = qApp->toPixel(CheckFormula(_id, tl, data));
+    }
+
+    if (autoSmooth && hasTarget && targetPx > 0.0)
+    {
+        // Combined: vary Hobby tension to hit the target length.
+        const QPair<qreal, qreal> s = VAbstractCubicBezier::SolveHobbyTension(
+            static_cast<QPointF>(*p1), static_cast<QPointF>(*p4),
+            calcAngle1, calcAngle2, targetPx, lengthMode);
+        finalLength1 = s.first;
+        finalLength2 = s.second;
+    }
+    else if (autoSmooth)
+    {
+        const QPair<qreal, qreal> s = VAbstractCubicBezier::HobbyHandleLengths(
+            static_cast<QPointF>(*p1), static_cast<QPointF>(*p4), calcAngle1, calcAngle2);
+        finalLength1 = s.first;
+        finalLength2 = s.second;
+    }
+    else if (hasTarget && targetPx > 0.0)
+    {
+        const QPair<qreal, qreal> s = VAbstractCubicBezier::SolveHandleLengths(
+            static_cast<QPointF>(*p1), static_cast<QPointF>(*p4),
+            calcAngle1, calcAngle2, calcLength1, calcLength2, targetPx, lengthMode);
+        finalLength1 = s.first;
+        finalLength2 = s.second;
     }
 
     auto spline = new VSpline(*p1, *p4, calcAngle1, a1, calcAngle2, a2, finalLength1, l1, finalLength2, l2);

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
@@ -266,6 +266,30 @@ void VToolSpline::setSpline(const VSpline &spl)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+bool VToolSpline::GetAutoSmooth() const
+{
+    return false;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VToolSpline::SetAutoSmooth(bool value)
+{
+    Q_UNUSED(value)
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+QString VToolSpline::GetTargetLength() const
+{
+    return QString();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VToolSpline::SetTargetLength(const QString &value)
+{
+    Q_UNUSED(value)
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 void VToolSpline::ShowVisualization(bool show)
 {
     ShowToolVisualization<VisToolSpline>(show);

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
@@ -97,11 +97,14 @@ const QString VToolSpline::OldToolType = QStringLiteral("simple");
 // @param typeCreation way we create this tool.
 // @param parent parent object.
 VToolSpline::VToolSpline(VAbstractPattern *doc, VContainer *data, quint32 id,
-                         bool autoSmooth, const Source &typeCreation,
-                         QGraphicsItem *parent)
+                         bool autoSmooth, int lengthMode,
+                         const QString &targetLength,
+                         const Source &typeCreation, QGraphicsItem *parent)
     : VAbstractSpline(doc, data, id, parent)
     , oldPosition()
     , m_autoSmooth(autoSmooth)
+    , m_lengthMode(lengthMode)
+    , m_targetLength(targetLength)
 {
     m_sceneType = SceneObject::Spline;
 
@@ -148,6 +151,7 @@ void VToolSpline::setDialog()
     const auto spl = VAbstractTool::data.GeometricObject<VSpline>(m_id);
     dialogTool->SetSpline(*spl);
     dialogTool->SetAutoSmooth(m_autoSmooth);
+    dialogTool->SetLengthMode(m_lengthMode);
     dialogTool->setLineColor(spl->getLineColor());
     dialogTool->setLineWeight(spl->getLineWeight());
     dialogTool->setPenStyle(spl->GetPenStyle());
@@ -214,7 +218,7 @@ VToolSpline* VToolSpline::Create(const quint32 _id, VSpline *spline, VMainGraphi
     if (parse == Document::FullParse)
     {
         VDrawTool::AddRecord(id, Tool::Spline, doc);
-        auto _spl = new VToolSpline(doc, data, id, autoSmooth, typeCreation);
+        auto _spl = new VToolSpline(doc, data, id, autoSmooth, 0, QString(), typeCreation);
         scene->addItem(_spl);
         initSplineToolConnections(scene, _spl);
         VAbstractPattern::AddTool(id, _spl);
@@ -298,26 +302,34 @@ void VToolSpline::SetAutoSmooth(bool value)
 //---------------------------------------------------------------------------------------------------------------------
 QString VToolSpline::GetTargetLength() const
 {
-    const auto spl = VAbstractTool::data.GeometricObject<VSpline>(m_id);
-    return QString::number(qApp->fromPixel(spl->GetLength()));
+    if (m_targetLength.isEmpty())
+    {
+        const auto spl = VAbstractTool::data.GeometricObject<VSpline>(m_id);
+        return QString::number(qApp->fromPixel(spl->GetLength()));
+    }
+    return m_targetLength;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void VToolSpline::SetTargetLength(const QString &value)
 {
-    Q_UNUSED(value)
+    m_targetLength = value;
+    QSharedPointer<VGObject> obj = VAbstractTool::data.GetGObject(m_id);
+    SaveOption(obj);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 int VToolSpline::GetLengthMode() const
 {
-    return 0;
+    return m_lengthMode;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void VToolSpline::SetLengthMode(int value)
 {
-    Q_UNUSED(value)
+    m_lengthMode = value;
+    QSharedPointer<VGObject> obj = VAbstractTool::data.GetGObject(m_id);
+    SaveOption(obj);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -374,6 +386,8 @@ void VToolSpline::showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32
 void VToolSpline::ReadToolAttributes(const QDomElement &domElement)
 {
     m_autoSmooth = (domElement.attribute(AttrAutoSmooth) == QStringLiteral("true"));
+    m_lengthMode = domElement.attribute(AttrLengthMode, QStringLiteral("0")).toInt();
+    m_targetLength = domElement.attribute(AttrLength, QString());
 }
 
 // @brief RemoveReferens decrement value of reference.
@@ -393,6 +407,8 @@ void VToolSpline::SaveDialog(QDomElement &domElement)
 
     const VSpline spl = dialogTool->GetSpline();
     m_autoSmooth = dialogTool->GetAutoSmooth();
+    m_lengthMode = dialogTool->GetLengthMode();
+    m_targetLength = dialogTool->GetTargetLength();
 
     m_controlPoints[0]->blockSignals(true);
     m_controlPoints[1]->blockSignals(true);
@@ -705,5 +721,19 @@ void VToolSpline::SetSplineAttributes(QDomElement &domElement, const VSpline &sp
     else
     {
         domElement.removeAttribute(AttrAutoSmooth);
+    }
+
+    if (m_lengthMode > 0)
+    {
+        doc->SetAttribute(domElement, AttrLengthMode, m_lengthMode);
+        if (!m_targetLength.isEmpty())
+        {
+            doc->SetAttribute(domElement, AttrLength, m_targetLength);
+        }
+    }
+    else
+    {
+        domElement.removeAttribute(AttrLengthMode);
+        domElement.removeAttribute(AttrLength);
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
@@ -234,7 +234,8 @@ VToolSpline *VToolSpline::Create(const quint32 _id, quint32 point1, quint32 poin
                                  QString &l1, QString &l2, quint32 duplicate, const QString &color,
                                  const QString &penStyle, const QString &lineWeight, VMainGraphicsScene *scene,
                                  VAbstractPattern *doc, VContainer *data, const Document &parse,
-                                 const Source &typeCreation, bool autoSmooth)
+                                 const Source &typeCreation, bool autoSmooth,
+                                 int lengthMode, const QString &targetLength)
 {
     const qreal calcAngle1 = CheckFormula(_id, a1, data);
     const qreal calcAngle2 = CheckFormula(_id, a2, data);
@@ -254,6 +255,21 @@ VToolSpline *VToolSpline::Create(const quint32 _id, quint32 point1, quint32 poin
             static_cast<QPointF>(*p1), static_cast<QPointF>(*p4), calcAngle1, calcAngle2);
         finalLength1 = hobby.first;
         finalLength2 = hobby.second;
+    }
+
+    if (lengthMode > 0 && !targetLength.isEmpty())
+    {
+        QString tl = targetLength;
+        const qreal targetPx = qApp->toPixel(CheckFormula(_id, tl, data));
+        if (targetPx > 0.0)
+        {
+            const QPair<qreal, qreal> solved = VAbstractCubicBezier::SolveHandleLengths(
+                static_cast<QPointF>(*p1), static_cast<QPointF>(*p4),
+                calcAngle1, calcAngle2, finalLength1, finalLength2,
+                targetPx, lengthMode);
+            finalLength1 = solved.first;
+            finalLength2 = solved.second;
+        }
     }
 
     auto spline = new VSpline(*p1, *p4, calcAngle1, a1, calcAngle2, a2, finalLength1, l1, finalLength2, l2);
@@ -726,14 +742,20 @@ void VToolSpline::SetSplineAttributes(QDomElement &domElement, const VSpline &sp
     if (m_lengthMode > 0)
     {
         doc->SetAttribute(domElement, AttrLengthMode, m_lengthMode);
-        if (!m_targetLength.isEmpty())
-        {
-            doc->SetAttribute(domElement, AttrLength, m_targetLength);
-        }
     }
     else
     {
         domElement.removeAttribute(AttrLengthMode);
+    }
+
+    // Persist the target length independently of the mode so toggling the mode
+    // Off and back On does not lose the user's entered value.
+    if (!m_targetLength.isEmpty())
+    {
+        doc->SetAttribute(domElement, AttrLength, m_targetLength);
+    }
+    else
+    {
         domElement.removeAttribute(AttrLength);
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
@@ -96,10 +96,12 @@ const QString VToolSpline::OldToolType = QStringLiteral("simple");
 // @param id object id in container.
 // @param typeCreation way we create this tool.
 // @param parent parent object.
-VToolSpline::VToolSpline(VAbstractPattern *doc, VContainer *data, quint32 id, const Source &typeCreation,
+VToolSpline::VToolSpline(VAbstractPattern *doc, VContainer *data, quint32 id,
+                         bool autoSmooth, const Source &typeCreation,
                          QGraphicsItem *parent)
     : VAbstractSpline(doc, data, id, parent)
     , oldPosition()
+    , m_autoSmooth(autoSmooth)
 {
     m_sceneType = SceneObject::Spline;
 
@@ -145,6 +147,7 @@ void VToolSpline::setDialog()
     SCASSERT(!dialogTool.isNull())
     const auto spl = VAbstractTool::data.GeometricObject<VSpline>(m_id);
     dialogTool->SetSpline(*spl);
+    dialogTool->SetAutoSmooth(m_autoSmooth);
     dialogTool->setLineColor(spl->getLineColor());
     dialogTool->setLineWeight(spl->getLineWeight());
     dialogTool->setPenStyle(spl->GetPenStyle());
@@ -167,8 +170,9 @@ VToolSpline* VToolSpline::Create(QSharedPointer<DialogTool> dialog, VMainGraphic
     spline->setLineColor(dialogTool->getLineColor());
     spline->SetPenStyle(dialogTool->getPenStyle());
     spline->setLineWeight(dialogTool->getLineWeight());
+    const bool autoSmooth = dialogTool->GetAutoSmooth();
 
-    auto spl = Create(0, spline, scene, doc, data, Document::FullParse, Source::FromGui);
+    auto spl = Create(0, spline, scene, doc, data, Document::FullParse, Source::FromGui, autoSmooth);
 
     if (spl != nullptr)
     {
@@ -187,7 +191,8 @@ VToolSpline* VToolSpline::Create(QSharedPointer<DialogTool> dialog, VMainGraphic
 // @param typeCreation way we create this tool.
 // @return the created tool
 VToolSpline* VToolSpline::Create(const quint32 _id, VSpline *spline, VMainGraphicsScene *scene, VAbstractPattern *doc,
-                                 VContainer *data, const Document &parse, const Source &typeCreation)
+                                 VContainer *data, const Document &parse, const Source &typeCreation,
+                                 bool autoSmooth)
 {
     quint32 id = _id;
 
@@ -209,7 +214,7 @@ VToolSpline* VToolSpline::Create(const quint32 _id, VSpline *spline, VMainGraphi
     if (parse == Document::FullParse)
     {
         VDrawTool::AddRecord(id, Tool::Spline, doc);
-        auto _spl = new VToolSpline(doc, data, id, typeCreation);
+        auto _spl = new VToolSpline(doc, data, id, autoSmooth, typeCreation);
         scene->addItem(_spl);
         initSplineToolConnections(scene, _spl);
         VAbstractPattern::AddTool(id, _spl);
@@ -225,7 +230,7 @@ VToolSpline *VToolSpline::Create(const quint32 _id, quint32 point1, quint32 poin
                                  QString &l1, QString &l2, quint32 duplicate, const QString &color,
                                  const QString &penStyle, const QString &lineWeight, VMainGraphicsScene *scene,
                                  VAbstractPattern *doc, VContainer *data, const Document &parse,
-                                 const Source &typeCreation)
+                                 const Source &typeCreation, bool autoSmooth)
 {
     const qreal calcAngle1 = CheckFormula(_id, a1, data);
     const qreal calcAngle2 = CheckFormula(_id, a2, data);
@@ -246,7 +251,7 @@ VToolSpline *VToolSpline::Create(const quint32 _id, quint32 point1, quint32 poin
     spline->SetPenStyle(penStyle);
     spline->setLineWeight(lineWeight);
 
-    return VToolSpline::Create(_id, spline, scene, doc, data, parse, typeCreation);
+    return VToolSpline::Create(_id, spline, scene, doc, data, parse, typeCreation, autoSmooth);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -268,13 +273,15 @@ void VToolSpline::setSpline(const VSpline &spl)
 //---------------------------------------------------------------------------------------------------------------------
 bool VToolSpline::GetAutoSmooth() const
 {
-    return false;
+    return m_autoSmooth;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void VToolSpline::SetAutoSmooth(bool value)
 {
-    Q_UNUSED(value)
+    m_autoSmooth = value;
+    QSharedPointer<VGObject> obj = VAbstractTool::data.GetGObject(m_id);
+    SaveOption(obj);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -355,6 +362,7 @@ void VToolSpline::SaveDialog(QDomElement &domElement)
     SCASSERT(dialogTool != nullptr)
 
     const VSpline spl = dialogTool->GetSpline();
+    m_autoSmooth = dialogTool->GetAutoSmooth();
 
     m_controlPoints[0]->blockSignals(true);
     m_controlPoints[1]->blockSignals(true);
@@ -654,5 +662,14 @@ void VToolSpline::SetSplineAttributes(QDomElement &domElement, const VSpline &sp
     if (domElement.hasAttribute(AttrKAsm2))
     {
         domElement.removeAttribute(AttrKAsm2);
+    }
+
+    if (m_autoSmooth)
+    {
+        doc->SetAttribute(domElement, AttrAutoSmooth, QStringLiteral("true"));
+    }
+    else
+    {
+        domElement.removeAttribute(AttrAutoSmooth);
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
@@ -298,11 +298,24 @@ void VToolSpline::SetAutoSmooth(bool value)
 //---------------------------------------------------------------------------------------------------------------------
 QString VToolSpline::GetTargetLength() const
 {
-    return QString();
+    const auto spl = VAbstractTool::data.GeometricObject<VSpline>(m_id);
+    return QString::number(qApp->fromPixel(spl->GetLength()));
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void VToolSpline::SetTargetLength(const QString &value)
+{
+    Q_UNUSED(value)
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+int VToolSpline::GetLengthMode() const
+{
+    return 0;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VToolSpline::SetLengthMode(int value)
 {
     Q_UNUSED(value)
 }

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
@@ -249,6 +249,12 @@ VToolSpline *VToolSpline::Create(const quint32 _id, quint32 point1, quint32 poin
     qreal finalLength1 = calcLength1;
     qreal finalLength2 = calcLength2;
 
+    // Mutual-exclusive dispatch: the three handle-computation modes (Hobby,
+    // length-solver, combined tension-solver) each produce a DIFFERENT set of
+    // handle lengths from the SAME inputs. Running them sequentially (Hobby
+    // first, then solver on the result) would feed solver inputs that are
+    // already transformed, producing wrong geometry. The if/else-if ensures
+    // exactly one code-path modifies the handles per Create() call.
     const bool hasTarget = (lengthMode > 0 && !targetLength.isEmpty());
     qreal targetPx = 0.0;
     if (hasTarget)

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
@@ -241,7 +241,18 @@ VToolSpline *VToolSpline::Create(const quint32 _id, quint32 point1, quint32 poin
     auto p1 = data->GeometricObject<VPointF>(point1);
     auto p4 = data->GeometricObject<VPointF>(point4);
 
-    auto spline = new VSpline(*p1, *p4, calcAngle1, a1, calcAngle2, a2, calcLength1, l1, calcLength2, l2);
+    qreal finalLength1 = calcLength1;
+    qreal finalLength2 = calcLength2;
+
+    if (autoSmooth)
+    {
+        const QPair<qreal, qreal> hobby = VAbstractCubicBezier::HobbyHandleLengths(
+            static_cast<QPointF>(*p1), static_cast<QPointF>(*p4), calcAngle1, calcAngle2);
+        finalLength1 = hobby.first;
+        finalLength2 = hobby.second;
+    }
+
+    auto spline = new VSpline(*p1, *p4, calcAngle1, a1, calcAngle2, a2, finalLength1, l1, finalLength2, l2);
     if (duplicate > 0)
     {
         spline->SetDuplicate(duplicate);
@@ -344,6 +355,12 @@ void VToolSpline::showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32
         Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VToolSpline::ReadToolAttributes(const QDomElement &domElement)
+{
+    m_autoSmooth = (domElement.attribute(AttrAutoSmooth) == QStringLiteral("true"));
 }
 
 // @brief RemoveReferens decrement value of reference.
@@ -565,6 +582,10 @@ void VToolSpline::SetVisualization()
         visual->SetKAsm2(spl->GetKasm2());
         visual->SetKCurve(spl->GetKcurve());
         visual->setLineStyle(lineTypeToPenStyle(spl->GetPenStyle()));
+        visual->setShowPoints(static_cast<QPointF>(spl->GetP1()),
+                              static_cast<QPointF>(spl->GetP2()),
+                              static_cast<QPointF>(spl->GetP3()),
+                              static_cast<QPointF>(spl->GetP4()));
         visual->SetMode(Mode::Show);
         visual->RefreshGeometry();
     }

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
@@ -152,6 +152,7 @@ void VToolSpline::setDialog()
     dialogTool->SetSpline(*spl);
     dialogTool->SetAutoSmooth(m_autoSmooth);
     dialogTool->SetLengthMode(m_lengthMode);
+    dialogTool->SetTargetLength(m_targetLength);
     dialogTool->setLineColor(spl->getLineColor());
     dialogTool->setLineWeight(spl->getLineWeight());
     dialogTool->setPenStyle(spl->GetPenStyle());

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.h
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.h
@@ -98,6 +98,9 @@ public:
     QString       GetTargetLength() const;
     void          SetTargetLength(const QString &value);
 
+    int           GetLengthMode() const;
+    void          SetLengthMode(int value);
+
     virtual void  ShowVisualization(bool show) override;
 
 public slots:

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.h
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.h
@@ -109,6 +109,7 @@ protected slots:
     virtual void  showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
+    virtual void  ReadToolAttributes(const QDomElement &domElement) override;
     virtual void  RemoveReferens() override;
     virtual void  SaveDialog(QDomElement &domElement) override;
     virtual void  SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.h
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.h
@@ -83,7 +83,8 @@ public:
                                QString &l2, quint32 duplicate, const QString &color, const QString &penStyle,
                                const QString &lineWeight, VMainGraphicsScene *scene, VAbstractPattern *doc,
                                VContainer *data, const Document &parse, const Source &typeCreation,
-                               bool autoSmooth = false);
+                               bool autoSmooth = false, int lengthMode = 0,
+                               const QString &targetLength = QString());
     static const QString ToolType;
     static const QString OldToolType;
     virtual int   type() const override {return Type;}

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.h
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.h
@@ -90,6 +90,12 @@ public:
     VSpline       getSpline()const;
     void          setSpline(const VSpline &spl);
 
+    bool          GetAutoSmooth() const;
+    void          SetAutoSmooth(bool value);
+
+    QString       GetTargetLength() const;
+    void          SetTargetLength(const QString &value);
+
     virtual void  ShowVisualization(bool show) override;
 
 public slots:

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.h
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.h
@@ -77,11 +77,13 @@ public:
                                VContainer *data);
     static VToolSpline *Create(const quint32 _id, VSpline *spline,
                                VMainGraphicsScene *scene, VAbstractPattern *doc, VContainer *data,
-                               const Document &parse, const Source &typeCreation);
+                               const Document &parse, const Source &typeCreation,
+                               bool autoSmooth = false);
     static VToolSpline *Create(const quint32 _id, quint32 point1, quint32 point4, QString &a1, QString &a2, QString &l1,
                                QString &l2, quint32 duplicate, const QString &color, const QString &penStyle,
                                const QString &lineWeight, VMainGraphicsScene *scene, VAbstractPattern *doc,
-                               VContainer *data, const Document &parse, const Source &typeCreation);
+                               VContainer *data, const Document &parse, const Source &typeCreation,
+                               bool autoSmooth = false);
     static const QString ToolType;
     static const QString OldToolType;
     virtual int   type() const override {return Type;}
@@ -121,9 +123,11 @@ protected:
 private:
     Q_DISABLE_COPY(VToolSpline)
     QPointF       oldPosition;
+    bool          m_autoSmooth;
 
                   VToolSpline (VAbstractPattern *doc, VContainer *data, quint32 id,
-                               const Source &typeCreation, QGraphicsItem * parent = nullptr );
+                               bool autoSmooth,
+                               const Source &typeCreation, QGraphicsItem *parent = nullptr);
 
     bool          IsMovable() const;
     void          SetSplineAttributes(QDomElement &domElement, const VSpline &spl);

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.h
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.h
@@ -128,9 +128,12 @@ private:
     Q_DISABLE_COPY(VToolSpline)
     QPointF       oldPosition;
     bool          m_autoSmooth;
+    int           m_lengthMode;
+    QString       m_targetLength;
 
                   VToolSpline (VAbstractPattern *doc, VContainer *data, quint32 id,
-                               bool autoSmooth,
+                               bool autoSmooth, int lengthMode,
+                               const QString &targetLength,
                                const Source &typeCreation, QGraphicsItem *parent = nullptr);
 
     bool          IsMovable() const;

--- a/src/libs/vtools/visualization/path/vistoolcubicbezier.cpp
+++ b/src/libs/vtools/visualization/path/vistoolcubicbezier.cpp
@@ -74,6 +74,11 @@ VisToolCubicBezier::VisToolCubicBezier(const VContainer *data, QGraphicsItem *pa
       object2Id(NULL_ID),
       object3Id(NULL_ID),
       object4Id(NULL_ID),
+      m_showPointsSet(false),
+      m_showP1(),
+      m_showP2(),
+      m_showP3(),
+      m_showP4(),
       point1(nullptr),
       point2(nullptr),
       point3(nullptr),
@@ -93,6 +98,27 @@ VisToolCubicBezier::VisToolCubicBezier(const VContainer *data, QGraphicsItem *pa
 //---------------------------------------------------------------------------------------------------------------------
 void VisToolCubicBezier::RefreshGeometry()
 {
+    // Show mode: draw the final computed geometry directly from the 4 stored points.
+    // This is the single source of truth — Hobby, force-length or any future modifier
+    // simply produces different control-point positions, no extra visualization code.
+    if (mode == Mode::Show && m_showPointsSet)
+    {
+        const VPointF sp1(m_showP1);
+        const VPointF sp2(m_showP2);
+        const VPointF sp3(m_showP3);
+        const VPointF sp4(m_showP4);
+        const VCubicBezier spline(sp1, sp2, sp3, sp4);
+        DrawPath(this, spline.GetPath(), spline.DirectionArrows(), mainColor, lineStyle,
+                 lineWeight, Qt::RoundCap);
+        DrawPoint(point1, m_showP1, supportColor);
+        DrawPoint(point2, m_showP2, mainColor);
+        DrawPoint(point3, m_showP3, mainColor);
+        DrawPoint(point4, m_showP4, supportColor);
+        DrawLine(helpLine1, QLineF(m_showP1, m_showP2), mainColor, lineWeight, Qt::DashLine);
+        DrawLine(helpLine2, QLineF(m_showP4, m_showP3), mainColor, lineWeight, Qt::DashLine);
+        return;
+    }
+
     if (object1Id > NULL_ID)
     {
         const auto first = Visualization::data->GeometricObject<VPointF>(object1Id);
@@ -160,4 +186,15 @@ void VisToolCubicBezier::setObject3Id(const quint32 &value)
 void VisToolCubicBezier::setObject4Id(const quint32 &value)
 {
     object4Id = value;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VisToolCubicBezier::setShowPoints(const QPointF &p1, const QPointF &p2,
+                                       const QPointF &p3, const QPointF &p4)
+{
+    m_showP1 = p1;
+    m_showP2 = p2;
+    m_showP3 = p3;
+    m_showP4 = p4;
+    m_showPointsSet = true;
 }

--- a/src/libs/vtools/visualization/path/vistoolcubicbezier.h
+++ b/src/libs/vtools/visualization/path/vistoolcubicbezier.h
@@ -56,6 +56,7 @@
 #include <QGraphicsItem>
 #include <QMetaObject>
 #include <QObject>
+#include <QPointF>
 #include <QString>
 #include <QtGlobal>
 
@@ -75,6 +76,9 @@ public:
     void         setObject3Id(const quint32 &value);
     void         setObject4Id(const quint32 &value);
 
+    void         setShowPoints(const QPointF &p1, const QPointF &p2,
+                               const QPointF &p3, const QPointF &p4);
+
     virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolCubicBezier)};
 protected:
@@ -82,6 +86,11 @@ protected:
     quint32         object2Id;
     quint32         object3Id;
     quint32         object4Id;
+    bool            m_showPointsSet;
+    QPointF         m_showP1;
+    QPointF         m_showP2;
+    QPointF         m_showP3;
+    QPointF         m_showP4;
     VScaledEllipse *point1;
     VScaledEllipse *point2;
     VScaledEllipse *point3;

--- a/src/libs/vtools/visualization/path/vistoolspline.cpp
+++ b/src/libs/vtools/visualization/path/vistoolspline.cpp
@@ -61,6 +61,7 @@
 #include "../vgeometry/vabstractcurve.h"
 #include "../vgeometry/vgeometrydef.h"
 #include "../vgeometry/vpointf.h"
+#include "../vgeometry/vcubicbezier.h"
 #include "../vgeometry/vspline.h"
 #include "../vpatterndb/vcontainer.h"
 #include "../vwidgets/vcontrolpointspline.h"
@@ -83,6 +84,11 @@ VisToolSpline::VisToolSpline(const VContainer *data, QGraphicsItem *parent)
       isLeftMousePressed(false),
       p2Selected(false),
       p3Selected(false),
+      m_showPointsSet(false),
+      m_showP1(),
+      m_showP2(),
+      m_showP3(),
+      m_showP4(),
       p2(),
       p3(),
       controlPoints()
@@ -108,6 +114,20 @@ VisToolSpline::~VisToolSpline()
 //---------------------------------------------------------------------------------------------------------------------
 void VisToolSpline::RefreshGeometry()
 {
+    if (mode == Mode::Show && m_showPointsSet)
+    {
+        const VPointF sp1(m_showP1);
+        const VPointF sp2(m_showP2);
+        const VPointF sp3(m_showP3);
+        const VPointF sp4(m_showP4);
+        const VCubicBezier spline(sp1, sp2, sp3, sp4);
+        DrawPath(this, spline.GetPath(), spline.DirectionArrows(), mainColor, lineStyle,
+                 lineWeight, Qt::RoundCap);
+        DrawPoint(point1, m_showP1, supportColor);
+        DrawPoint(point4, m_showP4, supportColor);
+        return;
+    }
+
     //Radius of point circle, but little bigger. Need handle with hover sizes.
     const static qreal radius = defPointRadiusPixel*1.5;
 
@@ -262,4 +282,15 @@ void VisToolSpline::MouseLeftReleased()
         isLeftMousePressed = false;
         RefreshGeometry();
     }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VisToolSpline::setShowPoints(const QPointF &p1, const QPointF &p2,
+                                  const QPointF &p3, const QPointF &p4)
+{
+    m_showP1 = p1;
+    m_showP2 = p2;
+    m_showP3 = p3;
+    m_showP4 = p4;
+    m_showPointsSet = true;
 }

--- a/src/libs/vtools/visualization/path/vistoolspline.h
+++ b/src/libs/vtools/visualization/path/vistoolspline.h
@@ -85,6 +85,9 @@ public:
     QPointF      GetP2() const;
     QPointF      GetP3() const;
 
+    void         setShowPoints(const QPointF &p1, const QPointF &p2,
+                               const QPointF &p3, const QPointF &p4);
+
     virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolSpline)};
 public slots:
@@ -105,6 +108,11 @@ protected:
     bool isLeftMousePressed;
     bool p2Selected;
     bool p3Selected;
+    bool m_showPointsSet;
+    QPointF m_showP1;
+    QPointF m_showP2;
+    QPointF m_showP3;
+    QPointF m_showP4;
 
     QPointF p2;
     QPointF p3;


### PR DESCRIPTION
## Summary

Adds two new curve properties — **Auto-Smooth** and **Curve Length** — to both Curve Fixed (`VToolCubicBezier`) and Curve Interactive (`VToolSpline`), with a combined tension-based mode when both are active.

- **Auto-Smooth** computes optimal handle lengths using the Hobby/MetaPost velocity function, preserving user-set handle directions
- **Curve Length** adjusts handle lengths (via secant method with bracket search) to match a target arc length, with per-handle control (Start / End / Both)
- **Combined mode** varies the Hobby tension parameter τ (via secant method) instead of linearly scaling handles, keeping the natural Hobby curve shape at any target length
- New schema version **v0.7.4** with `autoSmooth`, `lengthMode`, `length` attributes and converter from v0.7.3

## Details

### Math (in `VAbstractCubicBezier`)
- `HobbyHandleLengths()` — Hobby/MetaPost velocity function with optional tension parameters
- `CubicBezierLengthGL()` — 8-point Gauss-Legendre quadrature for fast arc length
- `SolveHandleLengths()` — secant method with bracket search for length-only mode
- `SolveHobbyTension()` — secant method with bracket search for combined auto-smooth + length mode

### UI
- **Dialog**: Auto-Smooth dropdown (No/Yes), Adjust Length dropdown (Off/Start/End/Both), curve length formula field with result label
- **Property Editor**: same controls, synchronized with dialog values
- Auto-switch: typing a curve length value while mode is Off automatically switches to Both
- Toggle preservation: switching Adjust Length to Off keeps the stored value; switching back restores it
- Default curve length field shows current arc length when no target is set

### Architecture
- `Create()` uses mutual-exclusive dispatch (documented in code): exactly one of plain / Hobby / solver / tension-solver modifies handles per call — sequential application would feed already-transformed values to the next stage
- Visualization (`setShowPoints()` pattern) renders the computed curve independently of canvas point positions, surviving mouseMove refresh cycles
- Fixes pre-existing reference counting bug in `VToolCubicBezier::Create()` (P1 incremented 3× instead of P1/P2/P3/P4)

## Files changed (25 files, +2694 / −33)

| Area | Files |
|------|-------|
| Math | `vabstractcubicbezier.h/.cpp` |
| Schema | `v0.7.4.xsd`, `vpatternconverter.h/.cpp`, `ifcdef.h/.cpp`, `schema.qrc` |
| Tools | `vtoolcubicbezier.h/.cpp`, `vtoolspline.h/.cpp` |
| Dialogs | `dialogcubicbezier.h/.cpp/.ui`, `dialogspline.h/.cpp/.ui` |
| Property Editor | `vtooloptionspropertybrowser.h/.cpp` |
| Visualization | `vistoolcubicbezier.h/.cpp`, `vistoolspline.h/.cpp` |
| XML Parse | `vpattern.cpp` |

## Test plan

- [ ] Create Curve Fixed with Auto-Smooth=Yes → handles jump to Hobby lengths
- [ ] Create Curve Interactive with Auto-Smooth=Yes → same behavior
- [ ] Set Adjust Length=Both with target value → curve matches length
- [ ] Auto-Smooth + Length combined → natural Hobby shape at target length
- [ ] Start/End mode → only one handle varies
- [ ] Toggle Off → value preserved; toggle back → value restored
- [ ] Save, close, reopen → all attributes persisted
- [ ] Property Editor matches Dialog values
- [ ] Undo/Redo works correctly
- [ ] Open pre-v0.7.4 file → schema converts cleanly