### PR TITLE
fix: second arc combo not validated in Intersect Arcs dialog issue-#1617

### DIFF
--- a/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
+++ b/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
@@ -1744,11 +1744,37 @@ void VToolOptionsPropertyBrowser::changeDataToolPointOfIntersectionArcs(VPE::VPr
             break;
         }
         case 47: // AttrFirstArc
-            tool->SetFirstArcId(value.toInt());
+        {
+            const quint32 arcId = value.toUInt();
+            if (arcId == tool->GetSecondArcId())
+            {
+                // Both arcs can not be the same: restore the previous selection
+                const qint32 index = VPE::VObjectProperty::indexOfObject(getObjectList(tool, GOType::Arc),
+                                                                         tool->FirstArcName());
+                idToProperty[AttrFirstArc]->setValue(index);
+            }
+            else
+            {
+                tool->SetFirstArcId(arcId);
+            }
             break;
+        }
         case 48: // AttrSecondArc
-            tool->SetSecondArcId(value.toInt());
+        {
+            const quint32 arcId = value.toUInt();
+            if (arcId == tool->GetFirstArcId())
+            {
+                // Both arcs can not be the same: restore the previous selection
+                const qint32 index = VPE::VObjectProperty::indexOfObject(getObjectList(tool, GOType::Arc),
+                                                                         tool->SecondArcName());
+                idToProperty[AttrSecondArc]->setValue(index);
+            }
+            else
+            {
+                tool->SetSecondArcId(arcId);
+            }
             break;
+        }
         default:
             qWarning() << "Unknown property type. id = "<<id;
             break;

--- a/src/libs/vpropertyexplorer/plugins/vobjectproperty.cpp
+++ b/src/libs/vpropertyexplorer/plugins/vobjectproperty.cpp
@@ -103,6 +103,21 @@ QVariant VPE::VObjectProperty::getEditorData(const QWidget *editor) const
     return QVariant(0);
 }
 
+//! Sets the data in the widget
+bool VPE::VObjectProperty::setEditorData(QWidget *editor)
+{
+    QComboBox *objEditor = qobject_cast<QComboBox*>(editor);
+    if (objEditor)
+    {
+        objEditor->blockSignals(true);
+        objEditor->setCurrentIndex(VProperty::d_ptr->VariantValue.toInt());
+        objEditor->blockSignals(false);
+        return true;
+    }
+
+    return false;
+}
+
 //! Sets the objects list
 // cppcheck-suppress unusedFunction
 void VPE::VObjectProperty::setObjectsList(const QMap<QString, quint32> &objects)

--- a/src/libs/vpropertyexplorer/plugins/vobjectproperty.h
+++ b/src/libs/vpropertyexplorer/plugins/vobjectproperty.h
@@ -70,6 +70,9 @@ public:
     //! Gets the data from the widget
     virtual QVariant       getEditorData(const QWidget* editor) const override;
 
+    //! Sets the data in the widget
+    virtual bool           setEditorData(QWidget* editor) override;
+
     //! Sets the objects list
     void                   setObjectsList(const QMap<QString, quint32> &objects);
 

--- a/src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp
@@ -88,7 +88,7 @@ DialogPointOfIntersectionArcs::DialogPointOfIntersectionArcs(const VContainer *d
 
     connect(ui->lineEditNamePoint, &QLineEdit::textChanged,  this, &DialogPointOfIntersectionArcs::NamePointChanged);
     connect(ui->comboBoxArc1,      &QComboBox::currentTextChanged, this, &DialogPointOfIntersectionArcs::ArcChanged);
-    connect(ui->comboBoxArc1,      &QComboBox::currentTextChanged, this, &DialogPointOfIntersectionArcs::ArcChanged);
+    connect(ui->comboBoxArc2,      &QComboBox::currentTextChanged, this, &DialogPointOfIntersectionArcs::ArcChanged);
 
     vis = new VisToolPointOfIntersectionArcs(data);
 }


### PR DESCRIPTION
The Options dialog for the Intersect Arcs tool only validated the first arc combo box. Both connect calls pointed to comboBoxArc1, so changing Arc 2 never ran the ArcChanged check and the dialog let you pick the same arc twice without any warning.

This PR points the second connect to comboBoxArc2 so both combos run the validation, like the other dual input dialogs do.

