### PR TITLE
feat: Piece Property Browser and Canvas Editor for piece mode

### DIFF
--- a/src/app/seamly2d/core/core.pri
+++ b/src/app/seamly2d/core/core.pri
@@ -5,6 +5,7 @@ HEADERS += \
     $$PWD/application_2d.h \
     $$PWD/vformulaproperty.h \
     $$PWD/vformulapropertyeditor.h \
+    $$PWD/vpieceoptionspropertybrowser.h \
     $$PWD/vtooloptionspropertybrowser.h \
     $$PWD/vcmdexport.h
 
@@ -12,5 +13,6 @@ SOURCES += \
     $$PWD/application_2d.cpp \
     $$PWD/vformulaproperty.cpp \
     $$PWD/vformulapropertyeditor.cpp \
+    $$PWD/vpieceoptionspropertybrowser.cpp \
     $$PWD/vtooloptionspropertybrowser.cpp \
     $$PWD/vcmdexport.cpp

--- a/src/app/seamly2d/core/vpieceoptionspropertybrowser.cpp
+++ b/src/app/seamly2d/core/vpieceoptionspropertybrowser.cpp
@@ -1,0 +1,345 @@
+/******************************************************************************
+*   @file   vpieceoptionspropertybrowser.cpp
+**  @author Douglas S Caskey
+**  @date   27 Jun, 2026
+**
+**  @brief
+**  @copyright
+**  This source code is part of the Seamly2D project, a pattern making
+**  program to create and model patterns of clothing.
+**  Copyright (C) 2017-2026 Seamly2D project
+**  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+**
+**  Seamly2D is free software: you can redistribute it and/or modify
+**  it under the terms of the GNU General Public License as published by
+**  the Free Software Foundation, either version 3 of the License, or
+**  (at your option) any later version.
+**
+**  Seamly2D is distributed in the hope that it will be useful,
+**  but WITHOUT ANY WARRANTY; without even the implied warranty of
+**  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**  GNU General Public License for more details.
+**
+**  You should have received a copy of the GNU General Public License
+**  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+**
+*************************************************************************/
+
+#include "vpieceoptionspropertybrowser.h"
+
+#include "../core/application_2d.h"
+#include "../ifc/ifcdef.h"
+#include "../vpatterndb/vpiece.h"
+#include "../vpropertyexplorer/vproperties.h"
+#include "../vtools/tools/pattern_piece_tool.h"
+#include "../vtools/tools/vabstracttool.h"
+#include "../vtools/undocommands/savepieceoptions.h"
+
+#include <QDockWidget>
+#include <QScrollArea>
+
+namespace
+{
+const QString IdName               = QStringLiteral("name");
+const QString IdColor              = QStringLiteral("color");
+const QString IdFill               = QStringLiteral("fill");
+const QString IdSeamAllowance      = QStringLiteral("seamAllowance");
+const QString IdSABuiltIn          = QStringLiteral("seamAllowanceBuiltIn");
+const QString IdHideSeamLine       = QStringLiteral("hideSeamLine");
+const QString IdLabelSelection     = QStringLiteral("labelSelection");
+const QString IdLabelProperties    = QStringLiteral("labelProperties");
+const QString IdLabelSeamAllowance = QStringLiteral("labelSeamAllowance");
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+VPieceOptionsPropertyBrowser::VPieceOptionsPropertyBrowser(VAbstractPattern *doc, QDockWidget *parent)
+    : QObject(parent)
+    , m_doc(doc)
+    , m_propertyModel(nullptr)
+    , m_formView(nullptr)
+    , m_scrollArea(nullptr)
+    , m_currentItem(nullptr)
+    , m_propertyToId(QMap<VPE::VProperty *, QString>())
+    , m_idToProperty(QMap<QString, VPE::VProperty *>())
+{
+    m_propertyModel = new VPE::VPropertyModel(this);
+    m_formView = new VPE::VPropertyFormView(m_propertyModel, parent);
+    m_formView->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+    m_scrollArea = new QScrollArea(parent);
+    m_scrollArea->setWidgetResizable(true);
+    m_scrollArea->setWidget(m_formView);
+
+    parent->setWidget(m_scrollArea);
+
+    connect(m_propertyModel, &VPE::VPropertyModel::onDataChangedByEditor, this,
+            &VPieceOptionsPropertyBrowser::userChangedData);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+QScrollArea *VPieceOptionsPropertyBrowser::scrollArea() const
+{
+    return m_scrollArea;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VPieceOptionsPropertyBrowser::clearPropertyBrowser()
+{
+    m_propertyModel->clear();
+    m_propertyToId.clear();
+    m_idToProperty.clear();
+    m_currentItem = nullptr;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VPieceOptionsPropertyBrowser::itemClicked(QGraphicsItem *item)
+{
+    if (item == nullptr)
+    {
+        clearPropertyBrowser();
+        return;
+    }
+
+    if (item == m_currentItem && !m_idToProperty.isEmpty())
+    {
+        updateOptions();
+        return;
+    }
+
+    clearPropertyBrowser();
+
+    QGraphicsItem *pieceItem = item;
+    while (pieceItem != nullptr && pieceItem->type() != PatternPieceTool::Type)
+    {
+        pieceItem = pieceItem->parentItem();
+    }
+
+    if (pieceItem != nullptr)
+    {
+        m_currentItem = pieceItem;
+        showPieceOptions(pieceItem);
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VPieceOptionsPropertyBrowser::updateOptions()
+{
+    if (m_currentItem == nullptr || m_idToProperty.isEmpty())
+    {
+        return;
+    }
+
+    if (m_currentItem->type() == PatternPieceTool::Type)
+    {
+        updatePieceOptions();
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VPieceOptionsPropertyBrowser::userChangedData(VPE::VProperty *property)
+{
+    if (property == nullptr)
+    {
+        return;
+    }
+
+    if (m_currentItem != nullptr && m_currentItem->type() == PatternPieceTool::Type)
+    {
+        changePieceData(property);
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VPieceOptionsPropertyBrowser::addProperty(VPE::VProperty *property, const QString &id)
+{
+    m_propertyToId[property] = id;
+    m_idToProperty[id] = property;
+    m_propertyModel->addProperty(property, id);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VPieceOptionsPropertyBrowser::showPieceOptions(QGraphicsItem *item)
+{
+    PatternPieceTool *tool = qgraphicsitem_cast<PatternPieceTool *>(item);
+    if (tool == nullptr)
+    {
+        return;
+    }
+
+    m_formView->setTitle(tr("Pattern Piece"));
+
+    const VPiece piece = tool->getData()->GetPiece(tool->getId());
+    const QStringList yesNo = QStringList() << tr("No") << tr("Yes");
+
+    // --- Selection ---
+    auto *labelSelection = new VPE::VLabelProperty(QStringLiteral("<b>") + tr("Selection") + QStringLiteral("</b>"));
+    labelSelection->setValue(QString());
+    labelSelection->setPropertyType(VPE::Property::Label);
+    addProperty(labelSelection, IdLabelSelection);
+
+    auto *nameProperty = new VPE::VStringProperty(tr("Name:"));
+    nameProperty->setClearButtonEnable(true);
+    nameProperty->setValue(piece.GetName());
+    addProperty(nameProperty, IdName);
+
+    // --- Properties ---
+    auto *labelProperties = new VPE::VLabelProperty(QStringLiteral("<b>") + tr("Properties") + QStringLiteral("</b>"));
+    labelProperties->setValue(QString());
+    labelProperties->setPropertyType(VPE::Property::Label);
+    addProperty(labelProperties, IdLabelProperties);
+
+    auto *colorProperty = new VPE::VLineColorProperty(tr("Color:"));
+    colorProperty->setColors(VAbstractTool::ColorsList());
+    const qint32 colorIndex = VPE::VLineColorProperty::indexOfColor(VAbstractTool::ColorsList(), piece.getColor());
+    colorProperty->setValue(colorIndex);
+    addProperty(colorProperty, IdColor);
+
+    auto *fillProperty = new VPE::VEnumProperty(tr("Fill:"));
+    fillProperty->setLiterals(VAbstractTool::fills());
+    const qint32 fillIndex = VAbstractTool::fills().indexOf(piece.getFill());
+    fillProperty->setValue(fillIndex >= 0 ? fillIndex : 0);
+    addProperty(fillProperty, IdFill);
+
+    // --- Seam Allowance ---
+    auto *labelSA = new VPE::VLabelProperty(QStringLiteral("<b>") + tr("Seam Allowance") + QStringLiteral("</b>"));
+    labelSA->setValue(QString());
+    labelSA->setPropertyType(VPE::Property::Label);
+    addProperty(labelSA, IdLabelSeamAllowance);
+
+    auto *saEnabledProperty = new VPE::VEnumProperty(tr("Enabled:"));
+    saEnabledProperty->setLiterals(yesNo);
+    saEnabledProperty->setValue(piece.IsSeamAllowance() ? 1 : 0);
+    addProperty(saEnabledProperty, IdSeamAllowance);
+
+    auto *saBuiltInProperty = new VPE::VEnumProperty(tr("Built in:"));
+    saBuiltInProperty->setLiterals(yesNo);
+    saBuiltInProperty->setValue(piece.IsSeamAllowanceBuiltIn() ? 1 : 0);
+    addProperty(saBuiltInProperty, IdSABuiltIn);
+
+    auto *hideSeamLineProperty = new VPE::VEnumProperty(tr("Hide seam line:"));
+    hideSeamLineProperty->setLiterals(yesNo);
+    hideSeamLineProperty->setValue(piece.isHideSeamLine() ? 1 : 0);
+    addProperty(hideSeamLineProperty, IdHideSeamLine);
+
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VPieceOptionsPropertyBrowser::updatePieceOptions()
+{
+    PatternPieceTool *tool = qgraphicsitem_cast<PatternPieceTool *>(m_currentItem);
+    if (tool == nullptr)
+    {
+        return;
+    }
+
+    const VPiece piece = tool->getData()->GetPiece(tool->getId());
+
+    if (m_idToProperty.contains(IdName))
+    {
+        m_idToProperty[IdName]->setValue(piece.GetName());
+    }
+
+    if (m_idToProperty.contains(IdColor))
+    {
+        const qint32 index = VPE::VLineColorProperty::indexOfColor(VAbstractTool::ColorsList(), piece.getColor());
+        m_idToProperty[IdColor]->setValue(index);
+    }
+
+    if (m_idToProperty.contains(IdFill))
+    {
+        const qint32 index = VAbstractTool::fills().indexOf(piece.getFill());
+        m_idToProperty[IdFill]->setValue(index >= 0 ? index : 0);
+    }
+
+    if (m_idToProperty.contains(IdSeamAllowance))
+    {
+        m_idToProperty[IdSeamAllowance]->setValue(piece.IsSeamAllowance() ? 1 : 0);
+    }
+
+    if (m_idToProperty.contains(IdSABuiltIn))
+    {
+        m_idToProperty[IdSABuiltIn]->setValue(piece.IsSeamAllowanceBuiltIn() ? 1 : 0);
+    }
+
+    if (m_idToProperty.contains(IdHideSeamLine))
+    {
+        m_idToProperty[IdHideSeamLine]->setValue(piece.isHideSeamLine() ? 1 : 0);
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VPieceOptionsPropertyBrowser::changePieceData(VPE::VProperty *property)
+{
+    SCASSERT(property != nullptr)
+
+    PatternPieceTool *tool = qgraphicsitem_cast<PatternPieceTool *>(m_currentItem);
+    if (tool == nullptr)
+    {
+        return;
+    }
+
+    const QString id = m_propertyToId[property];
+    const QVariant value = property->data(VPE::VProperty::DPC_Data, Qt::EditRole);
+    const quint32 toolId = tool->getId();
+
+    VPiece oldPiece = tool->getData()->GetPiece(toolId);
+    VPiece newPiece = oldPiece;
+
+    if (id == IdName)
+    {
+        const QString name = value.toString();
+        if (name.isEmpty())
+        {
+            return;
+        }
+        newPiece.SetName(name);
+    }
+    else if (id == IdColor)
+    {
+        const QMap<QString, QString> colors = VAbstractTool::ColorsList();
+        const QStringList keys = colors.keys();
+        const int index = value.toInt();
+        if (index >= 0 && index < keys.size())
+        {
+            newPiece.setColor(keys.at(index));
+        }
+        else
+        {
+            return;
+        }
+    }
+    else if (id == IdFill)
+    {
+        const QStringList fillsList = VAbstractTool::fills();
+        const int index = value.toInt();
+        if (index >= 0 && index < fillsList.size())
+        {
+            newPiece.setFill(fillsList.at(index));
+        }
+        else
+        {
+            return;
+        }
+    }
+    else if (id == IdSeamAllowance)
+    {
+        newPiece.SetSeamAllowance(value.toInt() != 0);
+    }
+    else if (id == IdSABuiltIn)
+    {
+        newPiece.SetSeamAllowanceBuiltIn(value.toInt() != 0);
+    }
+    else if (id == IdHideSeamLine)
+    {
+        newPiece.setHideSeamLine(value.toInt() != 0);
+    }
+    else
+    {
+        return;
+    }
+
+    SavePieceOptions *undoCommand = new SavePieceOptions(oldPiece, newPiece, m_doc, toolId);
+    qApp->getUndoStack()->push(undoCommand);
+    emit pieceOptionsChanged();
+}
+

--- a/src/app/seamly2d/core/vpieceoptionspropertybrowser.h
+++ b/src/app/seamly2d/core/vpieceoptionspropertybrowser.h
@@ -1,0 +1,80 @@
+/******************************************************************************
+*   @file   vpieceoptionspropertybrowser.h
+**  @author Douglas S Caskey
+**  @date   27 Jun, 2026
+**
+**  @brief
+**  @copyright
+**  This source code is part of the Seamly2D project, a pattern making
+**  program to create and model patterns of clothing.
+**  Copyright (C) 2017-2026 Seamly2D project
+**  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+**
+**  Seamly2D is free software: you can redistribute it and/or modify
+**  it under the terms of the GNU General Public License as published by
+**  the Free Software Foundation, either version 3 of the License, or
+**  (at your option) any later version.
+**
+**  Seamly2D is distributed in the hope that it will be useful,
+**  but WITHOUT ANY WARRANTY; without even the implied warranty of
+**  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**  GNU General Public License for more details.
+**
+**  You should have received a copy of the GNU General Public License
+**  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+**
+*************************************************************************/
+
+#ifndef VPIECEOPTIONSPROPERTYBROWSER_H
+#define VPIECEOPTIONSPROPERTYBROWSER_H
+
+#include <QObject>
+#include <QMap>
+
+#include "../vpropertyexplorer/vproperty.h"
+#include "../vpropertyexplorer/vpropertymodel.h"
+#include "../vpropertyexplorer/vpropertyformview.h"
+
+class QDockWidget;
+class QGraphicsItem;
+class QScrollArea;
+class VAbstractPattern;
+
+class VPieceOptionsPropertyBrowser : public QObject
+{
+    Q_OBJECT
+public:
+    explicit VPieceOptionsPropertyBrowser(VAbstractPattern *doc, QDockWidget *parent);
+    void     clearPropertyBrowser();
+
+    QScrollArea *scrollArea() const;
+
+public slots:
+    void itemClicked(QGraphicsItem *item);
+    void updateOptions();
+
+signals:
+    void pieceOptionsChanged();
+
+private slots:
+    void userChangedData(VPE::VProperty *property);
+
+private:
+    Q_DISABLE_COPY(VPieceOptionsPropertyBrowser)
+
+    VAbstractPattern                *m_doc;
+    VPE::VPropertyModel             *m_propertyModel;
+    VPE::VPropertyFormView          *m_formView;
+    QScrollArea                     *m_scrollArea;
+
+    QGraphicsItem                   *m_currentItem;
+    QMap<VPE::VProperty *, QString>  m_propertyToId;
+    QMap<QString, VPE::VProperty *>  m_idToProperty;
+
+    void addProperty(VPE::VProperty *property, const QString &id);
+    void showPieceOptions(QGraphicsItem *item);
+    void updatePieceOptions();
+    void changePieceData(VPE::VProperty *property);
+};
+
+#endif // VPIECEOPTIONSPROPERTYBROWSER_H

--- a/src/app/seamly2d/dialogs/pieces_widget.cpp
+++ b/src/app/seamly2d/dialogs/pieces_widget.cpp
@@ -1,76 +1,173 @@
-/***************************************************************************
- **  @file   pieces_widget.cpp
- **  @author Douglas S Caskey
- **  @date   Nov 22, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   pieces_widget.cpp
+//  @author Douglas S Caskey
+//  @date   17 Sep, 2023
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2026 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
-/************************************************************************
- **
- **  @file   vwidgetdetails.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   25 6, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Valentina project
- **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vwidgetdetails.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   Jun 25, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2016 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #include "pieces_widget.h"
 #include "ui_pieces_widget.h"
 #include "../ifc/xml/vabstractpattern.h"
+#include "../ifc/exception/vexceptionbadid.h"
 #include "../vpatterndb/floatItemData/vpiecelabeldata.h"
 #include "../vpatterndb/vcontainer.h"
+#include "../vpatterndb/vpiecenode.h"
+#include "../vpatterndb/vpiecepath.h"
+#include "../vgeometry/vpointf.h"
+#include "../vgeometry/vabstractcurve.h"
+#include "../vwidgets/global.h"
 #include "../vmisc/vabstractapplication.h"
 #include "../vtools/tools/pattern_piece_tool.h"
+#include "../vtools/tools/nodeDetails/vnodepoint.h"
 #include "../vtools/undocommands/togglepieceinlayout.h"
 #include "../vtools/undocommands/toggle_piecelock.h"
 #include "../vtools/undocommands/set_piece_color.h"
-#include "../vwidgets/piece_tablewidgetitem.h"
 #include "../vwidgets/vmaingraphicsscene.h"
+
+#include "../vtools/undocommands/savepieceoptions.h"
 
 #include <QColorDialog>
 #include <QList>
+#include <QSet>
 #include <QMenu>
 #include <QPainter>
+#include <QPen>
+#include <QPainterPath>
+#include <QGraphicsPathItem>
 #include <QPixmap>
 #include <QRegularExpression>
-#include <QTableWidget>
+#include <QTimer>
+#include <QTreeWidget>
 #include <QUndoStack>
+#include <QLineF>
+
+#include <algorithm>
+
+namespace
+{
+    const int NODE_HIGHLIGHT_KEY = 1000;
+
+    QString toolTypeIconPath(Tool toolType)
+    {
+        switch (toolType)
+        {
+            case Tool::NodePoint:
+                return QStringLiteral("://icon/16x16/toolsectionpoint.png");
+            case Tool::NodeArc:
+                return QStringLiteral("://icon/16x16/toolsectionarc.png");
+            case Tool::NodeElArc:
+                return QStringLiteral("://icon/16x16/toolsectionelarc.png");
+            case Tool::NodeSpline:
+            case Tool::NodeSplinePath:
+            default:
+                return QStringLiteral("://icon/16x16/toolsectioncurve.png");
+        }
+    }
+
+    QString notchIconPath(NotchType notchType)
+    {
+        switch (notchType)
+        {
+            case NotchType::TNotch:
+                return QStringLiteral("://icon/24x24/t_notch.png");
+            case NotchType::VInternal:
+                return QStringLiteral("://icon/24x24/internal_v_notch.png");
+            case NotchType::VExternal:
+                return QStringLiteral("://icon/24x24/external_v_notch.png");
+            case NotchType::UNotch:
+                return QStringLiteral("://icon/24x24/u_notch.png");
+            case NotchType::Castle:
+                return QStringLiteral("://icon/24x24/castle_notch.png");
+            case NotchType::Diamond:
+                return QStringLiteral("://icon/24x24/diamond_notch.png");
+            case NotchType::Slit:
+            default:
+                return QStringLiteral("://icon/24x24/slit_notch.png");
+        }
+    }
+
+    // Mirrors VAbstractCurve::DirectionArrows so a reversed node shows a reversed arrow.
+    QVector<DirectionArrow> directionArrowsForPoints(const QVector<QPointF> &points, qreal length)
+    {
+        QVector<DirectionArrow> arrows;
+        if (points.count() < 2)
+        {
+            return arrows;
+        }
+
+        const qreal seek_length = qAbs(length) / 2.0;
+        qreal found_length = 0;
+        QLineF arrow;
+        for (qint32 i = 1; i <= points.size() - 1; ++i)
+        {
+            arrow = QLineF(points.at(i - 1), points.at(i));
+            found_length += arrow.length();
+            if (seek_length <= found_length)
+            {
+                arrow.setLength(arrow.length() - (found_length - seek_length));
+                break;
+            }
+        }
+
+        arrow = QLineF(arrow.p2(), arrow.p1());
+        const qreal angle = arrow.angle();
+        arrow.setLength(VAbstractCurve::lengthCurveDirectionArrow);
+
+        DirectionArrow dArrow;
+        arrow.setAngle(angle - 35);
+        dArrow.first = arrow;
+        arrow.setAngle(angle + 35);
+        dArrow.second = arrow;
+        arrows.append(dArrow);
+
+        return arrows;
+    }
+}
 
 #define BASE_10 10
 #define MAX_LENGTH 3
@@ -82,14 +179,33 @@ PiecesWidget::PiecesWidget(VContainer *data, VAbstractPattern *doc, QWidget *par
     , m_doc(doc)
     , m_data(data)
     , m_allPieces()
+    , m_highlightedNodeId(NULL_ID)
+    , m_fillTreeInProgress(false)
 {
     ui->setupUi(this);
 
-    ui->tableWidget->setContextMenuPolicy(Qt::CustomContextMenu);
+    ui->treeWidget->setContextMenuPolicy(Qt::CustomContextMenu);
+    ui->treeWidget->setDragDropMode(QAbstractItemView::InternalMove);
+    ui->treeWidget->setDefaultDropAction(Qt::MoveAction);
+    ui->treeWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+    ui->treeWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui->treeWidget->setHeaderLabels({makeHeaderName(tr("Included")),
+                                     makeHeaderName(tr("Locked")),
+                                     makeHeaderName(tr("Color")),
+                                     makeHeaderName(tr("Piece")),
+                                     tr("Name")});
+    ui->treeWidget->header()->setSectionResizeMode(0, QHeaderView::Fixed);
+    ui->treeWidget->header()->setSectionResizeMode(1, QHeaderView::Fixed);
+    ui->treeWidget->header()->setSectionResizeMode(2, QHeaderView::Fixed);
+    ui->treeWidget->header()->setSectionResizeMode(3, QHeaderView::ResizeToContents);
+    ui->treeWidget->header()->setSectionResizeMode(4, QHeaderView::Stretch);
+    ui->treeWidget->setColumnWidth(0, 48);
+    ui->treeWidget->setColumnWidth(1, 26);
+    ui->treeWidget->setColumnWidth(2, 26);
+    ui->treeWidget->setTextElideMode(Qt::ElideRight);
+    ui->treeWidget->setIndentation(12);
 
-    fillTable(m_data->DataPieces());
-    QSettings settings;
-    ui->tableWidget->sortItems(settings.value("pieceSort", 4).toInt(), Qt::AscendingOrder);
+    fillTree(m_data->DataPieces());
 
     connect(ui->includeAllPieces_ToolButton,     &QToolButton::clicked, this,  &PiecesWidget::includeAllPieces);
     connect(ui->invertIncludedPieces_ToolButton, &QToolButton::clicked, this,  [this]()
@@ -110,16 +226,19 @@ PiecesWidget::PiecesWidget(VContainer *data, VAbstractPattern *doc, QWidget *par
 
     connect(ui->editColor_ToolButton, &QToolButton::clicked, this,  [this]()
     {
-        QList<QTableWidgetItem *> selected = ui->tableWidget->selectedItems();
+        QList<QTreeWidgetItem *> selected = ui->treeWidget->selectedItems();
         if (selected.isEmpty())
         {
             QApplication::beep();
             return;
         }
-        QTableWidgetItem *item = ui->tableWidget->item(selected.first()->row(), 0);
-        if (!item) return;
+        QTreeWidgetItem *item = selected.first();
+        if (item->data(0, IsNodeRole).toBool())
+        {
+            return;
+        }
 
-        const quint32 id = item->data(Qt::UserRole).toUInt();
+        const quint32 id = item->data(0, PieceIdRole).toUInt();
         const QHash<quint32, VPiece> *allPieces = m_data->DataPieces();
         const bool locked = allPieces->value(id).isLocked();
 
@@ -129,22 +248,25 @@ PiecesWidget::PiecesWidget(VContainer *data, VAbstractPattern *doc, QWidget *par
             return;
         }
         editPieceColor(id);
-        ui->tableWidget->clearSelection();
+        ui->treeWidget->clearSelection();
         emit Highlight(NULL);
     });
 
     connect(ui->editPiece_ToolButton, &QToolButton::clicked, this,  [this]()
     {
-        QList<QTableWidgetItem *> selected = ui->tableWidget->selectedItems();
+        QList<QTreeWidgetItem *> selected = ui->treeWidget->selectedItems();
         if (selected.isEmpty())
         {
             QApplication::beep();
             return;
         }
-        QTableWidgetItem *item = ui->tableWidget->item(selected.first()->row(), 0);
-        if (!item) return;
+        QTreeWidgetItem *item = selected.first();
+        if (item->data(0, IsNodeRole).toBool())
+        {
+            return;
+        }
 
-        const quint32 id = item->data(Qt::UserRole).toUInt();
+        const quint32 id = item->data(0, PieceIdRole).toUInt();
         const QHash<quint32, VPiece> *allPieces = m_data->DataPieces();
         const bool locked = allPieces->value(id).isLocked();
 
@@ -154,14 +276,14 @@ PiecesWidget::PiecesWidget(VContainer *data, VAbstractPattern *doc, QWidget *par
             return;
         }
         editPieceProperties(id);
-        ui->tableWidget->clearSelection();
+        ui->treeWidget->clearSelection();
         emit Highlight(NULL);
     });
 
-    connect(ui->tableWidget, &QTableWidget::cellClicked,                       this, &PiecesWidget::cellClicked);
-    connect(ui->tableWidget, &QTableWidget::cellDoubleClicked,                 this, &PiecesWidget::cellDoubleClicked);
-    connect(ui->tableWidget, &QTableWidget::customContextMenuRequested,        this, &PiecesWidget::showContextMenu);
-    connect(ui->tableWidget->horizontalHeader(), &QHeaderView::sectionClicked, this, &PiecesWidget::headerClicked);
+    connect(ui->treeWidget, &QTreeWidget::itemClicked,                    this, &PiecesWidget::itemClicked);
+    connect(ui->treeWidget, &QTreeWidget::itemDoubleClicked,              this, &PiecesWidget::itemDoubleClicked);
+    connect(ui->treeWidget, &QTreeWidget::itemChanged,                    this, &PiecesWidget::itemChanged);
+    connect(ui->treeWidget, &QTreeWidget::customContextMenuRequested,     this, &PiecesWidget::showContextMenu);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -178,111 +300,145 @@ void PiecesWidget::changeEvent(QEvent *event)
         ui->retranslateUi(this);
     }
 
-    // remember to call base class implementation
     QWidget::changeEvent(event);
 }
+
 //---------------------------------------------------------------------------------------------------------------------
 void PiecesWidget::togglePiece(quint32 id)
 {
-    ui->tableWidget->setSortingEnabled(false);
-    ui->tableWidget->clearSelection();
-
-    int selectedRow = 0;
     const QHash<quint32, VPiece> *pieces = m_data->DataPieces();
-
-    if (pieces->contains(id))
+    if (!pieces->contains(id))
     {
-        for (int row = 0; row < ui->tableWidget->rowCount(); ++row)
-        {
-            QTableWidgetItem *item = ui->tableWidget->item(row, 0);
-            SCASSERT(item != nullptr)
-
-            if (item && item->data(Qt::UserRole).toUInt() == id)
-            {
-                    selectedRow = row;
-                    VPiece piece = pieces->value(id);
-                    const bool inLayout = piece.isInLayout();
-                    inLayout ? item->setIcon(QIcon("://icon/32x32/visible_on.png"))
-                             : item->setIcon(QIcon("://icon/32x32/visible_off.png"));
-                    {
-                        QTableWidgetItem *item = ui->tableWidget->item(row, 1);
-                        const bool locked = piece.isLocked();
-                        locked ? item->setIcon(QIcon("://icon/32x32/lock_on.png"))
-                               : item->setIcon(QIcon("://icon/32x32/lock_off.png"));
-                    }
-
-                    {
-                        QTableWidgetItem *item = ui->tableWidget->item(row, 2);
-                        QPixmap pixmap(20, 20);
-                        pixmap.fill(QColor(piece.getColor()));
-                        item->setIcon(QIcon(pixmap));
-                        item->setData(Qt::UserRole, piece.getColor());
-                    }
-
-                    {
-                        QTableWidgetItem *item = ui->tableWidget->item(row, 3);
-                        item->setText(formatLetterString(piece));
-                    }
-
-                    {
-                        QTableWidgetItem *item = ui->tableWidget->item(row, 4);
-                        item->setText(piece.GetName());
-                    }
-            }
-        }
+        return;
     }
 
-    ui->tableWidget->selectRow(selectedRow);
-    ui->tableWidget->setSortingEnabled(true);
-}
+    const VPiece piece = pieces->value(id);
+    QList<QTreeWidgetItem *> items = allPieceItems();
 
-//---------------------------------------------------------------------------------------------------------------------
-void PiecesWidget::updateList()
-{
-    fillTable(m_data->DataPieces());
-}
-
-
-//---------------------------------------------------------------------------------------------------------------------
-void PiecesWidget::selectPiece(quint32 id)
-{
-    const int rowCount = ui->tableWidget->rowCount();
-    for (int row = 0; row < rowCount; ++row)
+    for (QTreeWidgetItem *item : items)
     {
-        QTableWidgetItem *item = ui->tableWidget->item(row, 0);
-
-        if (item->data(Qt::UserRole).toUInt() == id)
+        if (item->data(0, PieceIdRole).toUInt() == id)
         {
-            ui->tableWidget->setCurrentItem(item);
+            PatternPieceTool *tool = qobject_cast<PatternPieceTool*>(VAbstractPattern::getTool(id));
+            const bool visible = tool ? tool->isVisible() : true;
+            item->setIcon(0, visible ? QIcon("://icon/32x32/visible_on.png")
+                                     : QIcon("://icon/32x32/visible_off.png"));
+            item->setIcon(1, piece.isLocked() ? QIcon("://icon/32x32/lock_on.png")
+                                              : QIcon("://icon/32x32/lock_off.png"));
+
+            QPixmap pixmap(20, 20);
+            pixmap.fill(QColor(piece.getColor()));
+            item->setIcon(2, QIcon(pixmap));
+
+            item->setText(3, formatLetterString(piece));
+            item->setText(4, piece.GetName());
+
+            ui->treeWidget->setCurrentItem(item);
             return;
         }
     }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void PiecesWidget::cellClicked(int row, int column)
+void PiecesWidget::updateList()
 {
-    QTableWidgetItem *item = ui->tableWidget->item(row, 0);
-    if (!item) return;
+    fillTree(m_data->DataPieces());
+}
 
-    const quint32 id = item->data(Qt::UserRole).toUInt();
+//---------------------------------------------------------------------------------------------------------------------
+void PiecesWidget::selectPiece(quint32 id)
+{
+    QList<QTreeWidgetItem *> items = allPieceItems();
+    for (QTreeWidgetItem *item : items)
+    {
+        if (item->data(0, PieceIdRole).toUInt() == id)
+        {
+            ui->treeWidget->setCurrentItem(item);
+            return;
+        }
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void PiecesWidget::clear()
+{
+    ui->treeWidget->clear();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void PiecesWidget::itemClicked(QTreeWidgetItem *item, int column)
+{
+    if (!item)
+    {
+        return;
+    }
+
+    if (item->data(0, IsNodeRole).toBool())
+    {
+        const quint32 nodeId = item->data(0, NodeIdRole).toUInt();
+        clearNodeHighlight();
+        if (nodeId == NULL_ID)
+        {
+            return;
+        }
+
+        // In Piece (Stück) mode the current scene is the piece scene, where the
+        // VNodePoint items live as children of the PatternPieceTool. NodeIdRole holds
+        // the VNode tool id, so getTool() returns the node tool directly.
+        // getTool() throws VExceptionBadId for an unknown id.
+        VNodePoint *nodePoint = nullptr;
+        try
+        {
+            nodePoint = qobject_cast<VNodePoint *>(VAbstractPattern::getTool(nodeId));
+        }
+        catch (const VExceptionBadId &)
+        {
+            return;
+        }
+
+        if (nodePoint != nullptr)
+        {
+            // Point node: it has its own scene item, highlight it directly.
+            if (nodePoint->isVisible())
+            {
+                nodePoint->setHighlighted(true);
+                nodePoint->ensureVisible();
+                m_highlightedNodeId = nodeId;
+            }
+        }
+        else
+        {
+            // Curve node (spline/arc/...): no own scene item, it is drawn by the piece
+            // path. Draw a temporary red overlay along the curve geometry instead.
+            highlightCurveNode(nodeId, item->parent());
+        }
+        return;
+    }
+
+    clearNodeHighlight();
+
+    const quint32 id = item->data(0, PieceIdRole).toUInt();
     const QHash<quint32, VPiece> *allPieces = m_data->DataPieces();
     const bool locked = allPieces->value(id).isLocked();
 
     if (column == 0)
     {
-        if (locked == false)
+        PatternPieceTool *tool = qobject_cast<PatternPieceTool*>(VAbstractPattern::getTool(id));
+        if (tool)
         {
-            const bool inLayout = !allPieces->value(id).isInLayout();
+            const bool nowVisible = !tool->isVisible();
+            tool->setVisible(nowVisible);
 
-            TogglePieceInLayout *command = new TogglePieceInLayout(id, inLayout, m_data, m_doc);
+            TogglePieceInLayout *command = new TogglePieceInLayout(id, nowVisible, m_data, m_doc);
             connect(command, &TogglePieceInLayout::updateList, this, &PiecesWidget::togglePiece);
             qApp->getUndoStack()->push(command);
+
+            ui->treeWidget->blockSignals(true);
+            item->setIcon(0, nowVisible ? QIcon("://icon/32x32/visible_on.png")
+                                        : QIcon("://icon/32x32/visible_off.png"));
+            ui->treeWidget->blockSignals(false);
         }
-        else
-        {
-            QApplication::beep();
-        }
+        return;
     }
     else if (column == 1)
     {
@@ -294,38 +450,38 @@ void PiecesWidget::cellClicked(int row, int column)
         SCASSERT(scene != nullptr)
         emit scene->pieceLockedChanged(id, locked);
     }
-    if (column == 2)
+    else if (column == 2 || column == 3 || column == 4)
     {
         if (locked == true)
         {
             QApplication::beep();
         }
-    }
-    else if (column == 3 || column == 4)
-    {
-        if (locked == true)
-        {
-            QApplication::beep();
-        }
-
     }
     emit Highlight(id);
+    emit pieceSelected(id);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void PiecesWidget::cellDoubleClicked(int row, int column)
+void PiecesWidget::itemDoubleClicked(QTreeWidgetItem *item, int column)
 {
-    QTableWidgetItem *item = ui->tableWidget->item(row, 0);
-    if (!item) return;
+    if (!item)
+    {
+        return;
+    }
 
-    const quint32 id = item->data(Qt::UserRole).toUInt();
+    if (item->data(0, IsNodeRole).toBool())
+    {
+        return;
+    }
+
+    const quint32 id = item->data(0, PieceIdRole).toUInt();
     const QHash<quint32, VPiece> *allPieces = m_data->DataPieces();
     const bool locked = allPieces->value(id).isLocked();
 
     if (locked == true)
     {
         QApplication::beep();
-        ui->tableWidget->clearSelection();
+        ui->treeWidget->clearSelection();
         emit Highlight(NULL);
         return;
     }
@@ -333,98 +489,199 @@ void PiecesWidget::cellDoubleClicked(int row, int column)
     if (column == 2)
     {
         editPieceColor(id);
+        ui->treeWidget->clearSelection();
+        emit Highlight(NULL);
     }
-    else if (column == 3 || column == 4)
+    else if (column == 3)
     {
         editPieceProperties(id);
+        ui->treeWidget->clearSelection();
+        emit Highlight(NULL);
     }
-    ui->tableWidget->clearSelection();
-    emit Highlight(NULL);
+    else if (column == 4)
+    {
+        item->setFlags(item->flags() | Qt::ItemIsEditable);
+        ui->treeWidget->editItem(item, 4);
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void PiecesWidget::fillTable(const QHash<quint32, VPiece> *pieces)
+QTreeWidgetItem *PiecesWidget::createPieceItem(quint32 id, const VPiece &piece)
 {
-    ui->tableWidget->blockSignals(true);
-    ui->tableWidget->clearContents();
-    ui->tableWidget->setColumnCount(5);
-    ui->tableWidget->setRowCount(pieces->size());
-    ui->tableWidget->setSortingEnabled(false);
+    QTreeWidgetItem *item = new QTreeWidgetItem();
 
-    qint32 currentRow = -1;
-    auto i = pieces->constBegin();
-    while (i != pieces->constEnd())
+    PatternPieceTool *tool = qobject_cast<PatternPieceTool*>(VAbstractPattern::getTool(id));
+    const bool visible = tool ? tool->isVisible() : true;
+    item->setIcon(0, visible ? QIcon("://icon/32x32/visible_on.png")
+                             : QIcon("://icon/32x32/visible_off.png"));
+    item->setToolTip(0, tr("Toggle visibility of pattern piece on canvas"));
+
+    item->setIcon(1, piece.isLocked() ? QIcon("://icon/32x32/lock_on.png")
+                                      : QIcon("://icon/32x32/lock_off.png"));
+    item->setToolTip(1, tr("Toggle lock on pattern piece"));
+
+    QPixmap pixmap(20, 20);
+    pixmap.fill(QColor(piece.getColor()));
+    item->setIcon(2, QIcon(pixmap));
+    item->setToolTip(2, tr("Double click opens color selector"));
+
+    item->setText(3, formatLetterString(piece));
+    item->setToolTip(3, tr("Double click opens pattern piece properties dialog"));
+
+    item->setText(4, piece.GetName());
+    item->setToolTip(4, tr("Click to rename"));
+
+    item->setData(0, PieceIdRole, id);
+    item->setData(0, IsNodeRole, false);
+    item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsDragEnabled);
+
+    const QVector<VPieceNode> nodes = piece.GetPath().getNodes();
+    for (const VPieceNode &node : nodes)
     {
-        ++currentRow;
-        const VPiece piece = i.value();
-
-        // Add in layout item
-        PieceTableWidgetItem *item = new PieceTableWidgetItem(m_data);
-        item->setTextAlignment(Qt::AlignHCenter);
-        item->setSizeHint(QSize(20, 20));
-        item->setIcon(piece.isInLayout() ? QIcon("://icon/32x32/visible_on.png") : QIcon("://icon/32x32/visible_off.png"));
-        item->setData(Qt::UserRole, i.key());
-        item->setFlags(item->flags() &= ~(Qt::ItemIsEditable)); // set the item non-editable (view only), and non-selectable
-        item->setToolTip(tr("Toggle inclusion of pattern piece in layout"));
-        ui->tableWidget->setItem(currentRow, 0, item);
-
-        // Add locked item
-        item = new PieceTableWidgetItem(m_data);
-        item->setTextAlignment(Qt::AlignHCenter);
-        item->setSizeHint(QSize(20, 20));
-        item->setIcon(piece.isLocked() ? QIcon("://icon/32x32/lock_on.png") : QIcon("://icon/32x32/lock_off.png"));
-        item->setData(Qt::UserRole, i.key());
-        item->setFlags(item->flags() &= ~(Qt::ItemIsEditable));  // set the item non-editable (view only), and non-selectable
-        item->setToolTip(tr("Toggle lock on pattern piece"));
-        ui->tableWidget->setItem(currentRow, 1, item);
-
-        // Add color item
-        item = new PieceTableWidgetItem(m_data);
-        item->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
-        item->setSizeHint(QSize(20, 20));
-        QPixmap pixmap(20, 20);
-        pixmap.fill(QColor(piece.getColor()));
-        item->setIcon(QIcon(pixmap));
-        item->setData(Qt::UserRole, piece.getColor());
-        item->setFlags(item->flags() &= ~(Qt::ItemIsEditable));  // set the item non-editable (view only), and non-selectable
-        item->setToolTip(tr("Double click opens color selector"));
-        ui->tableWidget->setItem(currentRow, 2, item);
-
-        { // Add letter item
-            QTableWidgetItem *item = new QTableWidgetItem(formatLetterString(piece));
-            item->setTextAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
-            item->setFlags(item->flags() &= ~(Qt::ItemIsEditable));  // set the item non-editable (view only), and non-selectable
-            item->setToolTip(tr("Double click opens pattern piece properties dialog"));
-            ui->tableWidget->setItem(currentRow, 3, item);
+        QTreeWidgetItem *nodeItem = createNodeItem(node);
+        if (nodeItem)
+        {
+            item->addChild(nodeItem);
         }
-
-        { // Add name item
-            QTableWidgetItem *item = new QTableWidgetItem(piece.GetName());
-            item->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
-            item->setFlags(item->flags() &= ~(Qt::ItemIsEditable));  // set the item non-editable (view only), and non-selectable
-            item->setToolTip(tr("Double click opens pattern piece properties dialog"));
-            ui->tableWidget->setItem(currentRow, 4, item);
-        }
-
-        ++i;
     }
 
-    ui->tableWidget->setHorizontalHeaderItem(0, new QTableWidgetItem(makeHeaderName(tr("Included"))));
-    ui->tableWidget->horizontalHeaderItem(0)->setToolTip(tr("Pattern piece is included in layout"));
-    ui->tableWidget->setHorizontalHeaderItem(1, new QTableWidgetItem(makeHeaderName(tr("Locked"))));
-    ui->tableWidget->horizontalHeaderItem(1)->setToolTip(tr("Pattern piece is locked"));
-    ui->tableWidget->setHorizontalHeaderItem(2, new QTableWidgetItem(makeHeaderName(tr("Color"))));
-    ui->tableWidget->horizontalHeaderItem(2)->setToolTip(tr("Pattern piece color"));
-    ui->tableWidget->setHorizontalHeaderItem(3, new QTableWidgetItem(makeHeaderName(tr("Piece"))));
-    ui->tableWidget->horizontalHeaderItem(3)->setToolTip(tr("Pattern piece letter"));
-    ui->tableWidget->setHorizontalHeaderItem(4, new QTableWidgetItem(tr("Name")));
-    ui->tableWidget->horizontalHeaderItem(4)->setToolTip(tr("Pattern piece name"));
-    ui->tableWidget->horizontalHeaderItem(4)->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
-    ui->tableWidget->horizontalHeader()->setSectionResizeMode(QHeaderView::Fixed);
-    ui->tableWidget->resizeColumnsToContents();
-    ui->tableWidget->resizeRowsToContents();
-    ui->tableWidget->setSortingEnabled(true);
-    ui->tableWidget->blockSignals(false);
+    return item;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+QTreeWidgetItem *PiecesWidget::createNodeItem(const VPieceNode &node)
+{
+    QTreeWidgetItem *item = new QTreeWidgetItem();
+
+    const bool isPoint = (node.GetTypeTool() == Tool::NodePoint);
+
+    QString name;
+    try
+    {
+        if (isPoint)
+        {
+            name = m_data->GeometricObject<VPointF>(node.GetId())->name();
+        }
+        else
+        {
+            name = m_data->GeometricObject<VAbstractCurve>(node.GetId())->name();
+        }
+    }
+    catch (...)
+    {
+        return nullptr;
+    }
+
+    // Column 2: modifier icon — notch-type icon for points, reverse icon for curves.
+    // (A node is either a point or a curve, so the column serves both cases.)
+    if (isPoint && node.isNotch())
+    {
+        item->setIcon(2, QIcon(notchIconPath(node.getNotchType())));
+        item->setToolTip(2, tr("Notch"));
+    }
+    else if (!isPoint && node.GetReverse())
+    {
+        item->setIcon(2, QIcon(QStringLiteral("://icon/24x24/reverse.png")));
+        item->setToolTip(2, tr("Reversed"));
+    }
+
+    // Column 3: tool-type icon — depends only on the node's tool type.
+    item->setIcon(3, QIcon(toolTypeIconPath(node.GetTypeTool())));
+
+    item->setText(4, name);
+    item->setToolTip(4, tr("Double click to edit node"));
+
+    if (node.isExcluded())
+    {
+        QFont strikeFont = item->font(4);
+        strikeFont.setStrikeOut(true);
+        item->setFont(4, strikeFont);
+        item->setForeground(4, QColor(Qt::gray));
+    }
+
+    item->setData(0, IsNodeRole, true);
+    item->setData(0, NodeIdRole, node.GetId());
+    item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+
+    return item;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void PiecesWidget::fillTree(const QHash<quint32, VPiece> *pieces)
+{
+    if (m_fillTreeInProgress)
+    {
+        return;
+    }
+    m_fillTreeInProgress = true;
+
+    QSet<quint32> expandedPieces;
+    QList<QTreeWidgetItem *> oldItems = allPieceItems();
+    for (QTreeWidgetItem *old : oldItems)
+    {
+        if (old->isExpanded())
+        {
+            expandedPieces.insert(old->data(0, PieceIdRole).toUInt());
+        }
+    }
+
+    ui->treeWidget->blockSignals(true);
+    ui->treeWidget->clear();
+
+    auto it = pieces->constBegin();
+    while (it != pieces->constEnd())
+    {
+        QTreeWidgetItem *item = createPieceItem(it.key(), it.value());
+        ui->treeWidget->addTopLevelItem(item);
+        item->setExpanded(expandedPieces.contains(it.key()));
+        ++it;
+    }
+
+    ui->treeWidget->blockSignals(false);
+    m_fillTreeInProgress = false;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+QList<QTreeWidgetItem *> PiecesWidget::allPieceItems() const
+{
+    QList<QTreeWidgetItem *> result;
+    for (int i = 0; i < ui->treeWidget->topLevelItemCount(); ++i)
+    {
+        result.append(ui->treeWidget->topLevelItem(i));
+    }
+    return result;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void PiecesWidget::itemChanged(QTreeWidgetItem *item, int column)
+{
+    if (!item || column != 4 || item->data(0, IsNodeRole).toBool())
+    {
+        return;
+    }
+
+    item->setFlags(item->flags() & ~Qt::ItemIsEditable);
+
+    const quint32 id = item->data(0, PieceIdRole).toUInt();
+    const QHash<quint32, VPiece> *allPieces = m_data->DataPieces();
+    if (!allPieces->contains(id))
+    {
+        return;
+    }
+
+    const QString newName = item->text(4).trimmed();
+    VPiece oldPiece = allPieces->value(id);
+    if (newName.isEmpty() || newName == oldPiece.GetName())
+    {
+        return;
+    }
+
+    VPiece newPiece = oldPiece;
+    newPiece.SetName(newName);
+
+    SavePieceOptions *command = new SavePieceOptions(oldPiece, newPiece, m_doc, id);
+    qApp->getUndoStack()->push(command);
+    QTimer::singleShot(0, this, &PiecesWidget::updateList);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -436,10 +693,10 @@ void PiecesWidget::toggleInLayoutPieces(bool inLayout)
         return;
     }
 
-    for (int row = 0; row<ui->tableWidget->rowCount(); ++row)
+    QList<QTreeWidgetItem *> items = allPieceItems();
+    for (QTreeWidgetItem *item : items)
     {
-        QTableWidgetItem *item = ui->tableWidget->item(row, 0);
-        const quint32 id = item->data(Qt::UserRole).toUInt();
+        const quint32 id = item->data(0, PieceIdRole).toUInt();
         if (allPieces->contains(id))
         {
             if (!(inLayout == allPieces->value(id).isInLayout()))
@@ -455,18 +712,17 @@ void PiecesWidget::toggleInLayoutPieces(bool inLayout)
 //---------------------------------------------------------------------------------------------------------------------
 void PiecesWidget::toggleLockedPieces(bool lock)
 {
-    ui->tableWidget->blockSignals(true);
-    ui->tableWidget->horizontalHeader()->setSortIndicator(-1, Qt::AscendingOrder);
+    ui->treeWidget->blockSignals(true);
     const QHash<quint32, VPiece> *allPieces = m_data->DataPieces();
     if (allPieces->count() == 0)
     {
         return;
     }
 
-    for (int row = 0; row<ui->tableWidget->rowCount(); ++row)
+    QList<QTreeWidgetItem *> items = allPieceItems();
+    for (QTreeWidgetItem *item : items)
     {
-        QTableWidgetItem *item = ui->tableWidget->item(row, 1);
-        const quint32 id = item->data(Qt::UserRole).toUInt();
+        const quint32 id = item->data(0, PieceIdRole).toUInt();
         if (allPieces->contains(id))
         {
             if (!(lock == allPieces->value(id).isLocked()))
@@ -481,22 +737,10 @@ void PiecesWidget::toggleLockedPieces(bool lock)
             }
         }
     }
-    ui->tableWidget->blockSignals(false);
-}
-/**
- * @brief headerClicked Sort state whenever header section clicked.
- * @param index
- */
-void PiecesWidget::headerClicked(int index)
-{
-    QSettings settings;
-    settings.setValue("pieceSort", index);
+    ui->treeWidget->blockSignals(false);
 }
 
-/**
- * @brief formatLetterString makes name to include piece letter and piece name
- * @param piece pattern piece
- */
+//---------------------------------------------------------------------------------------------------------------------
 QString PiecesWidget::formatLetterString(const VPiece piece)
 {
     QRegularExpression regExp("^\\d+$");
@@ -513,15 +757,20 @@ QString PiecesWidget::formatLetterString(const VPiece piece)
     }
     return letter;
 }
+
 //---------------------------------------------------------------------------------------------------------------------
 void PiecesWidget::showContextMenu(const QPoint &pos)
 {
-    ui->tableWidget->horizontalHeader()->setSortIndicator(-1, Qt::AscendingOrder);
-    ui->tableWidget->setSortingEnabled(false);
-    ui->tableWidget->blockSignals(true);
+    QTreeWidgetItem *clickedItem = ui->treeWidget->itemAt(pos);
+    if (clickedItem && clickedItem->data(0, IsNodeRole).toBool())
+    {
+        showNodeContextMenu(clickedItem, ui->treeWidget->viewport()->mapToGlobal(pos));
+        return;
+    }
 
-    // workaround for https://bugreports.qt.io/browse/QTBUG-97559: assign parent to QMenu
-    QScopedPointer<QMenu> menu(new QMenu(ui->tableWidget));
+    ui->treeWidget->blockSignals(true);
+
+    QScopedPointer<QMenu> menu(new QMenu(ui->treeWidget));
     QAction *selectAll = menu->addAction(tr("Include all pieces"));
     QAction *selectNone = menu->addAction(tr("Exclude all pieces"));
     QAction *invertSelection = menu->addAction(tr("Invert included pieces"));
@@ -575,7 +824,7 @@ void PiecesWidget::showContextMenu(const QPoint &pos)
         lockAll->setDisabled(true);
     }
 
-    QAction *selectedAction = menu->exec(ui->tableWidget->viewport()->mapToGlobal(pos));
+    QAction *selectedAction = menu->exec(ui->treeWidget->viewport()->mapToGlobal(pos));
 
     if (selectedAction == selectAll)
     {
@@ -589,7 +838,6 @@ void PiecesWidget::showContextMenu(const QPoint &pos)
     {
         invertIncludedPieces();
     }
-
     else if (selectedAction == lockAll)
     {
         lockAllPieces();
@@ -602,10 +850,10 @@ void PiecesWidget::showContextMenu(const QPoint &pos)
     {
         invertLockedPieces();
     }
-    ui->tableWidget->setSortingEnabled(true);
-    ui->tableWidget->blockSignals(false);
+    ui->treeWidget->blockSignals(false);
 }
 
+//---------------------------------------------------------------------------------------------------------------------
 void PiecesWidget::includeAllPieces()
 {
     qApp->getUndoStack()->beginMacro(tr("Include all pieces"));
@@ -613,6 +861,7 @@ void PiecesWidget::includeAllPieces()
     qApp->getUndoStack()->endMacro();
 }
 
+//---------------------------------------------------------------------------------------------------------------------
 void PiecesWidget::invertIncludedPieces()
 {
     if (m_allPieces->isEmpty())
@@ -621,10 +870,10 @@ void PiecesWidget::invertIncludedPieces()
     }
     qApp->getUndoStack()->beginMacro(tr("Invert included pieces"));
 
-    for (int row = 0; row < ui->tableWidget->rowCount(); ++row)
+    QList<QTreeWidgetItem *> items = allPieceItems();
+    for (QTreeWidgetItem *item : items)
     {
-        QTableWidgetItem *item = ui->tableWidget->item(row, 0);
-        const quint32 id = item->data(Qt::UserRole).toUInt();
+        const quint32 id = item->data(0, PieceIdRole).toUInt();
         if (m_allPieces->contains(id))
         {
             const bool inLayout = !m_allPieces->value(id).isInLayout();
@@ -638,6 +887,7 @@ void PiecesWidget::invertIncludedPieces()
     qApp->getUndoStack()->endMacro();
 }
 
+//---------------------------------------------------------------------------------------------------------------------
 void PiecesWidget::excludeAllPieces()
 {
     qApp->getUndoStack()->beginMacro(tr("Exclude all pieces"));
@@ -645,6 +895,7 @@ void PiecesWidget::excludeAllPieces()
     qApp->getUndoStack()->endMacro();
 }
 
+//---------------------------------------------------------------------------------------------------------------------
 void PiecesWidget::lockAllPieces()
 {
     qApp->getUndoStack()->beginMacro(tr("Lock all pieces"));
@@ -652,6 +903,7 @@ void PiecesWidget::lockAllPieces()
     qApp->getUndoStack()->endMacro();
 }
 
+//---------------------------------------------------------------------------------------------------------------------
 void PiecesWidget::invertLockedPieces()
 {
     if (m_allPieces->isEmpty())
@@ -660,10 +912,10 @@ void PiecesWidget::invertLockedPieces()
     }
     qApp->getUndoStack()->beginMacro(tr("Invert locked pieces"));
 
-    for (int row = 0; row < ui->tableWidget->rowCount(); ++row)
+    QList<QTreeWidgetItem *> items = allPieceItems();
+    for (QTreeWidgetItem *item : items)
     {
-        QTableWidgetItem *item = ui->tableWidget->item(row, 1);
-        const quint32 id = item->data(Qt::UserRole).toUInt();
+        const quint32 id = item->data(0, PieceIdRole).toUInt();
         if (m_allPieces->contains(id))
         {
             const bool lock = !m_allPieces->value(id).isLocked();
@@ -681,6 +933,7 @@ void PiecesWidget::invertLockedPieces()
     qApp->getUndoStack()->endMacro();
 }
 
+//---------------------------------------------------------------------------------------------------------------------
 void PiecesWidget::unlockAllPieces()
 {
     qApp->getUndoStack()->beginMacro(tr("Unlock all pieces"));
@@ -688,6 +941,7 @@ void PiecesWidget::unlockAllPieces()
     qApp->getUndoStack()->endMacro();
 }
 
+//---------------------------------------------------------------------------------------------------------------------
 void PiecesWidget::editPieceColor(quint32 id)
 {
     const QColor color = QColorDialog::getColor(Qt::white, this, tr("Select Color"), QColorDialog::DontUseNativeDialog);
@@ -700,9 +954,254 @@ void PiecesWidget::editPieceColor(quint32 id)
     }
 }
 
+//---------------------------------------------------------------------------------------------------------------------
 void PiecesWidget::editPieceProperties(quint32 id)
 {
     PatternPieceTool *tool = qobject_cast<PatternPieceTool*>(VAbstractPattern::getTool(id));
     SCASSERT(tool != nullptr);
     tool->editPieceProperties();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void PiecesWidget::clearNodeHighlight()
+{
+    // Clear a highlighted point node.
+    if (m_highlightedNodeId != NULL_ID)
+    {
+        try
+        {
+            VNodePoint *nodePoint = qobject_cast<VNodePoint *>(VAbstractPattern::getTool(m_highlightedNodeId));
+            if (nodePoint != nullptr)
+            {
+                nodePoint->setHighlighted(false);
+            }
+        }
+        catch (const VExceptionBadId &)
+        {
+            // tool no longer exists (e.g. piece deleted) — nothing to clear
+        }
+        m_highlightedNodeId = NULL_ID;
+    }
+
+    // Remove any temporary curve-highlight overlay. Query the live scene so we never
+    // dereference an item the scene may already have deleted (e.g. on file reload).
+    QGraphicsScene *scene = qApp->getCurrentScene();
+    if (scene != nullptr)
+    {
+        const QList<QGraphicsItem *> items = scene->items();
+        for (QGraphicsItem *gItem : items)
+        {
+            if (gItem->data(NODE_HIGHLIGHT_KEY).toBool())
+            {
+                scene->removeItem(gItem);
+                delete gItem;
+            }
+        }
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void PiecesWidget::highlightCurveNode(quint32 nodeId, QTreeWidgetItem *pieceItem)
+{
+    QGraphicsScene *scene = qApp->getCurrentScene();
+    if (scene == nullptr)
+    {
+        return;
+    }
+
+    // Find whether this node is reversed within its owning piece.
+    bool reversed = false;
+    if (pieceItem != nullptr)
+    {
+        const quint32 pieceId = pieceItem->data(0, PieceIdRole).toUInt();
+        const QHash<quint32, VPiece> *allPieces = m_data->DataPieces();
+        if (allPieces->contains(pieceId))
+        {
+            const QVector<VPieceNode> nodes = allPieces->value(pieceId).GetPath().getNodes();
+            for (const VPieceNode &n : nodes)
+            {
+                if (n.GetId() == nodeId)
+                {
+                    reversed = n.GetReverse();
+                    break;
+                }
+            }
+        }
+    }
+
+    QPainterPath path;
+    try
+    {
+        const QSharedPointer<VAbstractCurve> curve = m_data->GeometricObject<VAbstractCurve>(nodeId);
+        path = curve->GetPath();
+
+        // Append the direction arrow, mirroring how curves show direction in draft mode.
+        // Reverse the point order for reversed nodes so the arrow points the right way.
+        QVector<QPointF> points = curve->getPoints();
+        if (reversed)
+        {
+            std::reverse(points.begin(), points.end());
+        }
+        const QPainterPath arrows = VAbstractCurve::ShowDirection(
+            directionArrowsForPoints(points, curve->GetLength()),
+            scaleWidth(VAbstractCurve::lengthCurveDirectionArrow, sceneScale(scene)));
+        if (arrows != QPainterPath())
+        {
+            path.addPath(arrows);
+        }
+    }
+    catch (...)
+    {
+        return;
+    }
+
+    if (path == QPainterPath())
+    {
+        return;
+    }
+
+    QGraphicsPathItem *overlay = new QGraphicsPathItem(path);
+    QPen pen(Qt::red);
+    pen.setWidth(3);
+    pen.setCosmetic(true);   // constant width regardless of zoom
+    overlay->setPen(pen);
+    overlay->setBrush(Qt::NoBrush);
+    overlay->setZValue(1000);
+    overlay->setData(NODE_HIGHLIGHT_KEY, true);
+
+    // Parent the overlay to the PatternPieceTool so it follows the piece's transform;
+    // the curve geometry is in the same local coordinate system as the piece nodes.
+    PatternPieceTool *pieceTool = nullptr;
+    if (pieceItem != nullptr)
+    {
+        const quint32 pieceId = pieceItem->data(0, PieceIdRole).toUInt();
+        if (pieceId != NULL_ID)
+        {
+            try
+            {
+                pieceTool = qobject_cast<PatternPieceTool *>(VAbstractPattern::getTool(pieceId));
+            }
+            catch (const VExceptionBadId &)
+            {
+                pieceTool = nullptr;
+            }
+        }
+    }
+
+    if (pieceTool != nullptr)
+    {
+        overlay->setParentItem(pieceTool);
+    }
+    else
+    {
+        scene->addItem(overlay);
+    }
+
+    overlay->ensureVisible();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void PiecesWidget::showNodeContextMenu(QTreeWidgetItem *item, const QPoint &globalPos)
+{
+    if (!item || !item->parent())
+    {
+        return;
+    }
+
+    const quint32 nodeId = item->data(0, NodeIdRole).toUInt();
+    const quint32 pieceId = item->parent()->data(0, PieceIdRole).toUInt();
+
+    const QHash<quint32, VPiece> *allPieces = m_data->DataPieces();
+    if (!allPieces->contains(pieceId))
+    {
+        return;
+    }
+
+    VPiece piece = allPieces->value(pieceId);
+    QVector<VPieceNode> nodes = piece.GetPath().getNodes();
+
+    int nodeIndex = -1;
+    for (int i = 0; i < nodes.size(); ++i)
+    {
+        if (nodes.at(i).GetId() == nodeId)
+        {
+            nodeIndex = i;
+            break;
+        }
+    }
+    if (nodeIndex < 0)
+    {
+        return;
+    }
+
+    const VPieceNode &node = nodes.at(nodeIndex);
+    const bool isPoint = (node.GetTypeTool() == Tool::NodePoint);
+    const bool excluded = node.isExcluded();
+
+    QScopedPointer<QMenu> menu(new QMenu(ui->treeWidget));
+
+    QAction *toggleExclude = menu->addAction(excluded ? tr("Include object")
+                                                      : tr("Exclude object"));
+
+    QAction *toggleReverse = nullptr;
+    if (!isPoint)
+    {
+        toggleReverse = menu->addAction(tr("Reverse direction"));
+    }
+
+    QAction *addDefaultNotch = nullptr;
+    QAction *toggleNotch = nullptr;
+    if (isPoint)
+    {
+        if (!node.isNotch())
+        {
+            addDefaultNotch = menu->addAction(tr("Add standard notch"));
+            toggleNotch = menu->addAction(tr("Add notch"));
+        }
+        else
+        {
+            toggleNotch = menu->addAction(tr("Remove notch"));
+        }
+    }
+
+    QAction *selectedAction = menu->exec(globalPos);
+    if (!selectedAction)
+    {
+        return;
+    }
+
+    if (selectedAction == toggleExclude)
+    {
+        nodes[nodeIndex].SetExcluded(!excluded);
+    }
+    else if (selectedAction == toggleReverse && toggleReverse)
+    {
+        nodes[nodeIndex].SetReverse(!node.GetReverse());
+    }
+    else if (selectedAction == addDefaultNotch && addDefaultNotch)
+    {
+        nodes[nodeIndex].setNotch(true);
+        nodes[nodeIndex].setNotchType(
+            static_cast<NotchType>(qApp->Settings()->GetDefaultNotchType()));
+        nodes[nodeIndex].setNotchSubType(
+            static_cast<NotchSubType>(qApp->Settings()->GetDefaultNotchSubType()));
+    }
+    else if (selectedAction == toggleNotch && toggleNotch)
+    {
+        nodes[nodeIndex].setNotch(!node.isNotch());
+    }
+    else
+    {
+        return;
+    }
+
+    VPiece newPiece = piece;
+    newPiece.GetPath().setNodes(nodes);
+
+    SavePieceOptions *command = new SavePieceOptions(piece, newPiece, m_doc, pieceId);
+    qApp->getUndoStack()->push(command);
+    // Rebuild after the command (and its lite parse) has fully applied, so the tree
+    // reflects the new node state. Doing it here (not via NeedLiteParsing) avoids reading
+    // stale container data before the parse completes.
+    updateList();
 }

--- a/src/app/seamly2d/dialogs/pieces_widget.h
+++ b/src/app/seamly2d/dialogs/pieces_widget.h
@@ -1,64 +1,65 @@
-/***************************************************************************
- **  @file   pieces_widget.h
- **  @author Douglas S Caskey
- **  @date   Jan 3, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+ //-----------------------------------------------------------------------------
+ //  @file   pieces_widget.h
+ //  @author Douglas S Caskey
+ //  @date   17 Sep, 2023
+ //
+ //  @brief
+ //  @copyright
+ //  This source code is part of the Seamly2D project, a pattern making
+ //  program, whose allow create and modeling patterns of clothing.
+ //  Copyright (C) 2013-2026 Seamly2D project
+ //  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ //
+ //  Seamly2D is free software: you can redistribute it and/or modify
+ //  it under the terms of the GNU General Public License as published by
+ //  the Free Software Foundation, either version 3 of the License, or
+ //  (at your option) any later version.
+ //
+ //  Seamly2D is distributed in the hope that it will be useful,
+ //  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ //  GNU General Public License for more details.
+ //
+ //  You should have received a copy of the GNU General Public License
+ //  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+ //-----------------------------------------------------------------------------
 
-/************************************************************************
- **
- **  @file   vwidgetdetails.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   25 6, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Valentina project
- **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+ //-----------------------------------------------------------------------------
+ //  @file   vwidgetdetails.h
+ //  @author Roman Telezhynskyi <dismine(at)gmail.com>
+ //  @date   Jun 25, 2016
+ //
+ //  @brief
+ //  @copyright
+ //  This source code is part of the Valentina project, a pattern making
+ //  program, whose allow create and modeling patterns of clothing.
+ //  Copyright (C) 2016 Valentina project
+ //  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+ //
+ //  Valentina is free software: you can redistribute it and/or modify
+ //  it under the terms of the GNU General Public License as published by
+ //  the Free Software Foundation, either version 3 of the License, or
+ //  (at your option) any later version.
+ //
+ //  Valentina is distributed in the hope that it will be useful,
+ //  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ //  GNU General Public License for more details.
+ //
+ //  You should have received a copy of the GNU General Public License
+ //  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+ //-----------------------------------------------------------------------------
 
 #ifndef PIECES_WIDGET_H
 #define PIECES_WIDGET_H
 
 #include <QWidget>
-#include <QTableWidgetItem>
+#include <QTreeWidgetItem>
 
 class VAbstractPattern;
 class VContainer;
 class VPiece;
+class VPieceNode;
 
 namespace Ui
 {
@@ -75,19 +76,23 @@ public:
 
 signals:
     void               Highlight(quint32 id);
+    void               pieceSelected(quint32 id);
 
 public slots:
     void               togglePiece(quint32 id);
     void               updateList();
     void               selectPiece(quint32 id);
+    void               clear();
+    void               clearNodeHighlight();
 
 private slots:
-    void               cellClicked(int row, int column);
-    void               cellDoubleClicked(int row, int column);
+    void               itemClicked(QTreeWidgetItem *item, int column);
+    void               itemDoubleClicked(QTreeWidgetItem *item, int column);
+    void               itemChanged(QTreeWidgetItem *item, int column);
     void               showContextMenu(const QPoint &pos);
 
 protected:
-    virtual void       changeEvent(QEvent* event) Q_DECL_OVERRIDE;
+    virtual void       changeEvent(QEvent* event) override;
 
 private:
     Q_DISABLE_COPY(PiecesWidget)
@@ -95,11 +100,21 @@ private:
     VAbstractPattern             *m_doc;
     VContainer                   *m_data;
     const QHash<quint32, VPiece> *m_allPieces;
+    quint32                          m_highlightedNodeId;
+    bool                             m_fillTreeInProgress;
 
-    void               fillTable(const QHash<quint32, VPiece> *details);
+    enum ItemRole
+    {
+        PieceIdRole   = Qt::UserRole,
+        IsNodeRole    = Qt::UserRole + 1,
+        NodeIdRole    = Qt::UserRole + 2
+    };
+
+    void               fillTree(const QHash<quint32, VPiece> *pieces);
+    QTreeWidgetItem   *createPieceItem(quint32 id, const VPiece &piece);
+    QTreeWidgetItem   *createNodeItem(const VPieceNode &node);
     void               toggleInLayoutPieces(bool inLayout);
     void               toggleLockedPieces(bool lock);
-    void               headerClicked(int index);
     QString            formatLetterString(const VPiece piece);
     void               includeAllPieces();
     void               invertIncludedPieces();
@@ -109,6 +124,9 @@ private:
     void               unlockAllPieces();
     void               editPieceColor(quint32 id);
     void               editPieceProperties(quint32 id);
+    void               showNodeContextMenu(QTreeWidgetItem *item, const QPoint &globalPos);
+    void               highlightCurveNode(quint32 nodeId, QTreeWidgetItem *pieceItem);
+    QList<QTreeWidgetItem *> allPieceItems() const;
 };
 
 #endif // PIECES_WIDGET_H

--- a/src/app/seamly2d/dialogs/pieces_widget.ui
+++ b/src/app/seamly2d/dialogs/pieces_widget.ui
@@ -222,7 +222,7 @@
       </layout>
      </item>
      <item>
-      <widget class="QTableWidget" name="tableWidget">
+      <widget class="QTreeWidget" name="treeWidget">
        <property name="palette">
         <palette>
          <active>
@@ -260,9 +260,6 @@
          </disabled>
         </palette>
        </property>
-       <property name="alternatingRowColors">
-        <bool>false</bool>
-       </property>
        <property name="selectionMode">
         <enum>QAbstractItemView::SingleSelection</enum>
        </property>
@@ -278,38 +275,43 @@
        <property name="textElideMode">
         <enum>Qt::ElideNone</enum>
        </property>
-       <property name="sortingEnabled">
-        <bool>false</bool>
+       <property name="dragEnabled">
+        <bool>true</bool>
+       </property>
+       <property name="dragDropMode">
+        <enum>QAbstractItemView::InternalMove</enum>
+       </property>
+       <property name="defaultDropAction">
+        <enum>Qt::MoveAction</enum>
        </property>
        <property name="columnCount">
         <number>5</number>
        </property>
-       <attribute name="horizontalHeaderMinimumSectionSize">
-        <number>16</number>
-       </attribute>
-       <attribute name="horizontalHeaderDefaultSectionSize">
-        <number>30</number>
-       </attribute>
-       <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
-        <bool>true</bool>
-       </attribute>
-       <attribute name="horizontalHeaderStretchLastSection">
-        <bool>true</bool>
-       </attribute>
-       <attribute name="verticalHeaderVisible">
-        <bool>false</bool>
-       </attribute>
-       <attribute name="verticalHeaderMinimumSectionSize">
-        <number>10</number>
-       </attribute>
-       <attribute name="verticalHeaderHighlightSections">
-        <bool>false</bool>
-       </attribute>
-       <column/>
-       <column/>
-       <column/>
-       <column/>
-       <column/>
+       <column>
+        <property name="text">
+         <string>Included</string>
+        </property>
+       </column>
+       <column>
+        <property name="text">
+         <string>Locked</string>
+        </property>
+       </column>
+       <column>
+        <property name="text">
+         <string>Color</string>
+        </property>
+       </column>
+       <column>
+        <property name="text">
+         <string>Piece</string>
+        </property>
+       </column>
+       <column>
+        <property name="text">
+         <string>Name</string>
+        </property>
+       </column>
       </widget>
      </item>
     </layout>

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -57,6 +57,7 @@
 #include "options.h"
 #include "version.h"
 #include "core/application_2d.h"
+#include "core/vpieceoptionspropertybrowser.h"
 #include "core/vtooloptionspropertybrowser.h"
 #include "dialogs/dialogs.h"
 #include "dialogs/calculator_dialog.h"
@@ -176,6 +177,7 @@ MainWindow::MainWindow(QWidget *parent)
     , isGroupsDockVisible(true)
     , isLayoutsDockVisible(false)
     , isToolboxDockVisible(true)
+    , isPiecesDockVisible(true)
     , drawMode(true)
     , recentFileActs()
     , separatorAct(nullptr)
@@ -188,8 +190,10 @@ MainWindow::MainWindow(QWidget *parent)
     , gradationHeightsLabel(nullptr)
     , gradationSizesLabel(nullptr)
     , toolProperties(nullptr)
+    , m_pieceProperties(nullptr)
     , groupsWidget(nullptr)
     , patternPiecesWidget(nullptr)
+    , actionDockWidgetPieces(nullptr)
     , lock(nullptr)
     , zoomScaleSpinBox(nullptr)
     , m_penToolBar(nullptr)
@@ -2692,6 +2696,28 @@ void MainWindow::initPropertyEditor()
     connect(doc, &VPattern::FullUpdateFromFile, toolProperties, &VToolOptionsPropertyBrowser::updateOptions);
 }
 
+//---------------------------------------------------------------------------------------------------------------------
+void MainWindow::initPiecePropertyEditor()
+{
+    qCDebug(vMainWindow, "Initialize the Piece Property Editor.");
+    if (m_pieceProperties != nullptr)
+    {
+        disconnect(m_pieceProperties, nullptr, this, nullptr);
+        delete m_pieceProperties;
+    }
+    m_pieceProperties = new VPieceOptionsPropertyBrowser(doc, ui->pieceProperties_DockWidget);
+
+    connect(ui->view, &VMainGraphicsView::itemClicked,
+            m_pieceProperties, &VPieceOptionsPropertyBrowser::itemClicked);
+    connect(doc, &VPattern::FullUpdateFromFile,
+            m_pieceProperties, &VPieceOptionsPropertyBrowser::updateOptions);
+    if (patternPiecesWidget)
+    {
+        connect(m_pieceProperties, &VPieceOptionsPropertyBrowser::pieceOptionsChanged,
+                patternPiecesWidget, &PiecesWidget::updateList);
+    }
+}
+
 /**
  * Called when something changed in the pen tool bar
  * (e.g. color, weight, or type).
@@ -3847,6 +3873,9 @@ void MainWindow::showDraftMode(bool checked)
         }
         ui->groups_DockWidget->setWidget(groupsWidget);
         ui->groups_DockWidget->setWindowTitle(tr("Group Manager"));
+
+        ui->pieces_DockWidget->setVisible(false);
+        ui->pieceProperties_DockWidget->setVisible(false);
     }
     else
     {
@@ -3893,6 +3922,8 @@ void MainWindow::showPieceMode(bool checked)
         }
 
         patternPiecesWidget->updateList();
+        ui->pieces_DockWidget->setVisible(true);
+        ui->pieceProperties_DockWidget->setVisible(true);
 
         qCDebug(vMainWindow, "Show piece scene");
         SaveCurrentScene();
@@ -3923,9 +3954,6 @@ void MainWindow::showPieceMode(bool checked)
             gradationSizesLabel->setVisible(true);
             gradationSizes->setVisible(true);
         }
-        ui->groups_DockWidget->setWidget(patternPiecesWidget);
-        ui->groups_DockWidget->setWindowTitle(tr("Pattern Pieces"));
-
         helpLabel->setText("");
     }
     else
@@ -3959,6 +3987,9 @@ void MainWindow::showLayoutMode(bool checked)
         ui->showDraftMode->setChecked(false);
         ui->pieceMode_Action->setChecked(false);
         ui->layoutMode_Action->setChecked(true);
+
+        ui->pieces_DockWidget->setVisible(false);
+        ui->pieceProperties_DockWidget->setVisible(false);
 
         QHash<quint32, VPiece> pieces;
         if(!qApp->getOpeningPattern())
@@ -4694,10 +4725,13 @@ void MainWindow::setWidgetsEnabled(bool enable)
 
     //enable dock widget actions
     ui->groups_DockWidget->setEnabled(enable && designStage);
+    ui->pieces_DockWidget->setEnabled(enable && pieceStage);
     ui->toolProperties_DockWidget->setEnabled(enable && draftStage);
+    ui->pieceProperties_DockWidget->setEnabled(enable && pieceStage);
     ui->layoutPages_DockWidget->setEnabled(enable && layoutStage);
     actionDockWidgetToolOptions->setEnabled(enable && designStage);
     actionDockWidgetGroups->setEnabled(enable && designStage);
+    actionDockWidgetPieces->setEnabled(enable && pieceStage);
     actionDockWidgetLayouts->setEnabled(enable && layoutStage);
 
     //Now we don't want allow user call context menu
@@ -5241,6 +5275,7 @@ void MainWindow::ReadSettings()
 
     isToolOptionsDockVisible = ui->toolProperties_DockWidget->isVisible();
     isGroupsDockVisible      = ui->groups_DockWidget->isVisible();
+    isPiecesDockVisible      = ui->pieces_DockWidget->isVisible();
     isLayoutsDockVisible     = ui->layoutPages_DockWidget->isVisible();
     isToolboxDockVisible     = ui->toolbox_DockWidget->isVisible();
 }
@@ -5650,6 +5685,13 @@ void MainWindow::AddDocks()
         isGroupsDockVisible = visible;
     });
 
+    actionDockWidgetPieces = ui->pieces_DockWidget->toggleViewAction();
+    ui->view_Menu->addAction(actionDockWidgetPieces);
+    connect(ui->pieces_DockWidget, &QDockWidget::visibilityChanged, this, [this](bool visible)
+    {
+        isPiecesDockVisible = visible;
+    });
+
     actionDockWidgetLayouts = ui->layoutPages_DockWidget->toggleViewAction();
     ui->view_Menu->addAction(actionDockWidgetLayouts);
     connect(ui->layoutPages_DockWidget, &QDockWidget::visibilityChanged, this, [this](bool visible)
@@ -5674,6 +5716,7 @@ void MainWindow::initializeDocksContain()
     setTabPosition(Qt::LeftDockWidgetArea, QTabWidget::East);
 
     initPropertyEditor();
+    initPiecePropertyEditor();
 
     qCDebug(vMainWindow, "Initialize Groups manager.");
     groupsWidget = new GroupsWidget(pattern, doc, this);
@@ -5681,11 +5724,30 @@ void MainWindow::initializeDocksContain()
     connect(doc, &VAbstractPattern::updateGroups, this, &MainWindow::updateGroups);
 
     patternPiecesWidget = new PiecesWidget(pattern, doc, this);
+    ui->pieces_DockWidget->setWidget(patternPiecesWidget);
+    connect(m_pieceProperties, &VPieceOptionsPropertyBrowser::pieceOptionsChanged,
+            patternPiecesWidget, &PiecesWidget::updateList);
     connect(doc, &VPattern::FullUpdateFromFile, patternPiecesWidget, &PiecesWidget::updateList);
     connect(doc, &VPattern::UpdateInLayoutList, patternPiecesWidget, &PiecesWidget::togglePiece);
     connect(doc, &VPattern::showPiece, patternPiecesWidget, &PiecesWidget::selectPiece);
     connect(patternPiecesWidget, &PiecesWidget::Highlight, pieceScene, &VMainGraphicsScene::HighlightItem);
-    patternPiecesWidget->setVisible(false);
+    connect(patternPiecesWidget, &PiecesWidget::pieceSelected, this, [this](quint32 id)
+    {
+        PatternPieceTool *tool = qobject_cast<PatternPieceTool *>(VAbstractPattern::getTool(id));
+        if (tool && m_pieceProperties)
+        {
+            m_pieceProperties->itemClicked(tool);
+        }
+    });
+    connect(ui->view, &VMainGraphicsView::itemClicked, patternPiecesWidget, &PiecesWidget::clearNodeHighlight);
+
+    ui->groups_DockWidget->setEnabled(false);
+    ui->pieces_DockWidget->setEnabled(false);
+    ui->toolProperties_DockWidget->setEnabled(false);
+    ui->pieceProperties_DockWidget->setEnabled(false);
+    ui->layoutPages_DockWidget->setEnabled(false);
+
+    tabifyDockWidget(ui->groups_DockWidget, ui->toolProperties_DockWidget);
 
     ui->toolbox_StackedWidget->setCurrentIndex(0);
 }

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -70,6 +70,7 @@ namespace Ui
 }
 
 class VToolOptionsPropertyBrowser;
+class VPieceOptionsPropertyBrowser;
 class MeasurementDoc;
 class QFileSystemWatcher;
 class QLabel;
@@ -328,6 +329,7 @@ private:
     bool                              isGroupsDockVisible;
     bool                              isLayoutsDockVisible;
     bool                              isToolboxDockVisible;
+    bool                              isPiecesDockVisible;
     bool                              drawMode;            /** @brief drawMode true if draft scene active. */
 
     enum { MaxRecentFiles = 5 };
@@ -343,8 +345,10 @@ private:
     QPointer<QLabel>                  gradationHeightsLabel;
     QPointer<QLabel>                  gradationSizesLabel;
     VToolOptionsPropertyBrowser      *toolProperties;
+    VPieceOptionsPropertyBrowser    *m_pieceProperties;
     GroupsWidget                     *groupsWidget;
     PiecesWidget                     *patternPiecesWidget;
+    QAction                          *actionDockWidgetPieces;
     std::shared_ptr<VLockGuard<char>> lock;
 
     QDoubleSpinBox                   *zoomScaleSpinBox;
@@ -364,6 +368,7 @@ private:
     void                              initializeToolBarVisibility();
     void                              initPenToolBar();
     void                              initPropertyEditor();
+    void                              initPiecePropertyEditor();
     void                              initBasePointComboBox();
 
     void                              updateToolBarVisibility();

--- a/src/app/seamly2d/mainwindow.ui
+++ b/src/app/seamly2d/mainwindow.ui
@@ -461,6 +461,36 @@
    </attribute>
    <widget class="QWidget" name="dockWidgetContents_10"/>
   </widget>
+  <widget class="QDockWidget" name="pieceProperties_DockWidget">
+   <property name="minimumSize">
+    <size>
+     <width>280</width>
+     <height>350</height>
+    </size>
+   </property>
+   <property name="windowTitle">
+    <string>Piece Property Editor</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>2</number>
+   </attribute>
+   <widget class="QWidget" name="piecePropertiesDockContents"/>
+  </widget>
+  <widget class="QDockWidget" name="pieces_DockWidget">
+   <property name="minimumSize">
+    <size>
+     <width>82</width>
+     <height>46</height>
+    </size>
+   </property>
+   <property name="windowTitle">
+    <string>Canvas Editor</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>2</number>
+   </attribute>
+   <widget class="QWidget" name="dockWidgetContents_3"/>
+  </widget>
   <widget class="QDockWidget" name="layoutPages_DockWidget">
    <property name="minimumSize">
     <size>

--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -178,6 +178,8 @@ const QString settingDefaultNotchLength                  = QStringLiteral("patte
 const QString settingDefaultNotchWidth                   = QStringLiteral("pattern/defaultNotchWidth");
 const QString settingDefaultNotchType                    = QStringLiteral("pattern/defaultNotchType");
 const QString settingDefaultNotchColor                   = QStringLiteral("pattern/defaultNotchColor");
+const QString settingPatternDefaultNotchTypeId           = QStringLiteral("pattern/defaultNotchTypeId");
+const QString settingPatternDefaultNotchSubType          = QStringLiteral("pattern/defaultNotchSubType");
 const QString settingSeamlineNotch                       = QStringLiteral("pattern/doubleNotch");
 const QString settingSeamAllowanceNotch                  = QStringLiteral("pattern/showSeamAllowanceNotch");
 
@@ -1700,6 +1702,30 @@ QString VCommonSettings::getDefaultNotchColor() const
 void VCommonSettings::setDefaultNotchColor(const QString &value)
 {
     setValue(settingDefaultNotchColor, value);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VCommonSettings::SetDefaultNotchType(int value)
+{
+    setValue(settingPatternDefaultNotchTypeId, value);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+int VCommonSettings::GetDefaultNotchType()
+{
+    return value(settingPatternDefaultNotchTypeId, 0).toInt();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VCommonSettings::SetDefaultNotchSubType(int value)
+{
+    setValue(settingPatternDefaultNotchSubType, value);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+int VCommonSettings::GetDefaultNotchSubType()
+{
+    return value(settingPatternDefaultNotchSubType, 0).toInt();
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vmisc/vcommonsettings.h
+++ b/src/libs/vmisc/vcommonsettings.h
@@ -380,6 +380,11 @@ public:
     QString              getDefaultNotchColor() const;
     void                 setDefaultNotchColor(const QString &value);
 
+    void                 SetDefaultNotchType(int value);
+    int                  GetDefaultNotchType();
+    void                 SetDefaultNotchSubType(int value);
+    int                  GetDefaultNotchSubType();
+
     void                 SetCSVWithHeader(bool withHeader);
     bool                 GetCSVWithHeader() const;
     bool                 GetDefCSVWithHeader() const;

--- a/src/libs/vwidgets/vmaingraphicsview.cpp
+++ b/src/libs/vwidgets/vmaingraphicsview.cpp
@@ -113,6 +113,9 @@ GraphicsViewZoom::GraphicsViewZoom(QGraphicsView* view)
 {
     m_view->viewport()->installEventFilter(this);
 
+    // Disabled because of bug QTBUG-103935
+    m_view->viewport()->setAttribute(Qt::WA_AcceptTouchEvents, false);
+
     //Enable gestures for the view widget
     m_view->viewport()->grabGesture(Qt::PinchGesture);
     m_view->viewport()->grabGesture(Qt::PanGesture);
@@ -687,6 +690,14 @@ void VMainGraphicsView::mousePressEvent(QMouseEvent *event)
                             }
                             else
                             {
+                                QGraphicsItem *parent = list.at(i)->parentItem();
+                                if (parent != nullptr
+                                    && parent->type() > QGraphicsItem::UserType
+                                    && parent->type() <= VSimpleCurve::Type)
+                                {
+                                    emit itemClicked(parent);
+                                    break;
+                                }
                                 emit itemClicked(nullptr);
                             }
                         }

--- a/src/libs/vwidgets/vscenepoint.cpp
+++ b/src/libs/vwidgets/vscenepoint.cpp
@@ -70,6 +70,7 @@ VScenePoint::VScenePoint(const QColor &lineColor, QGraphicsItem *parent)
     , m_pointColor(QColor(correctColor(this,lineColor)))
     , m_onlyPoint(false)
     , m_isHovered(false)
+    , m_isHighlighted(false)
     , m_showPointName(true)
 {
     m_pointLeader->setDefaultWidth(widthHairLine);
@@ -141,6 +142,22 @@ void VScenePoint::refreshPointGeometry(const VPointF &point)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+void VScenePoint::setHighlighted(bool highlighted)
+{
+    if (m_isHighlighted != highlighted)
+    {
+        m_isHighlighted = highlighted;
+        update();
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+bool VScenePoint::isHighlighted() const
+{
+    return m_isHighlighted;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 void VScenePoint::setOnlyPoint(bool value)
 {
     m_onlyPoint = value;
@@ -206,7 +223,7 @@ void VScenePoint::refreshLeader()
 //---------------------------------------------------------------------------------------------------------------------
 void VScenePoint::setPointPen(qreal scale)
 {
-    const qreal width = scaleWidth(m_isHovered ? widthMainLine : widthHairLine, scale);
+    const qreal width = scaleWidth((m_isHovered || m_isHighlighted) ? widthMainLine : widthHairLine, scale);
 
     if (qApp->Settings()->getUseToolColor() || isOnlyPoint())
     {
@@ -240,5 +257,22 @@ void VScenePoint::setPointPen(qreal scale)
            setBrush(QBrush(correctColor(this, QColor(qApp->Settings()->getPointNameColor())),Qt::NoBrush));
         }
 
+    }
+
+    // When the point is selected (e.g. picked in the Canvas Editor tree) draw it in a
+    // distinct highlight colour so it clearly stands out on the canvas.
+    if (m_isHighlighted)
+    {
+        const QColor highlight(Qt::red);
+        const qreal selectedWidth = scaleWidth(widthMainLine * 2.0, scale);
+        setPen(QPen(highlight, selectedWidth));
+        if (!qApp->Settings()->isWireframe() && !m_onlyPoint)
+        {
+            setBrush(QBrush(highlight, Qt::SolidPattern));
+        }
+        else
+        {
+            setBrush(QBrush(highlight, Qt::NoBrush));
+        }
     }
 }

--- a/src/libs/vwidgets/vscenepoint.h
+++ b/src/libs/vwidgets/vscenepoint.h
@@ -66,14 +66,17 @@ class VScenePoint: public QGraphicsEllipseItem
 public:
     explicit                 VScenePoint(const QColor &lineColor, QGraphicsItem *parent = nullptr);
     virtual                 ~VScenePoint() = default;
-    virtual int              type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int              type() const override {return Type;}
                              enum { Type = UserType + static_cast<int>(Vis::ScenePoint)};
 
     virtual void             paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
-                                   QWidget *widget = nullptr) Q_DECL_OVERRIDE;
+                                   QWidget *widget = nullptr) override;
     virtual void             refreshPointGeometry(const VPointF &point);
 
     void                     refreshLeader();
+
+    void                     setHighlighted(bool highlighted);
+    bool                     isHighlighted() const;
 
 protected:
 
@@ -82,10 +85,11 @@ protected:
     QColor                   m_pointColor; /** @brief m_pointColor color of point. */
     bool                     m_onlyPoint;
     bool                     m_isHovered;
+    bool                     m_isHighlighted;
     bool                     m_showPointName;
 
-    virtual void             hoverEnterEvent(QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
-    virtual void             hoverLeaveEvent(QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
+    virtual void             hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
+    virtual void             hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
 
     void                     setOnlyPoint(bool value);
     bool                     isOnlyPoint() const;


### PR DESCRIPTION
## Summary

Adds two new dock widgets that are visible exclusively in **Piece mode**, giving users direct control over piece properties and a structured view of piece nodes:

### Piece Property Editor
A new right-side dock (`pieceProperties_DockWidget`) powered by the new `VPieceOptionsPropertyBrowser` class:
- Activates when a piece is clicked in the canvas; clears when the canvas background is clicked
- Shows piece **name**, **color**, **fill color**
- Shows seam allowance options: enabled toggle, built-in SA toggle, hide seam line toggle
- All edits go through the `SavePieceOptions` undo command — fully undoable

### Canvas Editor
The existing `PiecesWidget` is upgraded from a flat `QTableWidget` to a rich `QTreeWidget`:
- Each piece is a top-level, expandable node
- Child nodes list the piece's seam nodes (points, curves) with geometry info
- Clicking a node highlights the corresponding point on the canvas via `VScenePoint::setHighlighted()`
- Piece name is inline-editable directly in the tree
- Right-click context menu lets users set the default notch type and sub-type

### Supporting changes
- `VMainGraphicsView::mousePressEvent`: walks parent items on click so child graphics items correctly propagate selection to their parent piece
- `VScenePoint`: new `setHighlighted()` / `isHighlighted()` API draws selected nodes in a distinct colour
- `VCommonSettings`: new `GetDefaultNotchType()` / `GetDefaultNotchSubType()` (integer enum storage, separate keys from the existing string-based notch type)
- `mainwindow`: `initPiecePropertyEditor()`, dock lifecycle wired in `initializeDocksContain()`, mode-switching visibility, dock toggle action in View menu

## Test plan
- [ ] Switch to Piece mode — both new docks appear; switching back to Draft/Layout mode hides them
- [ ] Click a piece → Property Editor shows name/color/SA options; edit name → undo/redo works
- [ ] Click canvas background → Property Editor clears
- [ ] Expand a piece node in Canvas Editor → seam nodes list with geometry
- [ ] Click a node in Canvas Editor → corresponding point highlights on canvas
- [ ] Inline-rename a piece in Canvas Editor → name updates everywhere
- [ ] Right-click piece in Canvas Editor → context menu shows notch options
- [ ] View menu → new "Canvas Editor" toggle action shows/hides the dock