### PR TITLE
fix: correct 'recieve' typo in user-facing strings issue-#674

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -10198,7 +10198,7 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
         <translation>Přiložte soubor 3DLook k e-mailu a odešlete jej na adresu convert@seamly.io.</translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Obdržíte e-mail s převedeným souborem, který pak můžete jako obvykle načíst do SeamlyME.</translation>
     </message>
     <message>
@@ -11757,7 +11757,7 @@ Chcete změny uložit?</translation>
 </translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -10184,7 +10184,7 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <translation>Hängen Sie Ihre 3DLook-Datei an eine E-Mail an und senden Sie sie an convert@seamly.io.</translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Sie erhalten dann eine E-Mail mit der konvertierten Datei, die Sie dann wie gewohnt in SeamlyME laden können.</translation>
     </message>
     <message>
@@ -11739,7 +11739,7 @@ Sollen die Änderungen gespeichert werden?</translation>
 </translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -10202,7 +10202,7 @@ Press enter to temporarily add it to the list.</source>
         <translation>Επισυνάψτε το αρχείο 3DLook σε ένα email και στείλτε το στη διεύθυνση convert@seamly.io.</translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Θα λάβετε ένα email με το αρχείο που έχει μετατραπεί, το οποίο μπορείτε στη συνέχεια να φορτώσετε στο SeamlyME ως συνήθως.</translation>
     </message>
     <message>
@@ -11761,7 +11761,7 @@ Do you want to save your changes?</source>
 </translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -10168,7 +10168,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11720,7 +11720,7 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -10168,7 +10168,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11724,7 +11724,7 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -10168,7 +10168,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11720,7 +11720,7 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -10183,7 +10183,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11735,7 +11735,7 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -10239,7 +10239,7 @@ actualización:</translation>
         <translation>Adjunte su archivo 3DLook a un correo electrónico y envíelo a convert@seamly.io.</translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Recibirá un correo electrónico con el archivo convertido, que podrá cargar en SeamlyME como de costumbre.</translation>
     </message>
     <message>
@@ -11790,7 +11790,7 @@ Do you want to save your changes?</source>
 </translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -10200,7 +10200,7 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
         <translation>Liitä 3DLook-tiedostosi sähköpostiviestiin ja lähetä se osoitteeseen convert@seamly.io.</translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Saat sähköpostin, jossa on muunnetut tiedostot. Voit sitten ladata ne SeamlyME:hen normaalisti.</translation>
     </message>
     <message>
@@ -11570,7 +11570,7 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
 </translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -10228,7 +10228,7 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
         <translation>Joignez votre fichier 3DLook à un courriel et envoyez-le à convert@seamly.io.</translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Vous recevrez un e-mail avec le fichier converti, que vous pourrez ensuite charger dans SeamlyME comme d&apos;habitude.</translation>
     </message>
     <message>
@@ -11788,7 +11788,7 @@ Voulez-vous enregistrer les changements?</translation>
 </translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -10164,7 +10164,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11715,7 +11715,7 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_hu_HU.ts
+++ b/share/translations/seamly2d_hu_HU.ts
@@ -10199,7 +10199,7 @@ Menti a módosításokat?</translation>
         <translation>Csatold a 3DLook fájlodat egy e-mailhez, és küldd el a convert@seamly.io címre.</translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Kapni fogsz egy e-mailt a konvertált fájllal, amelyet ezután a szokásos módon betölthetsz a SeamlyME-be.</translation>
     </message>
     <message>
@@ -11585,7 +11585,7 @@ Menti a módosításokat?</translation>
 </translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -10200,7 +10200,7 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
         <translation>Lampirkan file 3DLook Anda ke email dan kirim ke convert@seamly.io.</translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Anda akan menerima email berisi berkas yang dikonversi, yang kemudian dapat Anda unggah ke SeamlyME seperti biasa.</translation>
     </message>
     <message>
@@ -11759,7 +11759,7 @@ Apakah Anda ingin menyimpan perubahan Anda?</translation>
 </translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -10188,7 +10188,7 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
         <translation>Allegare il file 3DLook a un&apos;e-mail e inviarlo a convert@seamly.io.</translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Riceverete un&apos;e-mail con il file convertito, che potrete caricare in SeamlyME come di consueto.</translation>
     </message>
     <message>
@@ -11743,7 +11743,7 @@ Vuoi salvare le tue modifiche?</translation>
 </translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -10183,7 +10183,7 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
         <translation>Voeg uw 3DLook-bestand bij in een e-mail en stuur het naar convert@seamly.io.</translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Je ontvangt een e-mail met het geconverteerde bestand, dat je vervolgens zoals gewoonlijk in SeamlyME kunt laden.</translation>
     </message>
     <message>
@@ -11742,7 +11742,7 @@ Wil je deze veranderingen opslaan?</translation>
 </translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_pl_PL.ts
+++ b/share/translations/seamly2d_pl_PL.ts
@@ -10200,7 +10200,7 @@ Czy chcesz zapisać zmiany?</translation>
         <translation>Dołącz plik 3DLook do wiadomości e-mail i wyślij na adres convert@seamly.io.</translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Otrzymasz e-mail z przekonwertowanym plikiem, który możesz następnie wczytać do SeamlyME jak zwykle.</translation>
     </message>
     <message>
@@ -11586,7 +11586,7 @@ Czy chcesz zapisać zmiany?</translation>
 </translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -10188,7 +10188,7 @@ Prima enter para o adicionar temporariamente à lista.</translation>
         <translation>Anexe seu arquivo 3DLook a um e-mail e envie para convert@seamly.io.</translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Vocâ receberâ um e-mail com o arquivo convertido, que poderâ ser carregado no SeamlyME normalmente.</translation>
     </message>
     <message>
@@ -11747,7 +11747,7 @@ Pretende guardar as suas alterações?</translation>
 </translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -10202,7 +10202,7 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
         <translation>Atașați fișierul 3DLook la un e-mail și trimiteți-l la convert@seamly.io.</translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Veți primi un e-mail cu fișierul convertit, pe care îl puteți încărca apoi în SeamlyME ca de obicei.</translation>
     </message>
     <message>
@@ -11757,7 +11757,7 @@ Doriți să salvați modificările?</translation>
 </translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -10207,7 +10207,7 @@ Press enter to temporarily add it to the list.</source>
         <translation>Прикрепите файл 3DLook к электронному письму и отправьте его на адрес convert@seamly.io.</translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Вы получите электронное письмо с преобразованным файлом, который затем можно загрузить в SeamlyME, как обычно.</translation>
     </message>
     <message>
@@ -11766,7 +11766,7 @@ Do you want to save your changes?</source>
 </translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -10200,7 +10200,7 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
         <translation>3DLook dosyanızı bir e-postaya ekleyin ve convert@seamly.io adresine gönderin.</translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Dönüştürülen dosyanın bulunduğu bir e-posta alacaksınız, ardından dosyayı her zamanki gibi SeamlyME&apos;ye yükleyebilirsiniz.</translation>
     </message>
     <message>
@@ -11759,7 +11759,7 @@ Do you want to save your changes?</translation>
 </translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -10201,7 +10201,7 @@ Press enter to temporarily add it to the list.</source>
         <translation>Επισυνάψτε το αρχείο 3DLook σε ένα email και στείλτε το στη διεύθυνση convert@seamly.io.</translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Θα λάβετε ένα email με το αρχείο που έχει μετατραπεί, το οποίο μπορείτε στη συνέχεια να φορτώσετε στο SeamlyME ως συνήθως.</translation>
     </message>
     <message>
@@ -11760,7 +11760,7 @@ Do you want to save your changes?</source>
 </translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -10200,7 +10200,7 @@ Press enter to temporarily add it to the list.</source>
         <translation>将您的 3DLook 文件附加到电子邮件中并发送给convert@seamly.io.</translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
+        <source>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>您将收到一封包含已转换文件的电子邮件，然后您可以像往常一样将其加载到 Seamly ME 中.</translation>
     </message>
     <message>
@@ -11755,7 +11755,7 @@ Do you want to save your changes?</source>
 </translation>
     </message>
     <message>
-        <source>You will recieve an email with the converted file, which you can then
+        <source>You will receive an email with the converted file, which you can then
 load in SeamlyME as usual.
 
 </source>

--- a/src/app/seamlyme/dialogs/me_welcome_dialog.ui
+++ b/src/app/seamlyme/dialogs/me_welcome_dialog.ui
@@ -162,7 +162,7 @@
                    </font>
                   </property>
                   <property name="text">
-                   <string>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</string>
+                   <string>You will receive an email with the converted file, which you can then load in SeamlyME as usual.</string>
                   </property>
                   <property name="wordWrap">
                    <bool>true</bool>

--- a/src/app/seamlyme/tmainwindow.cpp
+++ b/src/app/seamlyme/tmainwindow.cpp
@@ -575,7 +575,7 @@ void TMainWindow::handleBodyScanner2()
 {
     QString msg = tr("To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.\n") +
                   tr("Attach your 3DLook file to an email and send to convert@seamly.io.\n\n") +
-                  tr("You will recieve an email with the converted file, which you can then\nload in SeamlyME as usual.\n\n");
+                  tr("You will receive an email with the converted file, which you can then\nload in SeamlyME as usual.\n\n");
 
     QMessageBox messageBox(this);
     messageBox.setIconPixmap(QPixmap(":/icon/body_scan.png"));


### PR DESCRIPTION
Follow-up to #1627 for the standing typo issue #674, addressing the `tr()` string that was deliberately left out there.

As @DSCaskey pointed out in https://github.com/FashionFreedom/Seamly2D/pull/1627#issuecomment-5049599167 (changing the `tr()` text **and** the matching source strings in all `.ts` files keeps existing translations attached), this PR does both:

## Changes
- `src/app/seamlyme/tmainwindow.cpp`: "recieve" → "receive" in the 3DLook conversion message (`tr()` string, context `TMainWindow`)
- `src/app/seamlyme/dialogs/me_welcome_dialog.ui`: same fix in the Welcome dialog label (context `SeamlyMeWelcomeDialog`)
- All 22 `share/translations/seamly2d_*.ts`: the two corresponding `<source>` entries updated to match, leaving every `<translation>` untouched

The updated `<source>` strings match the new source text byte-for-byte (including embedded newlines), so the next `lupdate` run will keep the existing translations instead of dropping them. XML validity of all 22 `.ts` files checked with `xmllint`. No other occurrence of the typo remains in the repo (case-insensitive search).
