### PR TITLE
fix: various typos in code comments issue-#674

### DIFF
--- a/src/libs/qmuparser/qmuparserbase.cpp
+++ b/src/libs/qmuparser/qmuparserbase.cpp
@@ -1382,7 +1382,7 @@ void QmuParserBase::CreateRPN() const
 
     ReInit();
 
-    // The outermost counter counts the number of seperated items
+    // The outermost counter counts the number of separated items
     // such as in "a=10,b=20,c=c+a"
     stArgCount.push(1);
 
@@ -1921,11 +1921,11 @@ void QmuParserBase::StackDump(const QStack<token_type> &a_stVal, const QStack<to
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/** @brief Evaluate an expression containing comma seperated subexpressions
+/** @brief Evaluate an expression containing comma separated subexpressions
   * @param [out] nStackSize The total number of results available
   * @return Pointer to the array containing all expression results
   *
-  * This member function can be used to retriev all results of an expression made up of multiple comma seperated
+  * This member function can be used to retrieve all results of an expression made up of multiple comma separated
   * subexpressions (i.e. "x+y,sin(x),cos(y)")
   */
 qreal* QmuParserBase::Eval(int &nStackSize) const

--- a/src/libs/qmuparser/qmuparserbase.h
+++ b/src/libs/qmuparser/qmuparserbase.h
@@ -446,7 +446,7 @@ inline bool QmuParserBase::HasBuiltInOprt() const
 /**
  * @brief Return the number of results on the calculation stack.
  *
- * If the expression contains comma seperated subexpressions (i.e. "sin(y), x+y"). There mey be more than one return
+ * If the expression contains comma separated subexpressions (i.e. "sin(y), x+y"). There may be more than one return
  * value. This function returns the number of available results.
  */
 // cppcheck-suppress unusedFunction

--- a/src/libs/qmuparser/qmuparserdef.h
+++ b/src/libs/qmuparser/qmuparserdef.h
@@ -176,7 +176,7 @@ enum EOprtPrecedence
     prLOR     = 1,
     prLAND    = 2,
     prLOGIC   = 3,  ///< logic operators
-    prCMP     = 4,  ///< comparsion operators
+    prCMP     = 4,  ///< comparison operators
     prADD_SUB = 5,  ///< addition
     prMUL_DIV = 6,  ///< multiplication/division
     prPOW     = 7,  ///< power operator priority (highest)

--- a/src/libs/qmuparser/qmuparsererror.cpp
+++ b/src/libs/qmuparser/qmuparsererror.cpp
@@ -201,7 +201,7 @@ QmuParserError::QmuParserError ( const QString &sMsg )
  * @param [in] iErrc the error code.
  * @param [in] sTok The token string related to this error.
  * @param [in] sExpr The expression related to the error.
- * @param [in] iPos the position in the expression where the error occured.
+ * @param [in] iPos the position in the expression where the error occurred.
  */
 QmuParserError::QmuParserError ( EErrorCodes iErrc, const QString &sTok, const QString &sExpr, int iPos )
     : QException(), m_sMsg(), m_sExpr ( sExpr ), m_sTok ( sTok ), m_iPos ( iPos ), m_iErrc ( iErrc ),
@@ -216,7 +216,7 @@ QmuParserError::QmuParserError ( EErrorCodes iErrc, const QString &sTok, const Q
 /**
  * @brief Construct an error object.
  * @param [in] a_iErrc the error code.
- * @param [in] a_iPos the position in the expression where the error occured.
+ * @param [in] a_iPos the position in the expression where the error occurred.
  * @param [in] sTok The token string related to this error.
  */
 QmuParserError::QmuParserError ( EErrorCodes a_iErrc, int a_iPos, const QString &sTok )

--- a/src/libs/qmuparser/qmuparsertoken.h
+++ b/src/libs/qmuparser/qmuparsertoken.h
@@ -128,7 +128,7 @@ public:
     /**
      * @brief Assign a token type.
      *
-     * Token may not be of type value, variable or function. Those have seperate set functions.
+     * Token may not be of type value, variable or function. Those have separate set functions.
      *
      * @pre [assert] a_iType!=cmVAR
      * @pre [assert] a_iType!=cmVAL

--- a/src/libs/vpropertyexplorer/vpropertyformview.cpp
+++ b/src/libs/vpropertyexplorer/vpropertyformview.cpp
@@ -104,7 +104,7 @@ void VPE::VPropertyFormView::setPropertySet(VPropertySet *property_set)
 
 void VPE::VPropertyFormView::rowsRemoved(const QModelIndex &parent, int start, int end)
 {
-    // todo: Only rebuild the neccessary parts
+    // todo: Only rebuild the necessary parts
     Q_UNUSED(parent)
     Q_UNUSED(start)
     Q_UNUSED(end)
@@ -113,7 +113,7 @@ void VPE::VPropertyFormView::rowsRemoved(const QModelIndex &parent, int start, i
 
 void VPE::VPropertyFormView::rowsInserted(const QModelIndex &parent, int start, int end) //-V524
 {
-    // todo: Only rebuild the neccessary parts
+    // todo: Only rebuild the necessary parts
     Q_UNUSED(parent)
     Q_UNUSED(start)
     Q_UNUSED(end)

--- a/src/libs/vpropertyexplorer/vpropertymodel.cpp
+++ b/src/libs/vpropertyexplorer/vpropertymodel.cpp
@@ -172,7 +172,7 @@ bool VPE::VPropertyModel::setData (const QModelIndex& index, const QVariant& val
     {
         bool tmpHasChanged = tmpProperty->setData(value, role);
         if (tmpProperty->getUpdateParent() && tmpHasChanged)
-        {   // If neccessary, update the parent as well
+        {   // If necessary, update the parent as well
             QModelIndex tmpParentIndex = parent(index);
             emit dataChanged(tmpParentIndex, tmpParentIndex);
         }

--- a/src/libs/vtools/dialogs/tools/dialogtool.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogtool.cpp
@@ -1445,10 +1445,10 @@ void DialogTool::FillCombo(QComboBox *box, GOType gType, FillComboBox rule, cons
 // This method sets the screen position of dialogs based on the user preference setting
 //
 // @details
-//  - Get dialog prefered possition from settings.
+//  - Get dialog preferred position from settings.
 //  - Determine geometry of screen and dialog.
-//  - Move dialog to prefered screen position with margin applied.
-//  - Positions include Top left, Top right, Center, Bottom Left, and Botton right corner of screen.
+//  - Move dialog to preferred screen position with margin applied.
+//  - Positions include Top left, Top right, Center, Bottom Left, and Bottom right corner of screen.
 void  DialogTool::setDialogPosition()
 {
     int position = qApp->Settings()->getDialogPosition();

--- a/src/libs/vwidgets/vtextgraphicsitem.cpp
+++ b/src/libs/vwidgets/vtextgraphicsitem.cpp
@@ -567,7 +567,7 @@ void VTextGraphicsItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event )
     else if (m_mode == Mode::Rotate && m_moveType & IsRotatable)
     {
         qDebug() << " Item is Rotatable\n";
-        // if the angle from the original position is small (0.5 degrees), just remeber the new angle
+        // if the angle from the original position is small (0.5 degrees), just remember the new angle
         // new angle will be the starting angle for rotation
         if (fabs(m_angle) < 0.01)
         {


### PR DESCRIPTION
Fixes several spelling errors in code comments across `src/libs`, as part of the standing typo issue #674.

## Changes
- `qmuparser` (qmuparserbase.cpp/.h, qmuparsererror.cpp, qmuparsertoken.h, qmuparserdef.h): "seperate(d)" → "separate(d)", "occured" → "occurred", "retriev" → "retrieve", "mey" → "may", "comparsion" → "comparison"
- `vtools/dialogs/tools/dialogtool.cpp`: "prefered" → "preferred", "possition" → "position", "Botton" → "Bottom"
- `vpropertyexplorer` (vpropertymodel.cpp, vpropertyformview.cpp): "neccessary" → "necessary"
- `vwidgets/vtextgraphicsitem.cpp`: "remeber" → "remember"

Comment-only changes: no code, strings, or identifiers are touched, so there is no behavior or translation impact.

Note: `src/app/seamlyme/tmainwindow.cpp:578` contains "recieve" inside a `tr()` string; it was deliberately left out to avoid invalidating existing Weblate translations. Happy to include it if preferred.
