### PR TITLE
Fix: Improve the notch context menus

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -8119,10 +8119,6 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
         <translation>Duplikát</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Zářez</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation>TNotch</translation>
     </message>
@@ -8337,6 +8333,26 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation>Vyberte objekty hlavní cesty ve směru hodinových ručiček. Pomocí klávesy &lt;b&gt;SHIFT&lt;/b&gt; obraťte směr křivky nebo klávesou &lt;b&gt;CTRL&lt;/b&gt; zachovejte směr křivky.</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Zobrazit nástřih střihové čáry</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Zobrazit nástřih švové čáry</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Nastavit jako výchozí nástřih</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Upravit nástřih</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Odstranit nástřih</translation>
     </message>
 </context>
 <context>
@@ -9039,6 +9055,38 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
     <message>
         <source> per file</source>
         <translation> na soubor</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Vzhled</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Systém</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10091,6 +10139,46 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
         <source>Positive Sign</source>
         <translation>Pozitivní signál</translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation>Vítejte</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Vzhled</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation>Míry</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Systém</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10241,6 +10329,34 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
         <source>Positive Sign</source>
         <translation>Pozitivní signál</translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Systém</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10339,6 +10455,34 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Pozitivní signál</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Systém</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12752,16 +12896,8 @@ SeamlyME jako obvykle.
         <translation>Druhá hrana, pravý úhel</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Zářez</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation>Typ</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Žádný</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12814,6 +12950,26 @@ SeamlyME jako obvykle.
     <message>
         <source>Delete</source>
         <translation>Smazat</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Zobrazit nástřih střihové čáry</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Zobrazit nástřih švové čáry</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Nastavit jako výchozí nástřih</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Upravit nástřih</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Odstranit nástřih</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -8104,10 +8104,6 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <translation>Duplizieren</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Markierung</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation>TMarkierung</translation>
     </message>
@@ -8322,6 +8318,26 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation>Hauptpfad Objekte im Uhrzeigersinn auswählen, mit &lt;b&gt;SHIFT&lt;/b&gt; Kurvenrichtung umkehren, oder &lt;b&gt;Strg&lt;/b&gt; um Kurvenrichtung beizubehalten.</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Cutline-Knipse anzeigen</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Nahtknipse anzeigen</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Als Standardknipse festlegen</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Knipse bearbeiten</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Knipse entfernen</translation>
     </message>
 </context>
 <context>
@@ -9025,6 +9041,38 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     <message>
         <source> per file</source>
         <translation>pro Datei</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Aussehen</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10077,6 +10125,46 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <source>Positive Sign</source>
         <translation>Positives Vorzeichen</translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation>Willkommen</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Aussehen</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation>Maße</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10227,6 +10315,34 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <source>Positive Sign</source>
         <translation>Positives Vorzeichen</translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10325,6 +10441,34 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     <message>
         <source>Positive Sign</source>
         <translation>Positives Vorzeichen</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12741,16 +12885,8 @@ wie gewohnt in SeamlyME laden können.
         <translation>Zweite Kante rechter Winkel</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Markierung</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation>Typ</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Keine</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12803,6 +12939,26 @@ wie gewohnt in SeamlyME laden können.
     <message>
         <source>Delete</source>
         <translation>Löschen</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Cutline-Knipse anzeigen</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Nahtknipse anzeigen</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Als Standardknipse festlegen</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Knipse bearbeiten</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Knipse entfernen</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -8123,10 +8123,6 @@ Press enter to temporarily add it to the list.</source>
         <translation>Διπλότυπο</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Εγκοπή</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation>TNotch</translation>
     </message>
@@ -8341,6 +8337,26 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation>Επιλέξτε αντικείμενα κύριας διαδρομής δεξιόστροφα, χρησιμοποιήστε το &lt;b&gt;SHIFT&lt;/b&gt; για να αντιστρέψετε την κατεύθυνση της καμπύλης ή το &lt;b&gt;CTRL&lt;/b&gt; για να διατηρήσετε την κατεύθυνση της καμπύλης.</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Εμφάνιση εγκοπής γραμμής κοπής</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Εμφάνιση εγκοπής γραμμής ραφής</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Ορισμός ως προεπιλεγμένη εγκοπή</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Επεξεργασία εγκοπής</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Κατάργηση εγκοπής</translation>
     </message>
 </context>
 <context>
@@ -9043,6 +9059,38 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source> per file</source>
         <translation> ανά αρχείο</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Εμφάνιση</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Σύστημα</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10095,6 +10143,46 @@ Press enter to temporarily add it to the list.</source>
         <source>Positive Sign</source>
         <translation>Θετικό Πρόσημο</translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation>Καλώς ήρθατε</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Εμφάνιση</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation>Μετρήσεις</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Σύστημα</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10245,6 +10333,34 @@ Press enter to temporarily add it to the list.</source>
         <source>Positive Sign</source>
         <translation>Θετικό Πρόσημο</translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Σύστημα</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10343,6 +10459,34 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Positive Sign</source>
         <translation>Θετικό Πρόσημο</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Σύστημα</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12756,16 +12900,8 @@ load in SeamlyME as usual.
         <translation>Δεύτερη ακμή ορθή γωνία</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Εγκοπή</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation>Τύπος</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Κανένα</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12818,6 +12954,26 @@ load in SeamlyME as usual.
     <message>
         <source>Delete</source>
         <translation>Διαγραφή</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Εμφάνιση εγκοπής γραμμής κοπής</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Εμφάνιση εγκοπής γραμμής ραφής</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Ορισμός ως προεπιλεγμένη εγκοπή</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Επεξεργασία εγκοπής</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Κατάργηση εγκοπής</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -8089,10 +8089,6 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation type="unfinished">Notch</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8306,6 +8302,26 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9008,6 +9024,38 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source> per file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10061,6 +10109,46 @@ Press enter to temporarily add it to the list.</source>
         <source>Positive Sign</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation type="unfinished">Measurements</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10211,6 +10299,34 @@ Press enter to temporarily add it to the list.</source>
         <source>Positive Sign</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10308,6 +10424,34 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Positive Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12715,16 +12859,8 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation type="unfinished">Notch</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation type="unfinished">None</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12777,6 +12913,26 @@ load in SeamlyME as usual.
     <message>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -8089,10 +8089,6 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation type="unfinished">Notch</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8306,6 +8302,26 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9008,6 +9024,38 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source> per file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10061,6 +10109,46 @@ Press enter to temporarily add it to the list.</source>
         <source>Positive Sign</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation type="unfinished">Measurements</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10211,6 +10299,34 @@ Press enter to temporarily add it to the list.</source>
         <source>Positive Sign</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10308,6 +10424,34 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Positive Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12715,16 +12859,8 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation type="unfinished">Notch</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation type="unfinished">None</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12777,6 +12913,26 @@ load in SeamlyME as usual.
     <message>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -8089,10 +8089,6 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation type="unfinished">Notch</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8306,6 +8302,26 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9008,6 +9024,38 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source> per file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10061,6 +10109,46 @@ Press enter to temporarily add it to the list.</source>
         <source>Positive Sign</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation type="unfinished">Measurements</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10211,6 +10299,34 @@ Press enter to temporarily add it to the list.</source>
         <source>Positive Sign</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10308,6 +10424,34 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Positive Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12715,16 +12859,8 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation type="unfinished">Notch</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation type="unfinished">None</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12777,6 +12913,26 @@ load in SeamlyME as usual.
     <message>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -8104,10 +8104,6 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Notch</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8321,6 +8317,26 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9023,6 +9039,38 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source> per file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished">System</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10076,6 +10124,46 @@ Press enter to temporarily add it to the list.</source>
         <source>Positive Sign</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation type="unfinished">Measurements</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished">System</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10226,6 +10314,34 @@ Press enter to temporarily add it to the list.</source>
         <source>Positive Sign</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished">System</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10323,6 +10439,34 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Positive Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished">System</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12730,16 +12874,8 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Notch</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation>Type</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>None</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12792,6 +12928,26 @@ load in SeamlyME as usual.
     <message>
         <source>Delete</source>
         <translation>Delete</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -8161,10 +8161,6 @@ Press enter to temporarily add it to the list.</source>
         <translation>Duplicado</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Piquete</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation>Piquete T</translation>
     </message>
@@ -8375,6 +8371,26 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation.</source>
         <translation>Presione la tecla &lt;b&gt;ENTER&lt;/b&gt; para finalizar la creación de la pieza.</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Mostrar piquete de línea de corte</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Mostrar piquete de línea de costura</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Establecer como piquete predeterminado</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Editar piquete</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Eliminar piquete</translation>
     </message>
 </context>
 <context>
@@ -9078,6 +9094,38 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source> per file</source>
         <translation> por archivo</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Apariencia</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10132,6 +10180,46 @@ actualización:</translation>
         <source>Positive Sign</source>
         <translation>Signo Positivo</translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation>Bienvenido</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Apariencia</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation>Medidas</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10282,6 +10370,34 @@ actualización:</translation>
         <source>Positive Sign</source>
         <translation>Signo Positivo</translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10380,6 +10496,34 @@ actualización:</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Signo Positivo</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12794,16 +12938,8 @@ load in SeamlyME as usual.
         <translation>Segundo arista ángulo recto</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Piquete</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation>Tipo</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Ninguno</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12856,6 +12992,26 @@ load in SeamlyME as usual.
     <message>
         <source>Delete</source>
         <translation>Eliminar</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Mostrar piquete de línea de corte</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Mostrar piquete de línea de costura</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Establecer como piquete predeterminado</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Editar piquete</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Eliminar piquete</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -8121,10 +8121,6 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
         <translation>Kopio</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Hakki</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation>THakki</translation>
     </message>
@@ -8339,6 +8335,26 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation>Valitse pääpolun objektit myötäpäivään. Käytä &lt;b&gt;SHIFT&lt;/b&gt;-näppäintä kääntääksesi käyrän suunnan tai &lt;b&gt;CTRL&lt;/b&gt;-näppäintä säilyttääksesi käyrän suunnan.</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Näytä leikkuulinjan merkki</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Näytä saumalinjan merkki</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Aseta oletusmerkiksi</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Muokkaa merkkiä</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Poista merkki</translation>
     </message>
 </context>
 <context>
@@ -9041,6 +9057,38 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
     <message>
         <source> per file</source>
         <translation> tiedostoa kohden</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Ulkoasu</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Järjestelmä</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10093,6 +10141,46 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
         <source>Positive Sign</source>
         <translation>Positiivinen merkki</translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation>Tervetuloa</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Ulkoasu</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation>Mitat</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Järjestelmä</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10243,6 +10331,34 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
         <source>Positive Sign</source>
         <translation>Positiivinen merkki</translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Järjestelmä</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10341,6 +10457,34 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
     <message>
         <source>Positive Sign</source>
         <translation>Positiivinen merkki</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Järjestelmä</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12754,16 +12898,8 @@ Haluatko tallentaa muutokset?</translation>
         <translation>Toisen reunan oikea kulma</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Hakki</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation>Tyyppi</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Ei mitään</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12816,6 +12952,26 @@ Haluatko tallentaa muutokset?</translation>
     <message>
         <source>Delete</source>
         <translation>Poista</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Näytä leikkuulinjan merkki</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Näytä saumalinjan merkki</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Aseta oletusmerkiksi</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Muokkaa merkkiä</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Poista merkki</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -8149,10 +8149,6 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
         <translation>Dupliquer</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Repère de montage</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation>Repère en T</translation>
     </message>
@@ -8363,6 +8359,26 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation>Sélectionnez les objets du chemin principal dans le sens des aiguilles d&apos;une montre. Utilisez &lt;b&gt;MAJ&lt;/b&gt; pour inverser le sens de la courbe ou &lt;b&gt;CTRL&lt;/b&gt; pour conserver le sens de la courbe.</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Cran de ligne de coupe</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Cran de ligne de couture</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Définir comme cran par défaut</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Modifier le cran</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Supprimer le cran</translation>
     </message>
 </context>
 <context>
@@ -9067,6 +9083,38 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
     <message>
         <source> per file</source>
         <translation> par fichier</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Apparence</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Système</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10121,6 +10169,46 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
         <source>Positive Sign</source>
         <translation>Signe positif</translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation>Bienvenue</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Apparence</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation>Mesures</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Système</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10272,6 +10360,34 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
         <source>Positive Sign</source>
         <translation>Signe positif</translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Système</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10370,6 +10486,34 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
     <message>
         <source>Positive Sign</source>
         <translation>Signe positif</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Système</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12782,16 +12926,8 @@ charger dans SeamlyME comme d&apos;habitude.
         <translation>Angle droit au second bord</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Repère de montage</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation>Type</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Aucun</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12844,6 +12980,26 @@ charger dans SeamlyME comme d&apos;habitude.
     <message>
         <source>Delete</source>
         <translation>Supprimer</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Cran de ligne de coupe</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Cran de ligne de couture</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Définir comme cran par défaut</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Modifier le cran</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Supprimer le cran</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -8085,10 +8085,6 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8302,6 +8298,26 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9004,6 +9020,38 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source> per file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10057,6 +10105,46 @@ Press enter to temporarily add it to the list.</source>
         <source>Positive Sign</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10207,6 +10295,34 @@ Press enter to temporarily add it to the list.</source>
         <source>Positive Sign</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10304,6 +10420,34 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Positive Sign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12708,15 +12852,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Type</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12770,6 +12906,26 @@ load in SeamlyME as usual.
     <message>
         <source>Delete</source>
         <translation type="unfinished">למחוק</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_hu_HU.ts
+++ b/share/translations/seamly2d_hu_HU.ts
@@ -8196,10 +8196,6 @@ Menti a módosításokat?</translation>
         <translation>Másodpéldány</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Bevágás</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation>TNotch</translation>
     </message>
@@ -8338,6 +8334,26 @@ Menti a módosításokat?</translation>
     <message>
         <source>Just rear</source>
         <translation>Csak hátul</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Vágásvonal-illesztőjel megjelenítése</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Varrásvonal-illesztőjel megjelenítése</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Beállítás alapértelmezett illesztőjelként</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Illesztőjel szerkesztése</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Illesztőjel eltávolítása</translation>
     </message>
 </context>
 <context>
@@ -9040,6 +9056,38 @@ Menti a módosításokat?</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Pozitív előjel</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Megjelenés</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Rendszer</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10092,6 +10140,46 @@ Menti a módosításokat?</translation>
         <source>Positive Sign</source>
         <translation>Pozitív előjel</translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation>Üdvözöljük</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Megjelenés</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation>Mérések</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Rendszer</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10242,6 +10330,34 @@ Menti a módosításokat?</translation>
         <source>Positive Sign</source>
         <translation>Pozitív előjel</translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Rendszer</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10340,6 +10456,34 @@ Menti a módosításokat?</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Pozitív előjel</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Rendszer</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12752,16 +12896,8 @@ Menti a módosításokat?</translation>
         <translation>A második él derékszöge</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Bevágás</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation>Típus</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Nincs</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12814,6 +12950,26 @@ Menti a módosításokat?</translation>
     <message>
         <source>Delete</source>
         <translation>Törlés</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Vágásvonal-illesztőjel megjelenítése</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Varrásvonal-illesztőjel megjelenítése</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Beállítás alapértelmezett illesztőjelként</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Illesztőjel szerkesztése</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Illesztőjel eltávolítása</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -8121,10 +8121,6 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
         <translation>Duplikat</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Takik</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation>Takik</translation>
     </message>
@@ -8339,6 +8335,26 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation>Pilih objek jalur utama searah jarum jam, Gunakan &lt;b&gt;SHIFT&lt;/b&gt; untuk membalikkan arah lengkung, atau &lt;b&gt;CTRL&lt;/b&gt; untuk mempertahankan arah lengkung.</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Tampilkan Takikan Garis Potong</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Tampilkan Takikan Garis Kampuh</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Jadikan Takikan Standar</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Ubah Takikan</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Hapus Takikan</translation>
     </message>
 </context>
 <context>
@@ -9041,6 +9057,38 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
     <message>
         <source> per file</source>
         <translation>per berkas</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Penampilan</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10093,6 +10141,46 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
         <source>Positive Sign</source>
         <translation>Tanda positif</translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation>Selamat datang</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Penampilan</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation>pengukuran</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10243,6 +10331,34 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
         <source>Positive Sign</source>
         <translation>Tanda positif</translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10341,6 +10457,34 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Tanda positif</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12754,16 +12898,8 @@ unggah ke SeamlyME seperti biasa.
         <translation>Sudut siku-siku tepi kedua</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Takik</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation>Jenis</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Tidak ada</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12816,6 +12952,26 @@ unggah ke SeamlyME seperti biasa.
     <message>
         <source>Delete</source>
         <translation>hapus</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Tampilkan Takikan Garis Potong</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Tampilkan Takikan Garis Kampuh</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Jadikan Takikan Standar</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Ubah Takikan</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Hapus Takikan</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -8109,10 +8109,6 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
         <translation>Duplicato</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Tacca</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation>Notch a T</translation>
     </message>
@@ -8327,6 +8323,26 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation>Selezionare gli oggetti del percorso principale in senso orario, Utilizzare &lt;b&gt;SHIFT&lt;/b&gt; per invertire la direzione della curva, oppure &lt;b&gt;CTRL&lt;/b&gt; per mantenere la direzione della curva.</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Mostra tacca della linea di taglio</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Mostra tacca della linea di cucitura</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Imposta come tacca predefinita</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Modifica tacca</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Rimuovi tacca</translation>
     </message>
 </context>
 <context>
@@ -9029,6 +9045,38 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
     <message>
         <source> per file</source>
         <translation> per file</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Aspetto</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10081,6 +10129,46 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
         <source>Positive Sign</source>
         <translation>Segno positivo</translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Aspetto</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation>Misure</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10231,6 +10319,34 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
         <source>Positive Sign</source>
         <translation>Segno positivo</translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10329,6 +10445,34 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Segno positivo</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12742,16 +12886,8 @@ caricare in SeamlyME come di consueto.
         <translation>Secondo bordo angolo retto</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Tacca</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation>Tipo</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Nessuno</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12804,6 +12940,26 @@ caricare in SeamlyME come di consueto.
     <message>
         <source>Delete</source>
         <translation>Eliminare</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Mostra tacca della linea di taglio</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Mostra tacca della linea di cucitura</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Imposta come tacca predefinita</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Modifica tacca</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Rimuovi tacca</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -8104,10 +8104,6 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
         <translation>Dubbel</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Pasmarkering</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation>T Pasmarkering</translation>
     </message>
@@ -8322,6 +8318,26 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation>Selecteer het pad van objecten met de klok mee, Gebruik &lt;b&gt;SHIFT&lt;/b&gt; om de richting van krommes om te draaien, of &lt;b&gt;Ctrl&lt;/b&gt; om de richting te bewaren.</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Kniplynkeep tonen</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Naadlynkeep tonen</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Als standaardkeep instellen</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Keep bewerken</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Keep verwijderen</translation>
     </message>
 </context>
 <context>
@@ -9024,6 +9040,38 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
     <message>
         <source> per file</source>
         <translation> per bestand</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Voorkomen</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Systeem</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10076,6 +10124,46 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
         <source>Positive Sign</source>
         <translation>Positief Teken</translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation>Welkom</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Voorkomen</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation>Maten</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Systeem</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10226,6 +10314,34 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
         <source>Positive Sign</source>
         <translation>Positief Teken</translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Systeem</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10324,6 +10440,34 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Positief Teken</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Systeem</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12736,16 +12880,8 @@ load in SeamlyME as usual.
         <translation>Tweede rand rechte hoek</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Inkeping</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation>Type</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Geen</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12798,6 +12934,26 @@ load in SeamlyME as usual.
     <message>
         <source>Delete</source>
         <translation>Verwijderen</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Kniplynkeep tonen</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Naadlynkeep tonen</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Als standaardkeep instellen</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Keep bewerken</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Keep verwijderen</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_pl_PL.ts
+++ b/share/translations/seamly2d_pl_PL.ts
@@ -8197,10 +8197,6 @@ Czy chcesz zapisać zmiany?</translation>
         <translation>Duplikat</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Wycięcie</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation>Wycięcie T</translation>
     </message>
@@ -8339,6 +8335,26 @@ Czy chcesz zapisać zmiany?</translation>
     <message>
         <source>Just rear</source>
         <translation>Tuż z tyłu</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Pokaż nacięcie linii cięcia</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Pokaż nacięcie linii szwu></translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Ustaw jako nacięcie domyślne</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Edytuj nacięcie></translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Usuń nacięcie</translation>
     </message>
 </context>
 <context>
@@ -9041,6 +9057,38 @@ Czy chcesz zapisać zmiany?</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Znak pozytywny</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Wygląd</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10093,6 +10141,46 @@ Czy chcesz zapisać zmiany?</translation>
         <source>Positive Sign</source>
         <translation>Znak pozytywny</translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation>Witamy</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Wygląd</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation>Pomiary</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10243,6 +10331,34 @@ Czy chcesz zapisać zmiany?</translation>
         <source>Positive Sign</source>
         <translation>Znak pozytywny</translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10341,6 +10457,34 @@ Czy chcesz zapisać zmiany?</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Znak pozytywny</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12753,16 +12897,8 @@ Czy chcesz zapisać zmiany?</translation>
         <translation>Druga krawędź pod kątem prostym</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Wycięcie</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation>Typ</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Brak</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12815,6 +12951,26 @@ Czy chcesz zapisać zmiany?</translation>
     <message>
         <source>Delete</source>
         <translation>Usuń</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Pokaż nacięcie linii cięcia</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Pokaż nacięcie linii szwu</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>"Ustaw jako nacięcie domyślne></translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Edytuj nacięcie</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Usuń nacięcie</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -8108,10 +8108,6 @@ Prima enter para o adicionar temporariamente à lista.</translation>
         <translation>Duplicado</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Entalhe</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation>Entalhe</translation>
     </message>
@@ -8327,6 +8323,26 @@ Prima enter para o adicionar temporariamente à lista.</translation>
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation>Selecionar os objectos da trajetória principal no sentido dos ponteiros do relógio, Utilizar &lt;b&gt;SHIFT&lt;/b&gt; para inverter a direção da curva, ou &lt;b&gt;CTRL&lt;/b&gt; para manter a direção da curva.</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Mostrar pique da linha de corte</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Mostrar pique da linha de costura</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Definir como pique padrão</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Editar pique</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Remover pique</translation>
     </message>
 </context>
 <context>
@@ -9029,6 +9045,38 @@ Prima enter para o adicionar temporariamente à lista.</translation>
     <message>
         <source> per file</source>
         <translation> Por arquivo</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Aparância</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10081,6 +10129,46 @@ Prima enter para o adicionar temporariamente à lista.</translation>
         <source>Positive Sign</source>
         <translation>Sinal Positivo</translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation>Bem-vindo</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Aparância</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation>Medidas</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10231,6 +10319,34 @@ Prima enter para o adicionar temporariamente à lista.</translation>
         <source>Positive Sign</source>
         <translation>Sinal Positivo</translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10329,6 +10445,34 @@ Prima enter para o adicionar temporariamente à lista.</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Sinal Positivo</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12742,16 +12886,8 @@ carregar no SeamlyME como de costume.
         <translation>Segunda aresta ângulo reto</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Entalhe</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation>Tipo</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Nenhum</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12804,6 +12940,26 @@ carregar no SeamlyME como de costume.
     <message>
         <source>Delete</source>
         <translation>Excluir</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Mostrar pique da linha de corte</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Mostrar pique da linha de costura</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Definir como pique padrão</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Editar pique</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Remover pique</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -8123,10 +8123,6 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
         <translation>Duplicat</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Cresătură</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation>TNotch</translation>
     </message>
@@ -8341,6 +8337,26 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation>Selectați obiectele principale ale căii în sensul acelor de ceasornic. Folosiți &lt;b&gt;SHIFT&lt;/b&gt; pentru a inversa direcția curbei sau &lt;b&gt;CTRL&lt;/b&gt; pentru a păstra direcția curbei.</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Arată crestătura liniei de tăiere</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Arată crestătura liniei de coasere</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Setează ca și crestătură implicită</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Ediztează crestătura</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Elimină crestătura</translation>
     </message>
 </context>
 <context>
@@ -9043,6 +9059,38 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
     <message>
         <source> per file</source>
         <translation> pe fișier</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Aspect</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10095,6 +10143,46 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
         <source>Positive Sign</source>
         <translation>Semn Pozitiv</translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation>Bun venit</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Aspect</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation>Măsurători</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10245,6 +10333,34 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
         <source>Positive Sign</source>
         <translation>Semn Pozitiv</translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10343,6 +10459,34 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Semn Pozitiv</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12755,16 +12899,8 @@ load in SeamlyME as usual.
         <translation>Unghi drept la a doua muchie</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Cresătură</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation>Tip</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Niciunul</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12817,6 +12953,26 @@ load in SeamlyME as usual.
     <message>
         <source>Delete</source>
         <translation>Șterge</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Arată crestătura liniei de tăiere></translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Arată crestătura liniei de coasere</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Setează ca și crestătură implicită</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Ediztează crestătura</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Elimină crestătura</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -971,11 +971,11 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Error</source>
-        <translation type="unfinished">Ошибка</translation>
+        <translation>Ошибка</translation>
     </message>
     <message>
         <source>Length can&apos;t be negative</source>
-        <translation type="unfinished">Длина не может быть отрицательной</translation>
+        <translation>Длина не может быть отрицательной</translation>
     </message>
 </context>
 <context>
@@ -8127,10 +8127,6 @@ Press enter to temporarily add it to the list.</source>
         <translation>Дубликат</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Надсечка</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation>Т-Надсечка</translation>
     </message>
@@ -8345,6 +8341,26 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation>Выберите объекты основного контура по часовой стрелке. Используйте &lt;b&gt;SHIFT&lt;/b&gt;, чтобы изменить направление кривой, или &lt;b&gt;CTRL&lt;/b&gt;, чтобы сохранить направление кривой. Нажмите &lt;b&gt;ENTER&lt;/b&gt;, чтобы завершить создание детали.</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Показать надсечку линии раскроя</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Показать надсечку линии шва</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Сделать надсечкой по умолчанию</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Редактировать надсечку</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Удалить надсечку</translation>
     </message>
 </context>
 <context>
@@ -9047,6 +9063,38 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source> per file</source>
         <translation> за файл</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Вид</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Система</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10100,6 +10148,46 @@ Press enter to temporarily add it to the list.</source>
         <source>Positive Sign</source>
         <translation>Положительный Знак</translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation>Добро пожаловать</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Вид</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation>Мерки</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Система</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10250,6 +10338,34 @@ Press enter to temporarily add it to the list.</source>
         <source>Positive Sign</source>
         <translation>Положительный Знак</translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Система</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10348,6 +10464,34 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Positive Sign</source>
         <translation>Положительный Знак</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Система</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12761,16 +12905,8 @@ load in SeamlyME as usual.
         <translation>Второй край, прямой угол</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Надсечка</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation>Тип</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Нет</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12823,6 +12959,26 @@ load in SeamlyME as usual.
     <message>
         <source>Delete</source>
         <translation>Удалить</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Показать надсечку линии раскроя</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Показать надсечку линии шва</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Сделать надсечкой по умолчанию</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Редактировать надсечку</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Удалить надсечку</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -8121,10 +8121,6 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
         <translation>Çoğalt</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Çentik</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation>T Çentik</translation>
     </message>
@@ -8339,6 +8335,26 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation>Ana yol nesnelerini saat yönünde seçin. Eğri yönünü tersine çevirmek için &lt;b&gt;SHIFT&lt;/b&gt;&apos;i veya eğri yönünü korumak için &lt;b&gt;CTRL&lt;/b&gt;&apos;yi kullanın.</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Kesim Çizgisi Çentiğini Göster</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Dikiş Çizgisi Çentiğini Göster</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Varsayılan Çentik Yap</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Çentiği Düzenle</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Çentiği Kaldır</translation>
     </message>
 </context>
 <context>
@@ -9041,6 +9057,38 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
     <message>
         <source> per file</source>
         <translation> dosya başına</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Görünüm</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10093,6 +10141,46 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
         <source>Positive Sign</source>
         <translation>Olumlu Işaret</translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation>Hoş Geldiniz</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Görünüm</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation>Ölçümler</translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10243,6 +10331,34 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
         <source>Positive Sign</source>
         <translation>Olumlu Işaret</translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10341,6 +10457,34 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
     <message>
         <source>Positive Sign</source>
         <translation>Olumlu Işaret</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12753,16 +12897,8 @@ load in SeamlyME as usual.
         <translation>İkinci kenar dik açı</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Çentik</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation>Tür</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Hiçbiri</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12815,6 +12951,26 @@ load in SeamlyME as usual.
     <message>
         <source>Delete</source>
         <translation>Sil</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Kesim Çizgisi Çentiğini Göster</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Dikiş Çizgisi Çentiğini Göster</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Varsayılan Çentik Yap</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Çentiği Düzenle</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Çentiği Kaldır</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -8122,10 +8122,6 @@ Press enter to temporarily add it to the list.</source>
         <translation>Διπλότυπο</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Надсічка</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation>TNotch</translation>
     </message>
@@ -8340,6 +8336,26 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation>Επιλέξτε αντικείμενα κύριας διαδρομής δεξιόστροφα, χρησιμοποιήστε το &lt;b&gt;SHIFT&lt;/b&gt; για να αντιστρέψετε την κατεύθυνση της καμπύλης ή το &lt;b&gt;CTRL&lt;/b&gt; για να διατηρήσετε την κατεύθυνση της καμπύλης.</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Показати надсічку лінії розкрою</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Показати надсічку лінії шва</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Зробити надсічкою за замовчуванням</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Редагувати надсічку</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Вилучити надсічку</translation>
     </message>
 </context>
 <context>
@@ -9042,6 +9058,38 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source> per file</source>
         <translation> за файл</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Εμφάνιση</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Σύστημα</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10094,6 +10142,46 @@ Press enter to temporarily add it to the list.</source>
         <source>Positive Sign</source>
         <translation>Θετικό Πρόσημο</translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation>Καλώς ήρθατε</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Εμφάνιση</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Σύστημα</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10244,6 +10332,34 @@ Press enter to temporarily add it to the list.</source>
         <source>Positive Sign</source>
         <translation>Θετικό Πρόσημο</translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Σύστημα</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10342,6 +10458,34 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Positive Sign</source>
         <translation>Θετικό Πρόσημο</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>Σύστημα</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12754,16 +12898,8 @@ load in SeamlyME as usual.
         <translation>Δεύτερη ακμή ορθή γωνία</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>Надсічка</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation>Συμβουλή</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Κανένα</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12816,6 +12952,26 @@ load in SeamlyME as usual.
     <message>
         <source>Delete</source>
         <translation>Видалити</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>Показати надсічку лінії розкрою</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>Показати надсічку лінії шва</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>Зробити надсічкою за замовчуванням</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>Редагувати надсічку</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>Вилучити надсічку</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -8121,10 +8121,6 @@ Press enter to temporarily add it to the list.</source>
         <translation>复制</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>缺口</translation>
-    </message>
-    <message>
         <source>TNotch</source>
         <translation>T缺口</translation>
     </message>
@@ -8339,6 +8335,26 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction.</source>
         <translation>顺时针选择主路径对象，使用&lt;b&gt;SHIFT&lt;/b&gt;反转曲线方向，或使用&lt;b&gt;CTRL&lt;/b&gt;保持曲线方向.</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>显示裁剪线剪口</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>显示缝纫线剪口</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>设为默认剪口</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>编辑剪口</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>移除剪口</translation>
     </message>
 </context>
 <context>
@@ -9041,6 +9057,38 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source> per file</source>
         <translation> 按文件</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>外貌</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>系统</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10093,6 +10141,46 @@ Press enter to temporarily add it to the list.</source>
         <source>Positive Sign</source>
         <translation>正号</translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation>欢迎</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>外貌</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Measurements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>系统</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
@@ -10243,6 +10331,34 @@ Press enter to temporarily add it to the list.</source>
         <source>Positive Sign</source>
         <translation>正号</translation>
     </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>系统</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10341,6 +10457,34 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Positive Sign</source>
         <translation>正号</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fusion Twilight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>系统</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Windows11</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12754,16 +12898,8 @@ load in SeamlyME as usual.
         <translation>第二条边直角</translation>
     </message>
     <message>
-        <source>Notch</source>
-        <translation>缺口</translation>
-    </message>
-    <message>
         <source>Type</source>
         <translation>类型</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>没有任何</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -12816,6 +12952,26 @@ load in SeamlyME as usual.
     <message>
         <source>Delete</source>
         <translation>删除</translation>
+    </message>
+    <message>
+        <source>Show Cut Line Notch</source>
+        <translation>显示裁剪线剪口</translation>
+    </message>
+    <message>
+        <source>Show Seam Line Notch</source>
+        <translation>显示缝纫线剪口</translation>
+    </message>
+    <message>
+        <source>Make Default Notch</source>
+        <translation>设为默认剪口</translation>
+    </message>
+    <message>
+        <source>Edit Notch</source>
+        <translation>编辑剪口</translation>
+    </message>
+    <message>
+        <source>Remove Notch</source>
+        <translation>移除剪口</translation>
     </message>
 </context>
 <context>

--- a/src/libs/vlayout/vabstractpiece.h
+++ b/src/libs/vlayout/vabstractpiece.h
@@ -1,53 +1,52 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vabstractpiece.h
+//  @author Douglas S Caskey
+//  @date   17 Jul, 2026
+//
+//  @copyright
+//  Copyright (C) 2017 - 2026 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
- ************************************************************************
- **
- **  @file
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   3 11, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vabstractpiece.h
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   3 11, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2016 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #ifndef VABSTRACTPIECE_H
 #define VABSTRACTPIECE_H

--- a/src/libs/vpatterndb/vpiece.cpp
+++ b/src/libs/vpatterndb/vpiece.cpp
@@ -4,7 +4,7 @@
 //  @date   17 Sep, 2023
 //
 //  @copyright
-//  Copyright (C) 2017 - 2025 Seamly, LLC
+//  Copyright (C) 2017 - 2026 Seamly, LLC
 //  https://github.com/fashionfreedom/seamly2d
 //
 //  @brief
@@ -486,12 +486,12 @@ void VPiece::setAnchors(const QVector<quint32> &anchors)
     d->m_anchors = anchors;
 }
 
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 /// @brief MissingNodes find missing nodes in piece. When we deleted object in piece and return this piece need
 ///  understand, what nodes need make invisible.
 /// @param piece changed piece.
 /// @return  list with missing nodes.
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 QVector<quint32> VPiece::MissingNodes(const VPiece &piece) const
 {
     return d->m_path.MissingNodes(piece.GetPath());
@@ -533,19 +533,19 @@ void VPiece::SetPatternPieceData(const VPieceLabelData &data)
     d->m_ppData = data;
 }
 
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 /// @brief Returns full access to the pattern piece data object
 /// @return pattern piece data object
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 VPieceLabelData &VPiece::GetPatternPieceData()
 {
     return d->m_ppData;
 }
 
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 /// @brief Returns the read only reference to the pattern piece data object
 /// @return pattern piece data object
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 const VPieceLabelData &VPiece::GetPatternPieceData() const
 {
     return d->m_ppData;
@@ -557,37 +557,37 @@ void VPiece::SetPatternInfo(const VPatternLabelData &info)
     d->m_piPatternInfo = info;
 }
 
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 /// @brief Returns full access to the pattern info geometry object
 /// @return pattern info geometry object
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 VPatternLabelData &VPiece::GetPatternInfo()
 {
     return d->m_piPatternInfo;
 }
 
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 /// @brief Returns the read only reference to the pattern info geometry object
 /// @return pattern info geometry object
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 const VPatternLabelData &VPiece::GetPatternInfo() const
 {
     return d->m_piPatternInfo;
 }
 
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 /// @brief VDetail::GetGrainlineGeometry full access to the grainline geometry object
 /// @return reference to grainline geometry object
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 VGrainlineData &VPiece::GetGrainlineGeometry()
 {
     return d->m_glGrainline;
 }
 
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 /// @brief VDetail::GetGrainlineGeometry returns the read-only reference to the grainline geometry object
 /// @return reference to grainline geometry object
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 const VGrainlineData &VPiece::GetGrainlineGeometry() const
 {
     return d->m_glGrainline;
@@ -979,7 +979,14 @@ QVector<QLineF> VPiece::createNotch(const QVector<VPieceNode> &path, int previou
     }
     else
     {
-        return createBuiltInSaNotch(path, previousSAPoint, notchSAPoint, nextSAPoint, data, notchIndex, mainPathPoints);
+        if (path.at(notchIndex).showNotch())
+        {
+            return createBuiltInSaNotch(path, previousSAPoint, notchSAPoint, nextSAPoint, data, notchIndex, mainPathPoints);
+        }
+        else
+        {
+            return QVector<QLineF>();
+        }
     }
 }
 

--- a/src/libs/vpatterndb/vpiece.h
+++ b/src/libs/vpatterndb/vpiece.h
@@ -4,7 +4,7 @@
 //  @date   17 Sep, 2023
 //
 //  @copyright
-//  Copyright (C) 2017 - 2025 Seamly, LLC
+//  Copyright (C) 2017 - 2026 Seamly, LLC
 //  https://github.com/fashionfreedom/seamly2d
 //
 //  @brief
@@ -69,6 +69,8 @@ struct NotchData
     qreal        offset {};
     int          count {};
     bool         isNotch {};
+    bool         showCutline {};
+    bool         showSeamline {};
 };
 
 class VPieceData;

--- a/src/libs/vpatterndb/vpiecenode.cpp
+++ b/src/libs/vpatterndb/vpiecenode.cpp
@@ -1,54 +1,52 @@
-/***************************************************************************
- **  @file   vpiecemode.cpp
- **  @author Douglas S Caskey
- **  @date   17 Sep, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vpiecemode.cpp
+//  @author Douglas S Caskey
+//  @date   17 Sep, 2023
+//
+//  @copyright
+//  Copyright (C) 2017 - 2026 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
-/************************************************************************
- **
- **  @file   vpiecemode.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   3 11, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2016 Valentina project
- **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vpiecemode.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   3 11, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2016 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #include "vpiecenode.h"
 #include "vpiecenode_p.h"

--- a/src/libs/vpatterndb/vpiecenode.h
+++ b/src/libs/vpatterndb/vpiecenode.h
@@ -1,10 +1,10 @@
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 //  @file   vpiecenode.h
 //  @author Douglas S Caskey
 //  @date  1 Mar, 2025
 //
 //  @copyright
-//  Copyright (C) 2017 - 2025 Seamly, LLC
+//  Copyright (C) 2017 - 2026 Seamly, LLC
 //  https://github.com/fashionfreedom/seamly2d
 //
 //  @brief
@@ -20,33 +20,33 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 //  @file
 //  @author Roman Telezhynskyi <dismine(at)gmail.com>
 //  @date   3 11, 2016
 //
 //  @brief
 //  @copyright
-//  This source code is part of the Valentine project, a pattern making
+//  This source code is part of the Valentina project, a pattern making
 //  program, whose allow create and modeling patterns of clothing.
-//  Copyright (C) 2016 Seamly2D project
-//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//  Copyright (C) 2013-2016 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
 //
-//  Seamly2D is free software: you can redistribute it and/or modify
+//  Valentina is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
 //  (at your option) any later version.
 //
-//  Seamly2D is distributed in the hope that it will be useful,
+//  Valentina is distributed in the hope that it will be useful,
 //  but WITHOUT ANY WARRANTY; without even the implied warranty of
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //  GNU General Public License for more details.
 //
 //  You should have received a copy of the GNU General Public License
 //  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 
 #ifndef VPIECENODE_H
 #define VPIECENODE_H

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
@@ -4,9 +4,7 @@
 //  @date   17 Sep, 2023
 //
 //  @copyright
-//  This source code is part of the Seamly2D project, a pattern making
-//  program to create and model patterns of clothing.
-//  Copyright (C) 2017 - 2025 Seamly, LLC
+//  Copyright (C) 2017 - 2026 Seamly, LLC
 //  https://github.com/fashionfreedom/seamly2d
 //
 //  @brief
@@ -21,7 +19,7 @@
 //  GNU General Public License for more details.
 //
 //  You should have received a copy of the GNU General Public License
-//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
 //---------------------------------------------------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -646,66 +644,75 @@ bool PatternPieceDialog::eventFilter(QObject *object, QEvent *event)
             }
             else if (keyEvent->modifiers() & Qt::ShiftModifier)
             {
-                VPieceNode rowNode = qvariant_cast<VPieceNode>(rowItem->data(Qt::UserRole));
-                NotchType notchType = rowNode.getNotchType();
+                VPieceNode rowNode        = qvariant_cast<VPieceNode>(rowItem->data(Qt::UserRole));
+                bool showCutline          = rowNode.showNotch();
+                bool showSeamline         = rowNode.showSeamlineNotch();
+                NotchType notchType       = rowNode.getNotchType();
                 NotchSubType notchSubType = rowNode.getNotchSubType();
-                int notchCount = rowNode.getNotchCount();
+                qreal notchLength         = rowNode.getNotchLength();
+                qreal notchWidth          = rowNode.getNotchWidth();
+                int notchCount            = rowNode.getNotchCount();
 
                 switch (keyEvent->key())
                 {
-                    case Qt::Key_N:
-                    {
-                        setNotch(rowItem, false, NotchType::Slit, notchSubType, notchCount);
-                        break;
-                    }
                     case Qt::Key_S:
                     {
-                        setNotch(rowItem, true, NotchType::Slit, notchSubType, notchCount);
+                        setNotch(rowItem, true, showCutline, showSeamline, NotchType::Slit,
+                                 notchSubType, notchLength, notchWidth, notchCount);
                         break;
                     }
                     case Qt::Key_T:
                     {
-                        setNotch(rowItem, true, NotchType::TNotch, notchSubType, notchCount);
+                        setNotch(rowItem,true, showCutline, showSeamline, NotchType::TNotch,
+                                 notchSubType, notchLength, notchWidth, notchCount);
                         break;
                     }
                     case Qt::Key_U:
                     {
-                        setNotch(rowItem, true, NotchType::UNotch, notchSubType, notchCount);
+                        setNotch(rowItem,true, showCutline, showSeamline, NotchType::UNotch,
+                                 notchSubType, notchLength, notchWidth, notchCount);
                         break;
                     }
                     case Qt::Key_I:
                     {
-                        setNotch(rowItem, true, NotchType::VInternal, notchSubType, notchCount);
+                        setNotch(rowItem,true, showCutline, showSeamline, NotchType::VInternal,
+                                 notchSubType, notchLength, notchWidth, notchCount);
                         break;
                     }
                     case Qt::Key_E:
                     {
-                        setNotch(rowItem, true, NotchType::VExternal, notchSubType, notchCount);
+                        setNotch(rowItem,true, showCutline, showSeamline, NotchType::VExternal,
+                                 notchSubType, notchLength, notchWidth, notchCount);
                         break;
                     }
                     case Qt::Key_C:
                     {
-                        setNotch(rowItem, true, NotchType::Castle, notchSubType, notchCount);
+                        setNotch(rowItem,true, showCutline, showSeamline, NotchType::Castle,
+                                 notchSubType, notchLength, notchWidth, notchCount);
                         break;
                     }
                     case Qt::Key_D:
                     {
-                        setNotch(rowItem, true, NotchType::Diamond, notchSubType, notchCount);
+                        setNotch(rowItem,true, showCutline, showSeamline, NotchType::Diamond,
+                                 notchSubType, notchLength, notchWidth, notchCount);
                         break;
                     }
                     case Qt::Key_F:
                     {
-                        setNotch(rowItem, true, notchType, NotchSubType::Straightforward, notchCount);
+                        setNotch(rowItem,true, showCutline, showSeamline, notchType,
+                                 NotchSubType::Straightforward, notchLength, notchWidth, notchCount);
                         break;
                     }
                     case Qt::Key_B:
                     {
-                        setNotch(rowItem, true, notchType, NotchSubType::Bisector, notchCount);
+                        setNotch(rowItem,true, showCutline, showSeamline, notchType,
+                                 NotchSubType::Bisector, notchLength, notchWidth, notchCount);
                         break;
                     }
                     case Qt::Key_X:
                     {
-                        setNotch(rowItem, true, notchType, NotchSubType::Intersection, notchCount);
+                        setNotch(rowItem,true, showCutline, showSeamline, notchType,
+                                 NotchSubType::Intersection, notchLength, notchWidth, notchCount);
                         break;
                     }
                     default:
@@ -810,27 +817,51 @@ void PatternPieceDialog::showMainPathContextMenu(const QPoint &pos)
         return;
     }
 
+    const VPiece piece = CreatePiece();
+    bool isBuiltInSA    = piece.IsSeamAllowanceBuiltIn();
+    bool isHideSeamline = piece.isHideSeamLine();
+
     QListWidgetItem *rowItem = ui->mainPath_ListWidget->item(row);
     SCASSERT(rowItem != nullptr);
     VPieceNode rowNode = qvariant_cast<VPieceNode>(rowItem->data(Qt::UserRole));
 
+    // Create a state-aware icon
+    QIcon checkIcon;
+    // Icons used when the item is checked or NOT checked
+    checkIcon.addFile("://icon/32x32/visible_off.png", QSize(), QIcon::Normal, QIcon::Off);
+    checkIcon.addFile("://icon/32x32/visible_on.png", QSize(), QIcon::Normal, QIcon::On);
+
+    // Icons used when the item IS disabled
+    checkIcon.addFile("://icon/32x32/visible_hover.png", QSize(), QIcon::Disabled, QIcon::On);
+    checkIcon.addFile("://icon/32x32/visible_hover.png", QSize(), QIcon::Disabled, QIcon::Off);
+
+
     // workaround for https://bugreports.qt.io/browse/QTBUG-97559: assign parent to QMenu
     QScopedPointer<QMenu> menu(new QMenu(ui->mainPath_ListWidget));
     NodeInfo info;
-    NotchType notchType = rowNode.getNotchType();
+    NotchType notchType       = rowNode.getNotchType();
     NotchSubType notchSubType = rowNode.getNotchSubType();
-    int notchCount = rowNode.getNotchCount();
-    bool isNotch = false;
+    qreal notchLength         = rowNode.getNotchLength();
+    qreal notchWidth          = rowNode.getNotchWidth();
+    int notchCount            = rowNode.getNotchCount();
+    bool isNotch              = rowNode.isNotch();
+    bool showCutline          = rowNode.showNotch();
+    bool showSeamline         = rowNode.showSeamlineNotch();
 
-    QAction *actionNotch     = nullptr;
-    QAction *actionNone      = nullptr;
-    QAction *actionSlit      = nullptr;
-    QAction *actionTNotch    = nullptr;
-    QAction *actionUNotch    = nullptr;
-    QAction *actionVInternal = nullptr;
-    QAction *actionVExternal = nullptr;
-    QAction *actionCastle    = nullptr;
-    QAction *actionDiamond   = nullptr;
+    QAction *actionShowCutNotch   = nullptr;
+    QAction *actionShowSeamNotch  = nullptr;
+
+    QAction *actionDefaultNotch = nullptr;
+    QAction *actionRemoveNotch  = nullptr;
+
+    QAction *actionNotch        = nullptr;
+    QAction *actionSlit         = nullptr;
+    QAction *actionTNotch       = nullptr;
+    QAction *actionUNotch       = nullptr;
+    QAction *actionVInternal    = nullptr;
+    QAction *actionVExternal    = nullptr;
+    QAction *actionCastle       = nullptr;
+    QAction *actionDiamond      = nullptr;
 
     QAction *actionStraightforward = nullptr;
     QAction *actionBisector        = nullptr;
@@ -853,13 +884,23 @@ void PatternPieceDialog::showMainPathContextMenu(const QPoint &pos)
     }
     else
     {
-        QMenu *notchMenu = menu->addMenu(tr("Notch"));
+        actionShowCutNotch = menu->addAction(checkIcon, tr("Show Cut Line Notch"));
+        actionShowCutNotch->setCheckable(true);
+        actionShowCutNotch->setChecked(showCutline && isNotch);
+        actionShowCutNotch->setEnabled(isNotch);
+
+        actionShowSeamNotch = menu->addAction(checkIcon, tr("Show Seam Line Notch"));
+        actionShowSeamNotch->setCheckable(true);
+        actionShowSeamNotch->setChecked(showSeamline && isNotch);
+        actionShowSeamNotch->setEnabled(isNotch && !isBuiltInSA && !isHideSeamline);
+
+        actionDefaultNotch = menu->addAction(tr("Make Default Notch"));
+
+        QMenu *notchMenu = menu->addMenu(tr("Edit Notch"));
         actionNotch = notchMenu->menuAction();
-        actionNotch->setCheckable(true);
-        actionNotch->setChecked(rowNode.isNotch());
+        notchMenu->setEnabled(isNotch);
 
         QMenu *notchTypeMenu = notchMenu->addMenu(tr("Type"));
-        actionNone      = notchTypeMenu->addAction( tr("None") + QStringLiteral("\tShift + N"));
         actionSlit      = notchTypeMenu->addAction(QIcon("://icon/24x24/slit_notch.png"),       tr("Slit") + QStringLiteral("\tShift + S"));
         actionTNotch    = notchTypeMenu->addAction(QIcon("://icon/24x24/t_notch.png"),          tr("TNotch") + QStringLiteral("\tShift + T"));
         actionUNotch    = notchTypeMenu->addAction(QIcon("://icon/24x24/u_notch.png"),          tr("UNotch") + QStringLiteral("\tShift + U"));
@@ -877,7 +918,13 @@ void PatternPieceDialog::showMainPathContextMenu(const QPoint &pos)
         action1Notch = notchCountMenu->addAction(QIcon(), QStringLiteral("1"));
         action2Notch = notchCountMenu->addAction(QIcon(), QStringLiteral("2"));
         action3Notch = notchCountMenu->addAction(QIcon(), QStringLiteral("3"));
-}
+
+        actionRemoveNotch = menu->addAction(tr("Remove Notch"));
+
+        QAction *separator = new QAction(this);
+        separator->setSeparator(true);
+        menu->addAction(separator);
+    }
 
     QAction *actionExcluded = menu->addAction(tr("Excluded") + QStringLiteral("\tCtrl + E"));
     actionExcluded->setCheckable(true);
@@ -902,81 +949,102 @@ void PatternPieceDialog::showMainPathContextMenu(const QPoint &pos)
     {
         excludeNode(rowItem);
     }
-    else
+    else if (selectedAction == actionShowCutNotch)
     {
-        if (selectedAction == actionNone)
-        {
-            isNotch = false;
-            notchType = NotchType::Slit;
-        }
-        else if (selectedAction == actionSlit)
-        {
-            isNotch = true;
-            notchType = NotchType::Slit;
-        }
-        else if (selectedAction == actionTNotch)
-        {
-            isNotch = true;
-            notchType = NotchType::TNotch;
-        }
-        else if (selectedAction == actionUNotch)
-        {
-            isNotch = true;
-            notchType = NotchType::UNotch;
-        }
-        else if (selectedAction == actionVInternal)
-        {
-            isNotch = true;
-            notchType = NotchType::VInternal;
-        }
-        else if (selectedAction == actionVExternal)
-        {
-            isNotch = true;
-            notchType = NotchType::VExternal;
-        }
-        else if (selectedAction == actionCastle)
-        {
-            isNotch = true;
-            notchType = NotchType::Castle;
-        }
-        else if (selectedAction == actionDiamond)
-        {
-            isNotch = true;
-            notchType = NotchType::Diamond;
-        }
-        else if (selectedAction == actionStraightforward)
-        {
-            isNotch = true;
-            notchSubType = NotchSubType::Straightforward;
-        }
-        else if (selectedAction == actionBisector)
-        {
-            isNotch = true;
-            notchSubType = NotchSubType::Bisector;
-        }
-        else if (selectedAction == actionIntersection)
-        {
-            isNotch = true;
-            notchSubType = NotchSubType::Intersection;
-        }
-        else if (selectedAction == action1Notch)
-        {
-            isNotch = true;
-            notchCount = 1;
-        }
-        else if (selectedAction == action2Notch)
-        {
-            isNotch = true;
-            notchCount = 2;
-        }
-        else if (selectedAction == action3Notch)
-        {
-            isNotch = true;
-            notchCount = 3;
-        }
-
-        setNotch(rowItem, isNotch, notchType, notchSubType, notchCount);
+        showCutline = !showCutline;
     }
+
+    else if (selectedAction == actionShowSeamNotch)
+    {
+        showSeamline = !showSeamline;
+    }
+
+    else if (selectedAction == actionDefaultNotch)
+    {
+        notchType    = stringToNotchType(qApp->Settings()->getDefaultNotchType());
+        notchSubType = NotchSubType::Straightforward;
+        notchLength  = qApp->Settings()->getDefaultNotchLength();
+        notchWidth   = qApp->Settings()->getDefaultNotchWidth();
+        notchCount   = 1;
+        isNotch      = true;
+        showCutline  = true;
+        showSeamline = true;
+    }
+
+    else if (selectedAction == actionSlit)
+    {
+        isNotch = true;
+        notchType = NotchType::Slit;
+    }
+    else if (selectedAction == actionTNotch)
+    {
+        isNotch = true;
+        notchType = NotchType::TNotch;
+    }
+    else if (selectedAction == actionUNotch)
+    {
+        isNotch = true;
+        notchType = NotchType::UNotch;
+    }
+    else if (selectedAction == actionVInternal)
+    {
+        isNotch = true;
+        notchType = NotchType::VInternal;
+    }
+    else if (selectedAction == actionVExternal)
+    {
+        isNotch = true;
+        notchType = NotchType::VExternal;
+    }
+    else if (selectedAction == actionCastle)
+    {
+        isNotch = true;
+        notchType = NotchType::Castle;
+    }
+    else if (selectedAction == actionDiamond)
+    {
+        isNotch = true;
+        notchType = NotchType::Diamond;
+    }
+    else if (selectedAction == actionStraightforward)
+    {
+        isNotch = true;
+        notchSubType = NotchSubType::Straightforward;
+    }
+    else if (selectedAction == actionBisector)
+    {
+        isNotch = true;
+        notchSubType = NotchSubType::Bisector;
+    }
+    else if (selectedAction == actionIntersection)
+    {
+        isNotch = true;
+        notchSubType = NotchSubType::Intersection;
+    }
+    else if (selectedAction == action1Notch)
+    {
+        isNotch = true;
+        notchCount = 1;
+    }
+    else if (selectedAction == action2Notch)
+    {
+        isNotch = true;
+        notchCount = 2;
+    }
+    else if (selectedAction == action3Notch)
+    {
+        isNotch = true;
+        notchCount = 3;
+    }
+    else if (selectedAction == actionRemoveNotch)
+    {
+        isNotch      = false;
+        showCutline  = true;
+        showSeamline = true;
+    }
+
+    setNotch(rowItem, isNotch, showCutline, showSeamline, notchType,
+             notchSubType, notchLength, notchWidth, notchCount);
 
     validateObjects(isMainPathValid());
     nodeListChanged();
@@ -1616,7 +1684,7 @@ void PatternPieceDialog::showSeamlineNotchChanged(int state)
         if (rowItem)
         {
             VPieceNode rowNode = qvariant_cast<VPieceNode>(rowItem->data(Qt::UserRole));
-            rowNode.setShowSeamlineNotch(state);
+            rowNode.setShowSeamlineNotch(state && !ui->builtIn_CheckBox->isChecked());
             rowItem->setData(Qt::UserRole, QVariant::fromValue(rowNode));
 
             nodeListChanged();
@@ -3687,15 +3755,20 @@ QString PatternPieceDialog::createPieceName() const
 /// @param rowItem list widget item of the selected row.
 /// @param notchType of the selected submenu item.
 //---------------------------------------------------------------------------------------------------------------------
-void PatternPieceDialog::setNotch(QListWidgetItem *rowItem, bool isNotch, NotchType notchType,
-                                  NotchSubType notchSubType, int count)
+void PatternPieceDialog::setNotch(QListWidgetItem *rowItem, bool isNotch, bool showCutline, bool showSeamline,
+                                  NotchType notchType, NotchSubType notchSubType, qreal notchLength,
+                                  qreal notchWidth, int count)
 {
     VPieceNode rowNode = qvariant_cast<VPieceNode>(rowItem->data(Qt::UserRole));
     if (rowNode.GetTypeTool() == Tool::NodePoint)
     {
         rowNode.setNotch(isNotch);
+        rowNode.setShowNotch(showCutline);
+        rowNode.setShowSeamlineNotch(showSeamline);
         rowNode.setNotchType(notchType);
         rowNode.setNotchSubType(notchSubType);
+        rowNode.setNotchLength(notchLength);
+        rowNode.setNotchWidth(notchWidth);
         rowNode.setNotchCount(count);
         NodeInfo info;
         info = getNodeInfo(rowNode, true);

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.h
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.h
@@ -4,9 +4,7 @@
 //  @date   17 Sep, 2023
 //
 //  @copyright
-//  This source code is part of the Seamly2D project, a pattern making
-//  program to create and model patterns of clothing.
-//  Copyright (C) 2017 - 2025 Seamly, LLC
+//  Copyright (C) 2017 - 2026 Seamly, LLC
 //  https://github.com/fashionfreedom/seamly2d
 //
 //  @brief
@@ -21,7 +19,7 @@
 //  GNU General Public License for more details.
 //
 //  You should have received a copy of the GNU General Public License
-//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
 //---------------------------------------------------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -291,8 +289,9 @@ private:
     void                        reverseNode(QListWidgetItem *rowItem);
     void                        duplicateNode(QListWidgetItem *rowItem);
     void                        excludeNode(QListWidgetItem *rowItem);
-    void                        setNotch(QListWidgetItem *rowItem, bool isNotch, NotchType notchType,
-                                         NotchSubType notchSubType, int notchCount);
+    void                        setNotch(QListWidgetItem *rowItem, bool isNotch, bool showCutline, bool showSeamline,
+                                         NotchType notchType, NotchSubType notchSubType, qreal notchLength,
+                                         qreal notchWidth, int notchCount);
     void                        setCurrentText(QComboBox *box, const QString &text) const;
     qreal                       getFormulaValue(QPlainTextEdit *text) const;
 };

--- a/src/libs/vtools/tools/nodeDetails/vnodepoint.cpp
+++ b/src/libs/vtools/tools/nodeDetails/vnodepoint.cpp
@@ -1,10 +1,10 @@
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 //  @file   vnodepoint.cpp
 //  @author Douglas S Caskey
 //  @date  1 Mar, 2025
 //
 //  @copyright
-//  Copyright (C) 2017 - 2025 Seamly, LLC
+//  Copyright (C) 2017 - 2026 Seamly, LLC
 //  https://github.com/fashionfreedom/seamly2d
 //
 //  @brief
@@ -20,35 +20,33 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
-//******************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
 
-//******************************************************************************
-//
+//---------------------------------------------------------------------------------------------------------------------
 //   @file   vnodepoint.cpp
 //   @author Roman Telezhynskyi <dismine(at)gmail.com>
 //   @date   November 15, 2013
 //
-//   @brief
-//   @copyright
-//   This source code is part of the Valentine project, a pattern making
-//   program, whose allow create and modeling patterns of clothing.
-//   Copyright (C) 2013-2015 Seamly2D project
-//   <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013 - 2015 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
 //
-//   Seamly2D is free software: you can redistribute it and/or modify
-//   it under the terms of the GNU General Public License as published by
-//   the Free Software Foundation, either version 3 of the License, or
-//   (at your option) any later version.
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
 //
-//   Seamly2D is distributed in the hope that it will be useful,
-//   but WITHOUT ANY WARRANTY; without even the implied warranty of
-//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//   GNU General Public License for more details.
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
 //
-//   You should have received a copy of the GNU General Public License
-//   along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
-//
-//******************************************************************************
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #include "vnodepoint.h"
 
@@ -328,13 +326,25 @@ void VNodePoint::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
     PatternPieceTool *tool = qgraphicsitem_cast<PatternPieceTool *>(parentItem());
     if (tool)
     {
+        // Create a state-aware icon
+        QIcon checkIcon;
+        // Icons used when the item is checked or NOT checked
+        checkIcon.addFile("://icon/32x32/visible_off.png", QSize(), QIcon::Normal, QIcon::Off);
+        checkIcon.addFile("://icon/32x32/visible_on.png", QSize(), QIcon::Normal, QIcon::On);
+
+        // Icons used when the item IS disabled
+        checkIcon.addFile("://icon/32x32/visible_hover.png", QSize(), QIcon::Disabled, QIcon::On);
+        checkIcon.addFile("://icon/32x32/visible_hover.png", QSize(), QIcon::Disabled, QIcon::Off);
+
         QMenu menu;
 
-        const VPiece piece = VAbstractTool::data.GetPiece(tool->getId());
-        const int index = piece.GetPath().indexOfNode(m_id);
-        VPieceNode node = piece.GetPath().at(index);
+        const VPiece piece  = VAbstractTool::data.GetPiece(tool->getId());
+        bool isBuiltInSA    = piece.IsSeamAllowanceBuiltIn();
+        bool isHideSeamline = piece.isHideSeamLine();
+        const int index     = piece.GetPath().indexOfNode(m_id);
+        VPieceNode node     = piece.GetPath().at(index);
 
-        QAction *actionShowPointName = menu.addAction(QIcon("://icon/16x16/open_eye.png"), tr("Show Point Name"));
+        QAction *actionShowPointName = menu.addAction(checkIcon, tr("Show Point Name"));
         actionShowPointName->setCheckable(true);
         actionShowPointName->setChecked(VAbstractTool::data.GeometricObject<VPointF>(m_id)->isShowPointName());
 
@@ -396,21 +406,41 @@ void VNodePoint::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
                 break;
         }
 
-        // Set default Notch values
-        NotchType notchType = node.getNotchType();
-        NotchSubType notchSubType = node.getNotchSubType();
-        int notchCount = node.getNotchCount();
-        bool isNotch = false;
+        QAction *separator = new QAction(this);
+        separator->setSeparator(true);
+        menu.addAction(separator);
 
         //Setup Notch menu
-        QAction *actionNotch     = nullptr;
-        QMenu *notchMenu = menu.addMenu(tr("Notch"));
+        // Get current Notch values
+        NotchType notchType = node.getNotchType();
+        NotchSubType notchSubType = node.getNotchSubType();
+        int notchCount    = node.getNotchCount();
+        bool isNotch      = node.isNotch();
+        bool showCutline  = node.showNotch();
+        bool showSeamline = node.showSeamlineNotch();
+        qreal notchLength = node.getNotchLength();
+        qreal notchWidth  = node.getNotchWidth();
+
+        QAction *actionShowCutNotch = menu.addAction(checkIcon, tr("Show Cut Line Notch"));
+        actionShowCutNotch->setCheckable(true);
+        actionShowCutNotch->setChecked(showCutline && isNotch);
+        actionShowCutNotch->setEnabled(isNotch);
+
+        QAction *actionShowSeamNotch = menu.addAction(checkIcon, tr("Show Seam Line Notch"));
+        actionShowSeamNotch->setCheckable(true);
+        actionShowSeamNotch->setChecked(showSeamline && isNotch);
+        actionShowSeamNotch->setEnabled(isNotch && !isBuiltInSA && !isHideSeamline);
+
+        QAction *actionDefaultNotch = menu.addAction(tr("Make Default Notch"));
+
+        QAction *actionNotch = nullptr;
+        QMenu *notchMenu = menu.addMenu(tr("Edit Notch"));
         actionNotch = notchMenu->menuAction();
-        actionNotch->setCheckable(true);
-        actionNotch->setChecked(node.isNotch());
+        notchMenu->setEnabled(isNotch);
+
+        QAction *actionRemoveNotch = menu.addAction(tr("Remove Notch"));
 
         //Setup Notch type submenu
-        QAction *actionNone      = nullptr;
         QAction *actionSlit      = nullptr;
         QAction *actionTNotch    = nullptr;
         QAction *actionUNotch    = nullptr;
@@ -419,7 +449,6 @@ void VNodePoint::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
         QAction *actionCastle    = nullptr;
         QAction *actionDiamond   = nullptr;
         QMenu *notchTypeMenu = notchMenu->addMenu(tr("Type"));
-        actionNone      = notchTypeMenu->addAction( tr("None") + QStringLiteral("\tShift + N"));
         actionSlit      = notchTypeMenu->addAction(QIcon("://icon/24x24/slit_notch.png"),       tr("Slit") + QStringLiteral("\tShift + S"));
         actionTNotch    = notchTypeMenu->addAction(QIcon("://icon/24x24/t_notch.png"),          tr("TNotch") + QStringLiteral("\tShift + T"));
         actionUNotch    = notchTypeMenu->addAction(QIcon("://icon/24x24/u_notch.png"),          tr("UNotch") + QStringLiteral("\tShift + U"));
@@ -445,6 +474,10 @@ void VNodePoint::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
         action1Notch = notchCountMenu->addAction(QIcon(), QStringLiteral("1"));
         action2Notch = notchCountMenu->addAction(QIcon(), QStringLiteral("2"));
         action3Notch = notchCountMenu->addAction(QIcon(), QStringLiteral("3"));
+
+        separator = new QAction(this);
+        separator->setSeparator(true);
+        menu.addAction(separator);
 
         //Setup Exclude node menu
         QAction *actionExcludeNode = menu.addAction(QIcon(), tr("Excluded"));
@@ -499,12 +532,29 @@ void VNodePoint::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
         }
         else
         {
-            if (selectedAction == actionNone)
+            if (selectedAction == actionShowCutNotch)
             {
-                isNotch = false;
-                notchType = NotchType::Slit;
+                showCutline = !showCutline;
             }
-            else if (selectedAction == actionSlit)
+
+            if (selectedAction == actionShowSeamNotch)
+            {
+                showSeamline = !showSeamline;
+            }
+
+            if (selectedAction == actionDefaultNotch)
+            {
+                notchType    = stringToNotchType(qApp->Settings()->getDefaultNotchType());
+                notchSubType = NotchSubType::Straightforward;
+                notchLength  = qApp->Settings()->getDefaultNotchLength();
+                notchWidth   = qApp->Settings()->getDefaultNotchWidth();
+                notchCount   = 1;
+                isNotch      = true;
+                showCutline  = true;
+                showSeamline = true;
+            }
+
+            if (selectedAction == actionSlit)
             {
                 isNotch = true;
                 notchType = NotchType::Slit;
@@ -569,17 +619,25 @@ void VNodePoint::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
                 isNotch = true;
                 notchCount = 3;
             }
+            if (selectedAction == actionRemoveNotch)
+            {
+                isNotch      = false;
+                showCutline  = true;
+                showSeamline = true;
+            }
 
             if (node.GetId() == m_id && node.GetTypeTool() == Tool::NodePoint)
             {
                 NotchData notchData;
-                notchData.isNotch = isNotch;
-                notchData.type    = notchType;
-                notchData.subType = notchSubType;
-                notchData.length  = ToPixel(node.getNotchLength(), *VDataTool::data.GetPatternUnit());
-                notchData.width   = ToPixel(node.getNotchWidth(),  *VDataTool::data.GetPatternUnit());
-                notchData.angle   = node.getNotchAngle();
-                notchData.count   = notchCount;
+                notchData.isNotch      = isNotch;
+                notchData.showCutline  = showCutline;
+                notchData.showSeamline = showSeamline;
+                notchData.type         = notchType;
+                notchData.subType      = notchSubType;
+                notchData.length       = notchLength;
+                notchData.width        = notchWidth;
+                notchData.angle        = node.getNotchAngle();
+                notchData.count        = notchCount;
 
                 emit notchChanged(m_id, notchData);
             }

--- a/src/libs/vtools/tools/pattern_piece_tool.cpp
+++ b/src/libs/vtools/tools/pattern_piece_tool.cpp
@@ -4,7 +4,7 @@
 //  @date   Dec 11, 2022
 //
 //  @copyright
-//  Copyright (C) 2017 - 2025 Seamly, LLC
+//  Copyright (C) 2017 - 2026 Seamly, LLC
 //  https://github.com/fashionfreedom/seamly2d
 //
 //  @brief
@@ -1657,6 +1657,7 @@ void PatternPieceTool::nodeAngleChanged(quint32 id, PieceNodeAngle type)
 void PatternPieceTool::notchChanged(quint32 id, NotchData notchData)
 {
     const VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
+    bool isBuiltInSA = oldPiece.IsSeamAllowanceBuiltIn();
     if (!oldPiece.isLocked())
     {
         VPiece newPiece = oldPiece;
@@ -1667,8 +1668,12 @@ void PatternPieceTool::notchChanged(quint32 id, NotchData notchData)
             if (node.GetId() == id && node.GetTypeTool() == Tool::NodePoint)
             {
                 node.setNotch(notchData.isNotch);
+                node.setShowNotch(notchData.showCutline);
+                node.setShowSeamlineNotch(notchData.showSeamline && !isBuiltInSA);
                 node.setNotchType(notchData.type);
                 node.setNotchSubType(notchData.subType);
+                node.setNotchLength(notchData.length);
+                node.setNotchWidth(notchData.width);
                 node.setNotchCount(notchData.count);
                 newPiece.GetPath()[i] = node;
 


### PR DESCRIPTION
This PR improves the creation and editing of notches in Node and Pattern Piece Dialog context menus. 

Adds the following menu items:

- Show Cut LIne Notch - toggle the view of the cut line notch
- Show Seam Line Notch - toggles the view of the seam line notch. 
- Make Deafult Notch - makes or resets a point node a notch with the default settings. 
- Remove Notch - removes the notch properties from a point node. 

Modifies:

- The "Notch" item becomes the "Edit Notch", and removes the now moot "None" type.

Fixes:
- The issue where unchecking the Show Cut Line Notch did not hide the notch if the "Built in" SA box was checked. 

Behavior:

If the node is not a notch then the checked icon display as red indicating a disabled state. Also if the SA is Built IN or the Hide Seamline are checked, the Show Seam LIne Notch displays the red disablers icon. In normal state the icons deispaly as Black for ON and Greyed Out for OFF. 

Node context menu with Hide Seam Line checked:
<img width="423" height="365" alt="image" src="https://github.com/user-attachments/assets/db91e196-26b1-4ebf-887d-3c5087c590c3" />

With Built In SA:
<img width="354" height="326" alt="image" src="https://github.com/user-attachments/assets/ef321526-4381-419c-8533-37c3ef909bab" />


Initial state in the Path context menu.. i.e. Not a notch:

<img width="779" height="378" alt="Screenshot 2026-07-17 115253" src="https://github.com/user-attachments/assets/50f241b6-6190-4910-8fe5-7cefdc9c5d6e" />

Notch just on the Cut LIne:

<img width="741" height="368" alt="image" src="https://github.com/user-attachments/assets/bde354e3-7c0a-4e6a-bdb1-49e8ac33b9f8" />


Closes issue #1619 