### PR TITLE
refactor: replace arc combo boxes with read-only labels in Intersect …

### DIFF
--- a/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
+++ b/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
@@ -1743,38 +1743,6 @@ void VToolOptionsPropertyBrowser::changeDataToolPointOfIntersectionArcs(VPE::VPr
             setCirclesCrossPoint<VToolPointOfIntersectionArcs>(value);
             break;
         }
-        case 47: // AttrFirstArc
-        {
-            const quint32 arcId = value.toUInt();
-            if (arcId == tool->GetSecondArcId())
-            {
-                // Both arcs can not be the same: restore the previous selection
-                const qint32 index = VPE::VObjectProperty::indexOfObject(getObjectList(tool, GOType::Arc),
-                                                                         tool->FirstArcName());
-                idToProperty[AttrFirstArc]->setValue(index);
-            }
-            else
-            {
-                tool->SetFirstArcId(arcId);
-            }
-            break;
-        }
-        case 48: // AttrSecondArc
-        {
-            const quint32 arcId = value.toUInt();
-            if (arcId == tool->GetFirstArcId())
-            {
-                // Both arcs can not be the same: restore the previous selection
-                const qint32 index = VPE::VObjectProperty::indexOfObject(getObjectList(tool, GOType::Arc),
-                                                                         tool->SecondArcName());
-                idToProperty[AttrSecondArc]->setValue(index);
-            }
-            else
-            {
-                tool->SetSecondArcId(arcId);
-            }
-            break;
-        }
         default:
             qWarning() << "Unknown property type. id = "<<id;
             break;
@@ -2824,8 +2792,8 @@ void VToolOptionsPropertyBrowser::showOptionsToolPointOfIntersectionArcs(QGraphi
 
     addPropertyLabel(tr("Selection"), AttrName);
     addPropertyObjectName(tool, tr("Name:"));
-    addObjectProperty(tool, tool->FirstArcName(), tr("First arc:"), AttrFirstArc, GOType::Arc);
-    addObjectProperty(tool, tool->SecondArcName(), tr("Second arc:"), AttrSecondArc, GOType::Arc);
+    addPropertyParentPointName(tool->FirstArcName(), tr("First arc:"), AttrFirstArc);
+    addPropertyParentPointName(tool->SecondArcName(), tr("Second arc:"), AttrSecondArc);
     addPropertyCrossPoint(tool, tr("Take:"));
 }
 
@@ -3733,18 +3701,8 @@ void VToolOptionsPropertyBrowser::updateOptionsToolPointOfIntersectionArcs()
 
     idToProperty[AttrName]->setValue(tool->name());
     idToProperty[AttrCrossPoint]->setValue(static_cast<int>(tool->GetCrossCirclesPoint())-1);
-
-    {
-        const qint32 index = VPE::VObjectProperty::indexOfObject(getObjectList(tool, GOType::Arc),
-                                                                               tool->FirstArcName());
-        idToProperty[AttrFirstArc]->setValue(index);
-    }
-
-    {
-        const qint32 index = VPE::VObjectProperty::indexOfObject(getObjectList(tool, GOType::Arc),
-                                                                               tool->SecondArcName());
-        idToProperty[AttrSecondArc]->setValue(index);
-    }
+    idToProperty[AttrFirstArc]->setValue(tool->FirstArcName());
+    idToProperty[AttrSecondArc]->setValue(tool->SecondArcName());
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vpropertyexplorer/plugins/vlabelproperty.cpp
+++ b/src/libs/vpropertyexplorer/plugins/vlabelproperty.cpp
@@ -107,6 +107,19 @@ QVariant VPE::VLabelProperty::getEditorData(const QWidget *editor) const
     return QVariant(QString());
 }
 
+//! Sets the data in the widget
+bool VPE::VLabelProperty::setEditorData(QWidget *editor)
+{
+    QLabel *labelTextEditor = qobject_cast<QLabel*>(editor);
+    if (labelTextEditor)
+    {
+        labelTextEditor->setText(d_ptr->VariantValue.toString());
+        return true;
+    }
+
+    return false;
+}
+
 void VPE::VLabelProperty::setSetting(const QString &key, const QVariant &value)
 {
     if (key == QLatin1String("TypeForParent"))

--- a/src/libs/vpropertyexplorer/plugins/vlabelproperty.h
+++ b/src/libs/vpropertyexplorer/plugins/vlabelproperty.h
@@ -88,6 +88,9 @@ public:
     //! Gets the data from the widget
     virtual QVariant     getEditorData(const QWidget *editor) const override;
 
+    //! Sets the data in the widget
+    virtual bool         setEditorData(QWidget *editor) override;
+
     //! Sets the settings.
     virtual void         setSetting(const QString &key, const QVariant &value) override;
 

--- a/src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp
@@ -49,7 +49,6 @@
 
 #include "dialogpointofintersectionarcs.h"
 
-#include <QColor>
 #include <QComboBox>
 #include <QLabel>
 #include <QLineEdit>
@@ -58,6 +57,7 @@
 #include "../../visualization/visualization.h"
 #include "../../visualization/line/vistoolpointofintersectionarcs.h"
 #include "../vmisc/vabstractapplication.h"
+#include "../vpatterndb/vcontainer.h"
 #include "dialogs/tools/dialogtool.h"
 #include "ui_dialogpointofintersectionarcs.h"
 
@@ -66,6 +66,8 @@ DialogPointOfIntersectionArcs::DialogPointOfIntersectionArcs(const VContainer *d
                                                              QWidget *parent)
     : DialogTool(data, toolId, parent)
     , ui(new Ui::DialogPointOfIntersectionArcs)
+    , firstArcId(NULL_ID)
+    , secondArcId(NULL_ID)
 {
     ui->setupUi(this);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
@@ -82,13 +84,9 @@ DialogPointOfIntersectionArcs::DialogPointOfIntersectionArcs(const VContainer *d
     initializeOkCancelApply(ui);
     DialogTool::CheckState();
 
-    fillComboBoxArcs(ui->comboBoxArc1);
-    fillComboBoxArcs(ui->comboBoxArc2);
     fillComboBoxCrossCirclesPoints(ui->comboBoxResult);
 
     connect(ui->lineEditNamePoint, &QLineEdit::textChanged,  this, &DialogPointOfIntersectionArcs::NamePointChanged);
-    connect(ui->comboBoxArc1,      &QComboBox::currentTextChanged, this, &DialogPointOfIntersectionArcs::ArcChanged);
-    connect(ui->comboBoxArc2,      &QComboBox::currentTextChanged, this, &DialogPointOfIntersectionArcs::ArcChanged);
 
     vis = new VisToolPointOfIntersectionArcs(data);
 }
@@ -109,13 +107,14 @@ void DialogPointOfIntersectionArcs::SetPointName(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 quint32 DialogPointOfIntersectionArcs::GetFirstArcId() const
 {
-    return getCurrentObjectId(ui->comboBoxArc1);
+    return firstArcId;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void DialogPointOfIntersectionArcs::SetFirstArcId(const quint32 &value)
 {
-    setCurrentArcId(ui->comboBoxArc1, value);
+    firstArcId = value;
+    ui->arc1Name_Label->setText(data->GetGObject(value)->name());
 
     VisToolPointOfIntersectionArcs *point = qobject_cast<VisToolPointOfIntersectionArcs *>(vis);
     SCASSERT(point != nullptr)
@@ -125,13 +124,14 @@ void DialogPointOfIntersectionArcs::SetFirstArcId(const quint32 &value)
 //---------------------------------------------------------------------------------------------------------------------
 quint32 DialogPointOfIntersectionArcs::GetSecondArcId() const
 {
-    return getCurrentObjectId(ui->comboBoxArc2);
+    return secondArcId;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void DialogPointOfIntersectionArcs::SetSecondArcId(const quint32 &value)
 {
-    setCurrentArcId(ui->comboBoxArc2, value);
+    secondArcId = value;
+    ui->arc2Name_Label->setText(data->GetGObject(value)->name());
 
     VisToolPointOfIntersectionArcs *point = qobject_cast<VisToolPointOfIntersectionArcs *>(vis);
     SCASSERT(point != nullptr)
@@ -171,23 +171,23 @@ void DialogPointOfIntersectionArcs::ChosenObject(quint32 id, const SceneObject &
             switch (number)
             {
                 case 0:
-                    if (SetObject(id, ui->comboBoxArc1, tr("Select second an arc")))
-                    {
-                        number++;
-                        point->VisualMode(id);
-                    }
+                    firstArcId = id;
+                    ui->arc1Name_Label->setText(data->GetGObject(id)->name());
+                    number++;
+                    point->VisualMode(id);
+                    emit ToolTip(tr("Select second an arc"));
                     break;
                 case 1:
-                    if (getCurrentObjectId(ui->comboBoxArc1) != id)
+                    if (firstArcId != id)
                     {
-                        if (SetObject(id, ui->comboBoxArc2, ""))
-                        {
-                            number = 0;
-                            point->setArc2Id(id);
-                            point->RefreshGeometry();
-                            prepare = true;
-                            DialogAccepted();
-                        }
+                        secondArcId = id;
+                        ui->arc2Name_Label->setText(data->GetGObject(id)->name());
+                        number = 0;
+                        point->setArc2Id(id);
+                        point->RefreshGeometry();
+                        prepare = true;
+                        emit ToolTip("");
+                        DialogAccepted();
                     }
                     break;
                 default:
@@ -195,25 +195,6 @@ void DialogPointOfIntersectionArcs::ChosenObject(quint32 id, const SceneObject &
             }
         }
     }
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-void DialogPointOfIntersectionArcs::ArcChanged()
-{
-    QColor color = okColor;
-    if (getCurrentObjectId(ui->comboBoxArc1) == getCurrentObjectId(ui->comboBoxArc2))
-    {
-        flagError = false;
-        color = errorColor;
-    }
-    else
-    {
-        flagError = true;
-        color = okColor;
-    }
-    ChangeColor(ui->labelArc1, color);
-    ChangeColor(ui->labelArc2, color);
-    CheckState();
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.h
+++ b/src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.h
@@ -88,7 +88,6 @@ public:
 
 public slots:
     virtual void   ChosenObject(quint32 id, const SceneObject &type) override;
-    virtual void   ArcChanged();
 
 protected:
     virtual void   ShowVisualization() override;
@@ -101,6 +100,12 @@ private:
     Q_DISABLE_COPY(DialogPointOfIntersectionArcs)
 
     Ui::DialogPointOfIntersectionArcs *ui;
+
+    /** @brief firstArcId id of the first arc chosen at creation */
+    quint32        firstArcId;
+
+    /** @brief secondArcId id of the second arc chosen at creation */
+    quint32        secondArcId;
 };
 
 #endif // DIALOGPOINTOFINTERSECTIONARCS_H

--- a/src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui
+++ b/src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui
@@ -129,7 +129,7 @@
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="QComboBox" name="comboBoxArc1">
+         <widget class="QLabel" name="arc1Name_Label">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -147,6 +147,9 @@
             <pointsize>9</pointsize>
             <bold>false</bold>
            </font>
+          </property>
+          <property name="text">
+           <string notr="true"/>
           </property>
          </widget>
         </item>
@@ -179,7 +182,7 @@
          </widget>
         </item>
         <item row="2" column="1">
-         <widget class="QComboBox" name="comboBoxArc2">
+         <widget class="QLabel" name="arc2Name_Label">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -197,6 +200,9 @@
             <pointsize>9</pointsize>
             <bold>false</bold>
            </font>
+          </property>
+          <property name="text">
+           <string notr="true"/>
           </property>
          </widget>
         </item>

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp
@@ -279,42 +279,6 @@ QString VToolPointOfIntersectionArcs::SecondArcName() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-quint32 VToolPointOfIntersectionArcs::GetFirstArcId() const
-{
-    return firstArcId;
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-void VToolPointOfIntersectionArcs::SetFirstArcId(const quint32 &value)
-{
-    if (value != NULL_ID)
-    {
-        firstArcId = value;
-
-        QSharedPointer<VGObject> obj = VAbstractTool::data.GetGObject(m_id);
-        SaveOption(obj);
-    }
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-quint32 VToolPointOfIntersectionArcs::GetSecondArcId() const
-{
-    return secondArcId;
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-void VToolPointOfIntersectionArcs::SetSecondArcId(const quint32 &value)
-{
-    if (value != NULL_ID)
-    {
-        secondArcId = value;
-
-        QSharedPointer<VGObject> obj = VAbstractTool::data.GetGObject(m_id);
-        SaveOption(obj);
-    }
-}
-
-//---------------------------------------------------------------------------------------------------------------------
 CrossCirclesPoint VToolPointOfIntersectionArcs::GetCrossCirclesPoint() const
 {
     return crossPoint;

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.h
@@ -95,12 +95,6 @@ public:
     QString              FirstArcName() const;
     QString              SecondArcName() const;
 
-    quint32              GetFirstArcId() const;
-    void                 SetFirstArcId(const quint32 &value);
-
-    quint32              GetSecondArcId() const;
-    void                 SetSecondArcId(const quint32 &value);
-
     CrossCirclesPoint    GetCrossCirclesPoint() const;
     void                 setCirclesCrossPoint(const CrossCirclesPoint &value);
 


### PR DESCRIPTION
…Arcs tool issue-#1625

The arcs are fixed when the point is created, so they don't need combo boxes.

Follow up to #1618 the two arcs never change after the
point is created, so the combo boxes are not needed. This replaces them with
plain labels in both the dialog and the Property Editor, and removes the
validation code from #1618 since the invalid state is no longer possible.

Closes #1625