### PR TITLE
BUG: fix seam allowance toggle

### DIFF
--- a/src/libs/vdxf/vdxfengine.cpp
+++ b/src/libs/vdxf/vdxfengine.cpp
@@ -1,30 +1,52 @@
- /************************************************************************
- **
- **  @file   vdxfengine.cpp
- **  @author Valentina Zhuravska <zhuravska19(at)gmail.com>
- **  @date   12 8, 2015
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vdxfengine.cpp
+//  @author Douglas S Caskey
+//  @date   8 Jul, 2026
+//
+//  @copyright
+//  Copyright (C) 2017 - 2026 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vdxfengine.cpp
+//  @author Valentina Zhuravska <zhuravska19(at)gmail.com>
+//  @date   12 8, 2015
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentine project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2015 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #include "vdxfengine.h"
 
@@ -693,7 +715,7 @@ void VDxfEngine::ExportAAMADraw(dx_ifaceBlock *detailBlock, const VLayoutPiece &
 //---------------------------------------------------------------------------------------------------------------------
 void VDxfEngine::ExportAAMAIntcut(dx_ifaceBlock *detailBlock, const VLayoutPiece &detail)
 {
-    QVector<QVector<QPointF>> drawIntCut = detail.InternalPathsForCut(false);
+    QVector<QVector<QPointF>> drawIntCut = detail.internalPathsForCut (false);
     for(int j = 0; j < drawIntCut.size(); ++j)
     {
         DRW_Entity *e = AAMAPolygon(drawIntCut.at(j), "8", false);
@@ -703,7 +725,7 @@ void VDxfEngine::ExportAAMAIntcut(dx_ifaceBlock *detailBlock, const VLayoutPiece
         }
     }
 
-    drawIntCut = detail.InternalPathsForCut(true);
+    drawIntCut = detail.internalPathsForCut (true);
     for(int j = 0; j < drawIntCut.size(); ++j)
     {
         DRW_Entity *e = AAMAPolygon(drawIntCut.at(j), "11", false);
@@ -746,10 +768,10 @@ void VDxfEngine::ExportAAMAGrainline(dx_ifaceBlock *detailBlock, const VLayoutPi
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VDxfEngine::ExportAAMAText(dx_ifaceBlock *detailBlock, const VLayoutPiece &detail)
+void VDxfEngine::ExportAAMAText(dx_ifaceBlock *detailBlock, const VLayoutPiece &piece)
 {
-    const QStringList list = detail.GetPieceText();
-    const QPointF startPos = detail.GetPieceTextPosition();
+    const QStringList list = piece.getPieceText();
+    const QPointF startPos = piece.getPieceTextPosition();
 
     for (int i = 0; i < list.size(); ++i)
     {
@@ -763,7 +785,7 @@ void VDxfEngine::ExportAAMAGlobalText(const QSharedPointer<dx_iface> &input, con
 {
     for(int i = 0; i < details.size(); ++i)
     {
-        const QStringList strings = details.at(i).GetPatternText();
+        const QStringList strings = details.at(i).getPatternText();
         if (not strings.isEmpty())
         {
             for (int j = 0; j < strings.size(); ++j)

--- a/src/libs/vdxf/vdxfengine.h
+++ b/src/libs/vdxf/vdxfengine.h
@@ -1,30 +1,52 @@
-/************************************************************************
- **
- **  @file   vdxfengine.h
- **  @author Valentina Zhuravska <zhuravska19(at)gmail.com>
- **  @date   12 8, 2015
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vdxfengine.h
+//  @author Douglas S Caskey
+//  @date   8 Jul, 2026
+//
+//  @copyright
+//  Copyright (C) 2017 - 2026 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vdxfengine.h
+//  @author Valentina Zhuravska <zhuravska19(at)gmail.com>
+//  @date   12 8, 2015
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentine project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2015 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #ifndef VDXFENGINE_H
 #define VDXFENGINE_H
@@ -71,39 +93,39 @@ public:
     virtual Type type() const override;
     virtual void drawPixmap(const QRectF &r, const QPixmap &pm, const QRectF &sr) override;
 
-    QSize getSize() const;
-    void setSize(const QSize &value);
+    QSize        getSize() const;
+    void         setSize(const QSize &value);
 
-    double getResolution() const;
-    void   setResolution(double value);
+    double       getResolution() const;
+    void         setResolution(double value);
 
-    QString getFileName() const;
-    void setFileName(const QString &value);
+    QString      getFileName() const;
+    void         setFileName(const QString &value);
 
     DRW::Version GetVersion() const;
     void         setVersion(DRW::Version version);
 
-    void SetBinaryFormat(bool binary);
-    bool IsBinaryFormat() const;
+    void         SetBinaryFormat(bool binary);
+    bool         IsBinaryFormat() const;
 
     std::string getPenStyle();
-    int getPenColor();
+    int         getPenColor();
 
-    void setMeasurement(const VarMeasurement &var);
-    void setInsunits(const VarInsunits &var);
+    void        setMeasurement(const VarMeasurement &var);
+    void        setInsunits(const VarInsunits &var);
 
 private:
     Q_DISABLE_COPY(VDxfEngine)
-    QSize            size;
-    double           resolution;
-    QString          fileName;
-    DRW::Version     m_version;
-    bool             m_binary;
-    QTransform       transform;
-    QSharedPointer<dx_iface> input;
-    VarMeasurement varMeasurement;
-    VarInsunits varInsunits;
-    DRW_Text *textBuffer;
+    QSize                     size;
+    double                    resolution;
+    QString                   fileName;
+    DRW::Version              m_version;
+    bool                      m_binary;
+    QTransform                transform;
+    QSharedPointer<dx_iface>  input;
+    VarMeasurement            varMeasurement;
+    VarInsunits               varInsunits;
+    DRW_Text                 *textBuffer;
 
     Q_REQUIRED_RESULT double FromPixel(double pix, const VarInsunits &unit) const;
     Q_REQUIRED_RESULT double ToPixel(double val, const VarInsunits &unit) const;

--- a/src/libs/vlayout/vlayoutpaper.cpp
+++ b/src/libs/vlayout/vlayoutpaper.cpp
@@ -439,7 +439,7 @@ bool VLayoutPaper::saveResult(const VBestSquare &bestResult, const VLayoutPiece 
     {
         VLayoutPiece workDetail = piece;
         workDetail.setTransform(bestResult.Transform());// Don't forget set transform
-        workDetail.SetMirror(bestResult.isMirror());
+        workDetail.setMirror (bestResult.isMirror());
         const QVector<QPointF> newGContour = d->globalContour.UniteWithContour(workDetail, bestResult.GContourEdge(),
                                                                                bestResult.pieceEdge(),
                                                                                bestResult.Type());

--- a/src/libs/vlayout/vlayoutpiece.cpp
+++ b/src/libs/vlayout/vlayoutpiece.cpp
@@ -4,7 +4,7 @@
 //  @date   17 Sep, 2023
 //
 //  @copyright
-//  Copyright (C) 2017 - 2025 Seamly, LLC
+//  Copyright (C) 2017 - 2026 Seamly, LLC
 //  https://github.com/fashionfreedom/seamly2d
 //
 //  @brief
@@ -84,7 +84,7 @@ static const int ObjectName = 0;
 namespace
 {
 //---------------------------------------------------------------------------------------------------------------------
-QVector<VLayoutPiecePath> ConvertInternalPaths(const VPiece &piece, const VContainer *pattern, const bool isCut)
+QVector<VLayoutPiecePath> convertInternalPaths (const VPiece &piece, const VContainer *pattern, const bool isCut)
 {
     SCASSERT(pattern != nullptr)
 
@@ -280,7 +280,7 @@ bool findGrainlineGeometry(const VGrainlineData& data, const VContainer *pattern
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-bool IsItemContained(const QRectF &parentBoundingRect, const QVector<QPointF> &shape, qreal &dX, qreal &dY)
+bool isItemContained (const QRectF &parentBoundingRect, const QVector<QPointF> &shape, qreal &dX, qreal &dY)
 {
     dX = 0;
     dY = 0;
@@ -328,11 +328,11 @@ bool IsItemContained(const QRectF &parentBoundingRect, const QVector<QPointF> &s
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QVector<QPointF> CorrectPosition(const QRectF &parentBoundingRect, QVector<QPointF> points)
+QVector<QPointF> correctPosition (const QRectF &parentBoundingRect, QVector<QPointF> points)
 {
     qreal dX = 0;
     qreal dY = 0;
-    if (!IsItemContained(parentBoundingRect, points, dX, dY))
+    if (!isItemContained (parentBoundingRect, points, dX, dY))
     {
         for (int i =0; i < points.size(); ++i)
         {
@@ -343,7 +343,7 @@ QVector<QPointF> CorrectPosition(const QRectF &parentBoundingRect, QVector<QPoin
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QVector<VSAPoint> PrepareAllowance(const QVector<QPointF> &points)
+QVector<VSAPoint> prepareAllowance (const QVector<QPointF> &points)
 {
     QVector<VSAPoint> allowancePoints;
     for(int i = 0; i < points.size(); ++i)
@@ -354,13 +354,13 @@ QVector<VSAPoint> PrepareAllowance(const QVector<QPointF> &points)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/// @brief VLayoutPiece::RotatePoint rotates a point around the center for given angle
+/// @brief VLayoutPiece::rotatePoint  rotates a point around the center for given angle
 /// @param ptCenter center around which the point is rotated
 /// @param pt point, which is rotated around the center
 /// @param rotationAngle angle of rotation
 /// @return position of point pt after rotating it around the center for rotation radians
 //---------------------------------------------------------------------------------------------------------------------
-QPointF RotatePoint(const QPointF &ptCenter, const QPointF& pt, qreal rotationAngle)
+QPointF rotatePoint (const QPointF &ptCenter, const QPointF& pt, qreal rotationAngle)
 {
     QPointF ptDest;
     QPointF ptRel = pt - ptCenter;
@@ -371,7 +371,7 @@ QPointF RotatePoint(const QPointF &ptCenter, const QPointF& pt, qreal rotationAn
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QStringList PieceLabelText(const QVector<QPointF> &labelShape, const VTextManager &tm)
+QStringList getLabelText (const QVector<QPointF> &labelShape, const VTextManager &tm)
 {
     QStringList text;
     if (labelShape.count() > 2)
@@ -429,15 +429,19 @@ VLayoutPiece VLayoutPiece::Create(const VPiece &piece, const VContainer *pattern
 
     layoutPiece.SetMx(piece.GetMx());
     layoutPiece.SetMy(piece.GetMy());
-
     layoutPiece.SetCountourPoints(piece.MainPathPoints(pattern), piece.isHideSeamLine());
-    layoutPiece.setSeamAllowancePoints(piece.SeamAllowancePoints(pattern), piece.IsSeamAllowance(),
-                               piece.IsSeamAllowanceBuiltIn());
-    layoutPiece.setInternalPaths(ConvertInternalPaths(piece, pattern, false));
-    layoutPiece.setCutoutPaths(ConvertInternalPaths(piece, pattern, true));
+    layoutPiece.setInternalPaths(convertInternalPaths (piece, pattern, false));
+    layoutPiece.setCutoutPaths(convertInternalPaths (piece, pattern, true));
     layoutPiece.setNotches(piece.createNotchLines(pattern));
-
     layoutPiece.SetName(piece.GetName());
+
+    // Disable SA in exports and layouts
+    if (qApp->Settings()->showSeamAllowances())
+    {
+        layoutPiece.setSeamAllowancePoints(piece.SeamAllowancePoints(pattern),
+                                           piece.IsSeamAllowance(),
+                                           piece.IsSeamAllowanceBuiltIn());
+    };
 
     // Very important to set main path first!
     if (layoutPiece.createMainPath().isEmpty() && layoutPiece.createAllowancePath().isEmpty())
@@ -445,19 +449,22 @@ VLayoutPiece VLayoutPiece::Create(const VPiece &piece, const VContainer *pattern
         throw VException (tr("Piece %1 doesn't have shape.").arg(piece.GetName()));
     }
 
+    // Disable piece labels in exports and layouts
     const VPieceLabelData& pieceLabelData = piece.GetPatternPieceData();
     if (pieceLabelData.IsVisible() & qApp->Settings()->showLabels())
     {
-        layoutPiece.SetPieceText(piece.GetName(), pieceLabelData, qApp->Settings()->getLabelFont(), pattern);
+        layoutPiece.setPieceText(piece.GetName(), pieceLabelData, qApp->Settings()->getLabelFont(), pattern);
     }
 
+    // Disable pattern labels in exports and layouts
     const VPatternLabelData& patternLabelData = piece.GetPatternInfo();
     if (patternLabelData.IsVisible() & qApp->Settings()->showLabels())
     {
         VAbstractPattern* pDoc = qApp->getCurrentDocument();
-        layoutPiece.SetPatternInfo(pDoc, patternLabelData, qApp->Settings()->getLabelFont(), pattern);
+        layoutPiece.setPatternText(pDoc, patternLabelData, qApp->Settings()->getLabelFont(), pattern);
     }
 
+    // Disable grainlines in exports and layouts
     const VGrainlineData& grainlineGeom = piece.GetGrainlineGeometry();
     if (grainlineGeom.IsVisible() & qApp->Settings()->showGrainlines())
     {
@@ -518,7 +525,7 @@ QVector<QPointF> VLayoutPiece::getLayoutAllowancePoints() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QPointF VLayoutPiece::GetPieceTextPosition() const
+QPointF VLayoutPiece::getPieceTextPosition() const
 {
     if (d->pieceLabel.count() > 2)
     {
@@ -531,13 +538,13 @@ QPointF VLayoutPiece::GetPieceTextPosition() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QStringList VLayoutPiece::GetPieceText() const
+QStringList VLayoutPiece::getPieceText() const
 {
-    return PieceLabelText(d->pieceLabel, d->m_tmPiece);
+    return getLabelText (d->pieceLabel, d->m_tmPiece);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VLayoutPiece::SetPieceText(const QString& qsName, const VPieceLabelData& data, const QFont &font,
+void VLayoutPiece::setPieceText(const QString& qsName, const VPieceLabelData& data, const QFont &font,
                                 const VContainer *pattern)
 {
     QPointF ptPos;
@@ -560,11 +567,11 @@ void VLayoutPiece::SetPieceText(const QString& qsName, const VPieceLabelData& da
 
     for (int i = 0; i < v.count(); ++i)
     {
-        v[i] = RotatePoint(ptCenter, v.at(i), rotationAngle);
+        v[i] = rotatePoint (ptCenter, v.at(i), rotationAngle);
     }
 
     QScopedPointer<QGraphicsItem> item(getMainPathItem());
-    d->pieceLabel = CorrectPosition(item->boundingRect(), v);
+    d->pieceLabel = correctPosition (item->boundingRect(), v);
 
     // generate text
     d->m_tmPiece.setFont(font);
@@ -577,7 +584,7 @@ void VLayoutPiece::SetPieceText(const QString& qsName, const VPieceLabelData& da
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QPointF VLayoutPiece::GetPatternTextPosition() const
+QPointF VLayoutPiece::getPatternTextPosition() const
 {
     if (d->patternInfo.count() > 2)
     {
@@ -590,13 +597,13 @@ QPointF VLayoutPiece::GetPatternTextPosition() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QStringList VLayoutPiece::GetPatternText() const
+QStringList VLayoutPiece::getPatternText() const
 {
-    return PieceLabelText(d->patternInfo, d->m_tmPattern);
+    return getLabelText (d->patternInfo, d->m_tmPattern);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VLayoutPiece::SetPatternInfo(VAbstractPattern* pDoc, const VPatternLabelData& data, const QFont &font,
+void VLayoutPiece::setPatternText(VAbstractPattern* pDoc, const VPatternLabelData& data, const QFont &font,
                                   const VContainer *pattern)
 {
     QPointF ptPos;
@@ -618,10 +625,10 @@ void VLayoutPiece::SetPatternInfo(VAbstractPattern* pDoc, const VPatternLabelDat
     const QPointF ptCenter(ptPos.x() + labelWidth/2, ptPos.y() + labelHeight/2);
     for (int i = 0; i < v.count(); ++i)
     {
-        v[i] = RotatePoint(ptCenter, v.at(i), rotationAngle);
+        v[i] = rotatePoint (ptCenter, v.at(i), rotationAngle);
     }
     QScopedPointer<QGraphicsItem> item(getMainPathItem());
-    d->patternInfo = CorrectPosition(item->boundingRect(), v);
+    d->patternInfo = correctPosition (item->boundingRect(), v);
 
     // Generate text
     d->m_tmPattern.setFont(font);
@@ -673,7 +680,7 @@ void VLayoutPiece::setGrainline(const VGrainlineData& data, const VContainer* pa
     path << pt2;
 
     QScopedPointer<QGraphicsItem> item(getMainPathItem());
-    d->grainlinePoints = CorrectPosition(item->boundingRect(), path);
+    d->grainlinePoints = correctPosition (item->boundingRect(), path);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -866,7 +873,7 @@ void VLayoutPiece::SetLayoutAllowancePoints()
     {
         if (IsSeamAllowance() && not IsSeamAllowanceBuiltIn())
         {
-            d->layoutAllowance = Equidistant(PrepareAllowance(GetSeamAllowancePoints()), d->layoutWidth);
+            d->layoutAllowance = Equidistant(prepareAllowance (GetSeamAllowancePoints()), d->layoutWidth);
             if (d->layoutAllowance.isEmpty() == false)
             {
                 d->layoutAllowance.removeLast();
@@ -874,7 +881,7 @@ void VLayoutPiece::SetLayoutAllowancePoints()
         }
         else
         {
-            d->layoutAllowance = Equidistant(PrepareAllowance(getContourPoints()), d->layoutWidth);
+            d->layoutAllowance = Equidistant(prepareAllowance (getContourPoints()), d->layoutWidth);
             if (d->layoutAllowance.isEmpty() == false)
             {
                 d->layoutAllowance.removeLast();
@@ -903,7 +910,7 @@ void VLayoutPiece::setNotches(const QVector<QLineF> &notches)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QVector<QVector<QPointF> > VLayoutPiece::InternalPathsForCut(bool cut) const
+QVector<QVector<QPointF> > VLayoutPiece::internalPathsForCut (bool cut) const
 {
     QVector<QVector<QPointF> > paths;
 
@@ -1321,7 +1328,7 @@ bool VLayoutPiece::isMirror() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VLayoutPiece::SetMirror(bool value)
+void VLayoutPiece::setMirror (bool value)
 {
     d->mirror = value;
 }

--- a/src/libs/vlayout/vlayoutpiece.h
+++ b/src/libs/vlayout/vlayoutpiece.h
@@ -4,7 +4,7 @@
 //  @date   Dec 27, 2022
 //
 //  @copyright
-//  Copyright (C) 2017 - 2025 Seamly, LLC
+//  Copyright (C) 2017 - 2026 Seamly, LLC
 //  https://github.com/fashionfreedom/seamly2d
 //
 //  @brief
@@ -107,21 +107,21 @@ public:
     QVector<QLineF>           getNotches() const;
     void                      setNotches(const QVector<QLineF> &notches);
 
-    QVector<QVector<QPointF>> InternalPathsForCut(bool cut) const;
+    QVector<QVector<QPointF>> internalPathsForCut (bool cut) const;
     QVector<VLayoutPiecePath> getInternalPaths() const;
     void                      setInternalPaths(const QVector<VLayoutPiecePath> &internalPaths);
 
     QVector<VLayoutPiecePath> getCutoutPaths() const;
     void                      setCutoutPaths(const QVector<VLayoutPiecePath> &cutoutPaths);
 
-    QPointF                   GetPieceTextPosition() const;
-    QStringList               GetPieceText() const;
-    void                      SetPieceText(const QString &qsName, const VPieceLabelData& data,
+    QPointF                   getPieceTextPosition() const;
+    QStringList               getPieceText() const;
+    void                      setPieceText(const QString &qsName, const VPieceLabelData& data,
                                            const QFont& font,  const VContainer *pattern);
 
-    QPointF                   GetPatternTextPosition() const;
-    QStringList               GetPatternText() const;
-    void                      SetPatternInfo(VAbstractPattern *pDoc, const VPatternLabelData& geom,
+    QPointF                   getPatternTextPosition() const;
+    QStringList               getPatternText() const;
+    void                      setPatternText(VAbstractPattern *pDoc, const VPatternLabelData& geom,
                                              const QFont& font, const VContainer *pattern);
 
     void                      setGrainline(const VGrainlineData& geom, const VContainer *pattern);
@@ -134,7 +134,7 @@ public:
     void                      setLayoutGap(const qreal &value);
 
     bool                      isMirror() const;
-    void                      SetMirror(bool value);
+    void                      setMirror (bool value);
 
     void                      Translate(qreal dx, qreal dy);
     void                      Rotate(const QPointF &originPoint, qreal degrees);


### PR DESCRIPTION
This PR fixes the issue with the global Seam Allowance toggle not disabling the SA when Exporting Pieces  or Exporting / Creating a Layout. 

Toggling the SA off via the View Toobar, the View Menu, or using the V,S shortcut will now correctly disaable the SA. 

Also includes some minor copyright header and naming updates.

Closes issue #1602 