### PR TITLE
Qt: Upgrade from Qt 6.8 to Qt 6.11

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -62,7 +62,7 @@ git commit push issue-#155
 
 ## Create a Pull Request -- git CLI
 
-* Build & test your issue branch with Qt 6.8.3 and Qt Creator
+* Build & test your issue branch with Qt 6.11.1 and Qt Creator
 * Push your issue branch up to the github repo
 
 ```Shell

--- a/.github/README-DEVELOPER.md
+++ b/.github/README-DEVELOPER.md
@@ -6,7 +6,7 @@ Read [.github\CONTRIBUTING.md](.github\CONTRIBUTING.md) to get started on GitFlo
 
 ## Basic Software Prerequisites
 
-* [Qt 6.8.3](https://www.qt.io/download-open-source) (includes Qt, QtCreator, QtChooser, and Qt Maintenance Tool)
+* [Qt 6.11.1](https://www.qt.io/download-open-source) (includes Qt, QtCreator, QtChooser, and Qt Maintenance Tool)
 * [Visual Studio](https://visualstudio.microsoft.com/downloads/) Qt Visual Studio Tools extension - needed to build with MSVC.
 * [Git](https://git-scm.com/downloads) or [Github Desktop for Windows and MacOS](https://desktop.github.com)
 * Compiler - MSVC 2022, gcc, and g++ are included with QtCreator, and you can add or update them using the Qt Maintenance Tool (Maintenance.exe).
@@ -61,12 +61,12 @@ Read [.github\CONTRIBUTING.md](.github\CONTRIBUTING.md) to get started on GitFlo
 
 ### ... on all platforms (Linux, MacOSX, Windows)
 
-* Install Qt 6.8.3, eg via [Qt unified installer](https://www.qt.io/download-qt-installer). Create a Qt account for open source Community Edition if you don't have one.
+* Install Qt 6.11.1, eg via [Qt unified installer](https://www.qt.io/download-qt-installer). Create a Qt account for open source Community Edition if you don't have one.
   * Download & run the [Qt unified installer](https://www.qt.io/download-qt-installer).
   * Select:
     * Custom Installation
     * Qt -- Minimize your options, otherwise your download size could be in Gs
-      * Qt 6.8.3
+      * Qt 6.11.1
       * MSVC 2022
       * Qt Debug Information Files
       * Developer and Designer Tools

--- a/.github/README.md
+++ b/.github/README.md
@@ -26,7 +26,7 @@ Don't know how? Join our multi-lingual Discourse [forum](https://forum.seamly.io
 
 ### Supported platforms:
    * Windows 10 & 11 (64-bit) 
-   * macOS Monterey (12), Ventura (13), Sonoma (14), and Sequoia (15)
+   * macOS Ventura (13), Sonoma (14), Sequoia (15), Tahoe (26)
    * Most current Linux distros as Flatpak via [Flathub](https://flathub.org/apps/io.seamly.seamly2d)
    * Most current Linux distros as AppImage
 ___________________________________________________
@@ -36,7 +36,7 @@ ___________________________________________________
 | :---:          | :---:         | :---: | :---:          | :---:         |
 | [![Seamly2D-windows.zip](./img/Microsoft_logo-60x60px.png)](https://github.com/FashionFreedom/Seamly2D/releases/latest/download/Seamly2D-windows.zip) | [![Seamly2D-win-arm64.zip](./img/Microsoft_logo-60x60px.png)](https://github.com/FashionFreedom/Seamly2D/releases/latest/download/Seamly2D-win-arm64.zip) | [![Seamly2D-macos.zip](./img/MacOS_logo_60x60.png)](https://github.com/FashionFreedom/Seamly2D/releases/latest/download/Seamly2D-macos.zip) | [![Seamly2D AppImage](./img/linux-svgrepo-com-60x71.png)](https://github.com/FashionFreedom/Seamly2D/releases/latest/download/Seamly2D-x86_64.AppImage) | [![Seamly2D Flatpak](./img/flathub-badge-en.png)](https://flathub.org/apps/io.seamly.seamly2d) |
 | Intel or AMD 64bit | ARM 64bit | Apple Silicon or Intel | Intel or AMD 64bit | Intel or AMD 64bit |
-| Windows 10<br>Windows 11 | Windows 11 | macos 12 Monterey<br>macOS 13 Ventura<br>macOS 14 Sonoma<br>macOS 15 Sequoia<br>macOS Tahoe 26 | Debian 10 Buster<br>Debian 11 Bullseye<br>Debian 12 Bookworm<br>Ubuntu 22.04 Jammy<br>Ubuntu 23.04 Lunar<br>Up-to-date Arch Linux -<br>Manjaro<br>ArcoLinux<br>EndeavourOS<br>Anarchy<br>ArchLabs|Debian 10 Buster<br>Debian 11 Bullseye<br>Debian 12 Bookworm<br>Ubuntu 22.04 Jammy<br>Ubuntu 23.04 Lunar<br>Up-to-date Arch Linux -<br>Manjaro<br>ArcoLinux<br>EndeavourOS<br>Anarchy,<br>ArchLabs|
+| Windows 10<br>Windows 11 | Windows 11 | macOS 13 Ventura<br>macOS 14 Sonoma<br>macOS 15 Sequoia<br>macOS Tahoe 26 | Debian 12+ (bookworm or later)<br>Ubuntu 22.04+ (jammy or later)<br>ArchLinux<br>Manjaro | Everywhere, where flathub is supported|
 
 ___________________________________________________
 ### Community :

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
   contents: write
 
 env:
-  QT_VERSION: '6.8.3' # quotes required or YAML parser will interpret as float
+  QT_VERSION: '6.11.1' # quotes required or YAML parser will interpret as float
 
 jobs:
 
@@ -69,10 +69,7 @@ jobs:
   linux:
     if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'weblate'
     name: 'Linux: Build AppImage'
-    runs-on: ubuntu-latest
-    container:
-      image: debian/eol:bullseye  # build on the oldest supported LTS so that resulting binaries are compatible with older and newer Linux releases
-      options: --device /dev/fuse --privileged
+    runs-on: ubuntu-24.04
     needs: version
     env:
       VERSION_NUMBER: ${{ needs.version.outputs.version_number }}
@@ -82,27 +79,23 @@ jobs:
 
       - name: install appimage dependencies
         run: |
-          apt update && apt install -y libfuse2 fuse wget file
-          wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -O /usr/local/bin/linuxdeploy-x86_64.AppImage
-          chmod +x /usr/local/bin/linuxdeploy-x86_64.AppImage
-          wget -q https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage -O /usr/local/bin/linuxdeploy-plugin-qt-x86_64.AppImage
-          chmod +x /usr/local/bin/linuxdeploy-plugin-qt-x86_64.AppImage
+          sudo apt update && sudo apt install -y libfuse2t64
+          sudo wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -O /usr/local/bin/linuxdeploy-x86_64.AppImage
+          sudo chmod +x /usr/local/bin/linuxdeploy-x86_64.AppImage
+          sudo wget -q https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage -O /usr/local/bin/linuxdeploy-plugin-qt-x86_64.AppImage
+          sudo chmod +x /usr/local/bin/linuxdeploy-plugin-qt-x86_64.AppImage
 
       - name: install build dependencies
         run: |
-          apt update
+          sudo apt update
           # install poppler-utils for pdftops, gstreamer1.0-plugins-base for QtMultimedia
           # install libxerces for xml manipulation
-          # install libcups2 for print support, libxrandr2 for multimedia
-          # install python3-pip for jurplel/install-qt-action
-          apt install -y poppler-utils gstreamer1.0-plugins-base libxerces-c-dev python3-pip libcups2 libxrandr2
+          sudo apt install -y poppler-utils gstreamer1.0-plugins-base libxerces-c-dev
 
       - uses: jurplel/install-qt-action@v4
         with:
           version: ${{ env.QT_VERSION }}
           cache: true
-          install-deps: nosudo
-          setup-python: false
           modules: qtmultimedia
 
       - name: update version
@@ -132,7 +125,7 @@ jobs:
   macos:
     if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'weblate'
     name: 'macOS: Build'
-    runs-on: macos-15  # pin to macos-15 due to https://qt-project.atlassian.net/browse/QTBUG-137687
+    runs-on: macos-26
     needs: version
     env:
       VERSION_NUMBER: ${{ needs.version.outputs.version_number }}
@@ -207,11 +200,11 @@ jobs:
         include:
           - msvc-arch: x64
             qt-arch: win64_msvc2022_64
-            qmake-spec: win32-msvc
+            qmake: qmake
             release-file: Seamly2D-windows.zip
           - msvc-arch: amd64_arm64
             qt-arch: win64_msvc2022_arm64_cross_compiled
-            qmake-spec: win32-arm64-msvc
+            qmake: host-qmake
             release-file: Seamly2D-win-arm64.zip
 
     steps:
@@ -227,6 +220,7 @@ jobs:
           arch: ${{ matrix.qt-arch }}
           cache: true
           modules: qtmultimedia
+          aqtsource: git+https://github.com/miurahr/aqtinstall.git  # Remove once aqtinstall 3.4.0 is released, see https://github.com/miurahr/aqtinstall/issues/1007
 
       - name: update version
         shell: bash
@@ -235,7 +229,7 @@ jobs:
 
       - name: make seamly2d.exe and seamlyme.exe
         run: |
-          qmake Seamly2D.pro -spec ${{ matrix.qmake-spec }} -config release CONFIG+=noTests
+          ${{ matrix.qmake }} Seamly2D.pro -config release CONFIG+=noTests
           nmake
 
       - name: install NSIS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
   linux:
     if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'weblate'
     name: 'Linux: Build AppImage'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     needs: version
     env:
       VERSION_NUMBER: ${{ needs.version.outputs.version_number }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: install appimage dependencies
         run: |
-          sudo apt update && sudo apt install -y libfuse2t64
+          sudo apt update && sudo apt install -y libfuse2
           sudo wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -O /usr/local/bin/linuxdeploy-x86_64.AppImage
           sudo chmod +x /usr/local/bin/linuxdeploy-x86_64.AppImage
           sudo wget -q https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage -O /usr/local/bin/linuxdeploy-plugin-qt-x86_64.AppImage

--- a/.github/workflows/feat-ci.yml
+++ b/.github/workflows/feat-ci.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 env:
-  QT_VERSION: '6.8.3'
+  QT_VERSION: '6.11.1'
 
 jobs:
 

--- a/src/app/seamly2d/seamly2d.pro
+++ b/src/app/seamly2d/seamly2d.pro
@@ -372,5 +372,5 @@ win32-msvc{
 }
 win32-arm64-msvc{
     qtPrepareTool(WINDEPLOYQT, windeployqt)
-    QMAKE_POST_LINK += $$WINDEPLOYQT --qtpaths $$shell_path($$[QT_INSTALL_BINS]/qtpaths.bat) $$shell_path($$DESTDIR/$${TARGET}.exe)
+    QMAKE_POST_LINK += $$WINDEPLOYQT --qtpaths $$shell_path($$[QT_INSTALL_BINS]/host-qtpaths.bat) $$shell_path($$DESTDIR/$${TARGET}.exe)
 }

--- a/src/app/seamlyme/seamlyme.pro
+++ b/src/app/seamlyme/seamlyme.pro
@@ -253,5 +253,5 @@ win32-msvc{
 }
 win32-arm64-msvc{
     qtPrepareTool(WINDEPLOYQT, windeployqt)
-    QMAKE_POST_LINK += $$WINDEPLOYQT --qtpaths $$shell_path($$[QT_INSTALL_BINS]/qtpaths.bat) $$shell_path($$DESTDIR/$${TARGET}.exe)
+    QMAKE_POST_LINK += $$WINDEPLOYQT --qtpaths $$shell_path($$[QT_INSTALL_BINS]/host-qtpaths.bat) $$shell_path($$DESTDIR/$${TARGET}.exe)
 }


### PR DESCRIPTION
For linux: now needs sudo again, as we are back to ubuntu 22.04 with Qt 6.11
For windows: It temporarily uses main branch of aqt, as there is no release
of aqt that supports the new directory structure that Qt uses to publish
windows builds yet. Once 3.4.0 of aqtinstall is released, that workaround
can be removed again

The differences needed were reverse-engineered by downloading Qt 6.8 and
Qt 6.11 locally and diffing the structure and names of eg qmake vs host-qmake