### PR TITLE
fix: Wayland app_id incorrect issue-#1477

### DIFF
--- a/src/app/seamly2d/core/application_2d.cpp
+++ b/src/app/seamly2d/core/application_2d.cpp
@@ -279,7 +279,7 @@ inline void noisyFailureMsgHandler(QtMsgType type, const QMessageLogContext &con
     //setApplicationDisplayName(VER_PRODUCTNAME_STR);
     setApplicationName(VER_INTERNALNAME_STR);
     setOrganizationName(VER_COMPANYNAME_STR);
-    setOrganizationDomain(VER_COMPANYDOMAIN_STR);
+    setOrganizationDomain(VER_COMPANYDOMAIN);
     // Setting the Application version
     setApplicationVersion(APP_VERSION_STR);
 

--- a/src/app/seamlyme/application_me.cpp
+++ b/src/app/seamlyme/application_me.cpp
@@ -260,7 +260,7 @@ ApplicationME::ApplicationME(int &argc, char **argv)
     //setApplicationDisplayName(VER_PRODUCTNAME_STR);
     setApplicationName(VER_INTERNALNAME_ME_STR);
     setOrganizationName(VER_COMPANYNAME_STR);
-    setOrganizationDomain(VER_COMPANYDOMAIN_STR);
+    setOrganizationDomain(VER_COMPANYDOMAIN);
     // Setting the Application version
     setApplicationVersion(APP_VERSION_STR);
 

--- a/src/libs/vmisc/projectversion.h
+++ b/src/libs/vmisc/projectversion.h
@@ -82,6 +82,9 @@ extern const QString APP_VERSION_STR;
 #define VER_LEGALTRADEMARKS1_STR    "All Rights Reserved"
 #define VER_LEGALTRADEMARKS2_STR    VER_LEGALTRADEMARKS1_STR
 #define VER_COMPANYDOMAIN_STR       "https://seamly.io"
+// Bare domain for QCoreApplication::setOrganizationDomain(): a URL scheme here breaks
+// the reverse-DNS app_id Qt derives on Wayland (e.g. "io.https://seamly.seamly2d")
+#define VER_COMPANYDOMAIN           "seamly.io"
 
 QString compilerString();
 QString buildCompatibilityString();


### PR DESCRIPTION
Fixes #1477.

## Problem
On Wayland the window `app_id` shows as `io.https://seamly.seamly2d` instead of `io.seamly.seamly2d`.

## Root cause
Both apps call `setOrganizationDomain(VER_COMPANYDOMAIN_STR)` where the macro is `"https://seamly.io"` — a URL, not a domain. When `desktopFileName` is not set, QtWayland derives the app_id by splitting the organization domain on `.`, reversing the components and appending the executable basename (see `QWaylandWindow::initWindow()` in qtwayland). `"https://seamly.io"` splits into `["https://seamly", "io"]`, producing exactly the reported `io.https://seamly.seamly2d`.

## Fix
Add a bare-domain macro `VER_COMPANYDOMAIN "seamly.io"` and use it for `setOrganizationDomain()` in both Seamly2D and SeamlyMe. `VER_COMPANYDOMAIN_STR` (the URL) is kept unchanged for its remaining uses as a clickable link in the About dialogs.

Resulting app_ids: `io.seamly.seamly2d` (matching the Flathub id) and `io.seamly.seamlyme`.

## Notes
- One-time side effect on macOS only: a few default-constructed `QSettings` (splitter sizes and sort order in the Groups/Pieces docks) derive their plist name from the organization domain, so those cosmetic preferences reset once. Main application settings use `IniFormat` with explicit organization name and are unaffected. Windows/Linux unaffected.
- Comment-verified against the qtwayland source; I don't have a Qt build environment at hand, but the change is a plain string-macro substitution at two existing call sites.
