### PR TITLE
fix: prevent deleting a Line tool used in a formula issue #1364

### DIFF
--- a/src/libs/ifc/xml/vabstractpattern.cpp
+++ b/src/libs/ifc/xml/vabstractpattern.cpp
@@ -1865,6 +1865,48 @@ QVector<VFormulaField> VAbstractPattern::ListExpressions() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+/// @brief isVariableUsedInFormulas check if a variable is referenced by any formula in the pattern.
+/// @param variable_name name of the variable to look for, for example "Line_A_B".
+/// @return true if at least one formula uses the variable.
+//---------------------------------------------------------------------------------------------------------------------
+
+bool VAbstractPattern::isVariableUsedInFormulas(const QString &variable_name) const
+{
+    if (variable_name.isEmpty())
+    {
+        return false;
+    }
+
+    const QVector<VFormulaField> expressions = ListExpressions();
+    for (int i = 0; i < expressions.size(); ++i)
+    {
+        // Cheap pre-check. Parsing every formula in the pattern is expensive.
+        if (expressions.at(i).expression.indexOf(variable_name) == -1)
+        {
+            continue;
+        }
+
+        try
+        {
+            QScopedPointer<qmu::QmuTokenParser> cal(new qmu::QmuTokenParser(expressions.at(i).expression, false,
+                                                                            false));
+
+            // Tokens (variables, measurements)
+            if (cal->GetTokens().values().contains(variable_name))
+            {
+                return true;
+            }
+        }
+        catch (const qmu::QmuParserError &)
+        {
+            // Do nothing. Because we not sure if used. A formula is broken.
+        }
+    }
+
+    return false;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 QVector<VFormulaField> VAbstractPattern::ListPointExpressions() const
 {
     // Check if new tool doesn't bring new attribute with a formula.

--- a/src/libs/ifc/xml/vabstractpattern.h
+++ b/src/libs/ifc/xml/vabstractpattern.h
@@ -120,6 +120,7 @@ public:
     QStringList                    ListMeasurements() const;
     QVector<VFormulaField>         ListExpressions() const;
     QVector<VFormulaField>         listVariableExpressions() const;
+    bool                           isVariableUsedInFormulas(const QString &variable_name) const;
 
     virtual void                   CreateEmptyFile()=0;
 

--- a/src/libs/vtools/tools/drawTools/vdrawtool.h
+++ b/src/libs/vtools/tools/drawTools/vdrawtool.h
@@ -251,7 +251,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
     {
         if (ref == Referens::Follow)
         {
-            if (_referens > 0)
+            if (isUsed())
             {
                 qCDebug(vTool, "Delete disabled. Tool has children.");
                 actionDelete->setEnabled(false);

--- a/src/libs/vtools/tools/drawTools/vtoolline.cpp
+++ b/src/libs/vtools/tools/drawTools/vtoolline.cpp
@@ -248,6 +248,36 @@ QString VToolLine::SecondPointName() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+/// @brief isUsedInFormula check if the length or the angle of this line is used in a formula.
+///
+/// A line has no object in the data container, only the length and angle variables the tool registers with
+/// VContainer::AddLine(). Those variables are referenced by name, so the id based reference counter never sees
+/// them and can't stop the line from being deleted while a formula still needs it.
+///
+/// @return true if a formula references the length or the angle of this line.
+//---------------------------------------------------------------------------------------------------------------------
+
+bool VToolLine::isUsedInFormula() const
+{
+    const QString first_name  = FirstPointName();
+    const QString second_name = SecondPointName();
+    const QString line_name   = QString("%1_%2").arg(first_name, second_name);
+
+    return doc->isVariableUsedInFormulas(line_ + line_name)
+        || doc->isVariableUsedInFormulas(angleLine_ + line_name);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief isUsed check if the line can't be deleted.
+/// @return true if another tool references the line by id, or a formula uses its length or angle.
+//---------------------------------------------------------------------------------------------------------------------
+
+bool VToolLine::isUsed() const
+{
+    return VDrawTool::isUsed() || isUsedInFormula();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 /**
  * @brief FullUpdateFromFile update tool data form file.
  */

--- a/src/libs/vtools/tools/drawTools/vtoolline.h
+++ b/src/libs/vtools/tools/drawTools/vtoolline.h
@@ -95,6 +95,9 @@ public:
     QString           FirstPointName() const;
     QString           SecondPointName() const;
 
+    bool              isUsedInFormula() const;
+    virtual bool      isUsed() const override;
+
     quint32           GetFirstPoint() const;
     void              SetFirstPoint(const quint32 &value);
 

--- a/src/libs/vtools/tools/vabstracttool.cpp
+++ b/src/libs/vtools/tools/vabstracttool.cpp
@@ -261,7 +261,7 @@ qreal VAbstractTool::CheckFormula(const quint32 &toolId, QString &formula, VCont
 void VAbstractTool::deleteTool(bool ask)
 {
     qCDebug(vTool, "Deleting abstract tool.");
-    if (_referens == 0)
+    if (not isUsed())
     {
         qCDebug(vTool, "No children.");
         qApp->getSceneView()->itemClicked(nullptr);

--- a/src/libs/vtools/tools/vdatatool.h
+++ b/src/libs/vtools/tools/vdatatool.h
@@ -76,6 +76,7 @@ public:
     VContainer      getData() const;
     void            setData(const VContainer *value);
     virtual quint32 referens() const;
+    virtual bool    isUsed() const;
     virtual void    incrementReferens();
     virtual void    decrementReferens();
     virtual void    GroupVisibility(quint32 object, bool visible)=0;
@@ -117,6 +118,20 @@ inline void VDataTool::setData(const VContainer *value)
 inline quint32 VDataTool::referens() const
 {
     return _referens;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief isUsed check if another tool still needs this tool, so it can't be deleted.
+///
+/// By default a tool is used when something references it by id. Tools whose dependents are not tracked by id
+/// override this, for example a line that a formula uses by name.
+///
+/// @return true if the tool can't be deleted.
+//---------------------------------------------------------------------------------------------------------------------
+
+inline bool VDataTool::isUsed() const
+{
+    return _referens > 0;
 }
 
 //---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1364

The delete check counts references by id, but formulas use a line by its name (like Line_A_B). A line doesn't even have an id in the data container, so its use count was always 0 and it could be deleted while a formula still needed it. That left the pattern with a broken formula.

The fix: the delete check now asks the tool if it is still used, instead of reading the counter directly. For all other tools nothing changes. For a line, it also checks if any formula uses its length or angle. If yes, Delete is greyed out in the context menu and the Delete key does nothing.

No file format change.

By the way, arcs and curves that are only used in formulas have the same problem. With this change each one would be a small follow-up, happy to do that in another PR if you want