### PR TITLE
fix: validate curve length formula in dialogs

### DIFF
--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp
@@ -256,7 +256,8 @@ void DialogCubicBezier::EvalCurveLength()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogCubicBezier::updateCurveLengthEnabled()
 {
-    if (ui->comboBoxLengthMode->currentIndex() == 0)
+    if (ui->comboBoxLengthMode->currentIndex() == 0
+        && ui->plainTextEditCurveLength->toPlainText().trimmed().isEmpty())
     {
         flagCurveLength = true;
     }

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp
@@ -56,6 +56,7 @@
 #include <QPlainTextEdit>
 #include <QPointer>
 #include <QPushButton>
+#include <QTimer>
 #include <new>
 
 #include "../../tools/vabstracttool.h"
@@ -79,6 +80,8 @@ DialogCubicBezier::DialogCubicBezier(const VContainer *data, const quint32 &tool
     , m_computedSpl()
     , m_hasComputedSpl(false)
     , newDuplicate(-1)
+    , timerCurveLength(new QTimer(this))
+    , flagCurveLength(true)
 {
     ui->setupUi(this);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
@@ -118,7 +121,7 @@ DialogCubicBezier::DialogCubicBezier(const VContainer *data, const quint32 &tool
         ui->lineType_ComboBox->setCurrentIndex(index);
     }
 
-    DialogTool::CheckState();
+    CheckState();
 
     connect(ui->comboBoxP1, &QComboBox::currentTextChanged, this, &DialogCubicBezier::PointNameChanged);
     connect(ui->comboBoxP2, &QComboBox::currentTextChanged, this, &DialogCubicBezier::PointNameChanged);
@@ -126,14 +129,9 @@ DialogCubicBezier::DialogCubicBezier(const VContainer *data, const quint32 &tool
     connect(ui->comboBoxP4, &QComboBox::currentTextChanged, this, &DialogCubicBezier::PointNameChanged);
 
     connect(ui->toolButtonExprCurveLength, &QPushButton::clicked, this, &DialogCubicBezier::FXCurveLength);
+    connect(timerCurveLength, &QTimer::timeout, this, &DialogCubicBezier::EvalCurveLength);
     connect(ui->comboBoxLengthMode, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &DialogCubicBezier::updateCurveLengthEnabled);
-    connect(ui->plainTextEditCurveLength, &QPlainTextEdit::textChanged, this, [this]()
-    {
-        if (ui->comboBoxLengthMode->currentIndex() == 0)
-        {
-            ui->comboBoxLengthMode->setCurrentIndex(3);
-        }
-    });
+    connect(ui->plainTextEditCurveLength, &QPlainTextEdit::textChanged, this, &DialogCubicBezier::CurveLengthChanged);
     updateCurveLengthEnabled();
 
     vis = new VisToolCubicBezier(data);
@@ -213,9 +211,56 @@ void DialogCubicBezier::FXCurveLength()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+void DialogCubicBezier::CheckState()
+{
+    SCASSERT(ok_Button != nullptr)
+    ok_Button->setEnabled(flagCurveLength && flagError);
+    if (apply_Button != nullptr)
+    {
+        apply_Button->setEnabled(ok_Button->isEnabled());
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void DialogCubicBezier::CurveLengthChanged()
+{
+    if (ui->comboBoxLengthMode->currentIndex() == 0)
+    {
+        ui->comboBoxLengthMode->setCurrentIndex(3);
+    }
+    labelEditFormula = ui->labelEditCurveLength;
+    labelResultCalculation = ui->labelResultCurveLength;
+    const QString postfix = UnitsToStr(qApp->patternUnit(), true);
+    formulaValueChanged(flagCurveLength, ui->plainTextEditCurveLength, timerCurveLength, postfix);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void DialogCubicBezier::EvalCurveLength()
+{
+    labelEditFormula = ui->labelEditCurveLength;
+    const QString postfix = UnitsToStr(qApp->patternUnit(), true);
+    const qreal length = Eval(ui->plainTextEditCurveLength->toPlainText(), flagCurveLength,
+                              ui->labelResultCurveLength, postfix, false);
+
+    if (length < 0)
+    {
+        flagCurveLength = false;
+        ChangeColor(labelEditFormula, Qt::red);
+        ui->labelResultCurveLength->setText(tr("Error") + " (" + postfix + ")");
+        ui->labelResultCurveLength->setToolTip(tr("Length can't be negative"));
+
+        DialogCubicBezier::CheckState();
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 void DialogCubicBezier::updateCurveLengthEnabled()
 {
-    Q_UNUSED(0)
+    if (ui->comboBoxLengthMode->currentIndex() == 0)
+    {
+        flagCurveLength = true;
+    }
+    CheckState();
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.h
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.h
@@ -105,6 +105,7 @@ public slots:
     void          updateCurveLengthEnabled();
 
 protected:
+    virtual void  CheckState() final;
     virtual void  ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
@@ -113,6 +114,7 @@ protected:
 
 private slots:
     void          FXCurveLength();
+    void          CurveLengthChanged();
 
 private:
     Q_DISABLE_COPY(DialogCubicBezier)
@@ -125,10 +127,15 @@ private:
 
     qint32        newDuplicate;
 
+    QTimer       *timerCurveLength;
+    bool          flagCurveLength;
+
     const QSharedPointer<VPointF> GetP1() const;
     const QSharedPointer<VPointF> GetP2() const;
     const QSharedPointer<VPointF> GetP3() const;
     const QSharedPointer<VPointF> GetP4() const;
+
+    void          EvalCurveLength();
 };
 
 #endif // DIALOGCUBICBEZIER_H

--- a/src/libs/vtools/dialogs/tools/dialogspline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogspline.cpp
@@ -98,10 +98,12 @@ DialogSpline::DialogSpline(const VContainer *data, const quint32 &toolId, QWidge
     , timerAngle2(new QTimer(this))
     , timerLength1(new QTimer(this))
     , timerLength2(new QTimer(this))
+    , timerCurveLength(new QTimer(this))
     , flagAngle1(false)
     , flagAngle2(false)
     , flagLength1(false)
     , flagLength2(false)
+    , flagCurveLength(true)
 {
     ui->setupUi(this);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
@@ -128,6 +130,7 @@ DialogSpline::DialogSpline(const VContainer *data, const quint32 &toolId, QWidge
     connect(timerAngle2, &QTimer::timeout, this, &DialogSpline::EvalAngle2);
     connect(timerLength1, &QTimer::timeout, this, &DialogSpline::EvalLength1);
     connect(timerLength2, &QTimer::timeout, this, &DialogSpline::EvalLength2);
+    connect(timerCurveLength, &QTimer::timeout, this, &DialogSpline::EvalCurveLength);
 
     initializeOkCancelApply(ui);
 
@@ -180,13 +183,7 @@ DialogSpline::DialogSpline(const VContainer *data, const quint32 &toolId, QWidge
     connect(ui->pushButtonGrowLength2, &QPushButton::clicked, this, &DialogSpline::DeployLength2TextEdit);
 
     connect(ui->comboBoxLengthMode, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &DialogSpline::updateCurveLengthEnabled);
-    connect(ui->plainTextEditCurveLength, &QPlainTextEdit::textChanged, this, [this]()
-    {
-        if (ui->comboBoxLengthMode->currentIndex() == 0)
-        {
-            ui->comboBoxLengthMode->setCurrentIndex(3);
-        }
-    });
+    connect(ui->plainTextEditCurveLength, &QPlainTextEdit::textChanged, this, &DialogSpline::CurveLengthChanged);
     updateCurveLengthEnabled();
 
     vis = new VisToolSpline(data);
@@ -280,6 +277,7 @@ void DialogSpline::closeEvent(QCloseEvent *event)
     ui->plainTextEditAngle2F->blockSignals(true);
     ui->plainTextEditLength1F->blockSignals(true);
     ui->plainTextEditLength2F->blockSignals(true);
+    ui->plainTextEditCurveLength->blockSignals(true);
     DialogTool::closeEvent(event);
 }
 
@@ -631,7 +629,7 @@ void DialogSpline::ShowDialog(bool click)
 void DialogSpline::CheckState()
 {
     SCASSERT(ok_Button != nullptr)
-    ok_Button->setEnabled(flagAngle1 && flagAngle2 && flagLength1 && flagLength2 && flagError);
+    ok_Button->setEnabled(flagAngle1 && flagAngle2 && flagLength1 && flagLength2 && flagCurveLength && flagError);
     // In case dialog does not have an apply button
     if (apply_Button != nullptr)
     {
@@ -695,9 +693,45 @@ void DialogSpline::SetTargetLength(const QString &formula)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+void DialogSpline::CurveLengthChanged()
+{
+    if (ui->comboBoxLengthMode->currentIndex() == 0)
+    {
+        ui->comboBoxLengthMode->setCurrentIndex(3);
+    }
+    labelEditFormula = ui->labelEditCurveLength;
+    labelResultCalculation = ui->labelResultCurveLength;
+    const QString postfix = UnitsToStr(qApp->patternUnit(), true);
+    formulaValueChanged(flagCurveLength, ui->plainTextEditCurveLength, timerCurveLength, postfix);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void DialogSpline::EvalCurveLength()
+{
+    labelEditFormula = ui->labelEditCurveLength;
+    const QString postfix = UnitsToStr(qApp->patternUnit(), true);
+    const qreal length = Eval(ui->plainTextEditCurveLength->toPlainText(), flagCurveLength,
+                              ui->labelResultCurveLength, postfix, false);
+
+    if (length < 0)
+    {
+        flagCurveLength = false;
+        ChangeColor(labelEditFormula, Qt::red);
+        ui->labelResultCurveLength->setText(tr("Error") + " (" + postfix + ")");
+        ui->labelResultCurveLength->setToolTip(tr("Length can't be negative"));
+
+        DialogSpline::CheckState();
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 void DialogSpline::updateCurveLengthEnabled()
 {
-    Q_UNUSED(0)
+    if (ui->comboBoxLengthMode->currentIndex() == 0)
+    {
+        flagCurveLength = true;
+    }
+    CheckState();
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogspline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogspline.cpp
@@ -727,7 +727,8 @@ void DialogSpline::EvalCurveLength()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogSpline::updateCurveLengthEnabled()
 {
-    if (ui->comboBoxLengthMode->currentIndex() == 0)
+    if (ui->comboBoxLengthMode->currentIndex() == 0
+        && ui->plainTextEditCurveLength->toPlainText().trimmed().isEmpty())
     {
         flagCurveLength = true;
     }

--- a/src/libs/vtools/dialogs/tools/dialogspline.h
+++ b/src/libs/vtools/dialogs/tools/dialogspline.h
@@ -132,6 +132,7 @@ private slots:
     void          FXLength1();
     void          FXLength2();
     void          FXCurveLength();
+    void          CurveLengthChanged();
 
 private:
     Q_DISABLE_COPY(DialogSpline)
@@ -151,12 +152,14 @@ private:
     QTimer           *timerAngle2;
     QTimer           *timerLength1;
     QTimer           *timerLength2;
+    QTimer           *timerCurveLength;
 
     /** @brief flagAngle1 true if value of first angle is correct */
     bool              flagAngle1;
     bool              flagAngle2;
     bool              flagLength1;
     bool              flagLength2;
+    bool              flagCurveLength;
 
     const QSharedPointer<VPointF> GetP1() const;
     const QSharedPointer<VPointF> GetP4() const;
@@ -165,6 +168,7 @@ private:
     void              EvalAngle2();
     void              EvalLength1();
     void              EvalLength2();
+    void              EvalCurveLength();
 
     VSpline           CurrentSpline() const;
 };


### PR DESCRIPTION
## Summary

- Adds formula validation to the curve length field in both Curve Interactive (DialogSpline) and Curve Fixed (DialogCubicBezier) dialogs
- Invalid formulas (e.g. "cccc") now show "Error" in red and disable the OK button, matching the existing behavior of angle and length formula fields
- Negative values are also caught and rejected

Fixes the bug reported in the [forum thread](https://forum.seamly.io/t/fx-bug-in-the-curve-dialogs).

## Test plan

- [ ] Open a curve dialog, type "cccc" in curve length → label shows "Error (cm)" in red, OK disabled
- [ ] Type a valid formula or number → label shows result, OK enabled
- [ ] Open dialog for a curve that already has a curve length formula → dialog opens correctly, no false "Error"
