### PR TITLE
fix: prevent deleting arcs and curves used in formulas issue-#1364

### DIFF
--- a/src/libs/ifc/xml/vabstractpattern.cpp
+++ b/src/libs/ifc/xml/vabstractpattern.cpp
@@ -1865,14 +1865,17 @@ QVector<VFormulaField> VAbstractPattern::ListExpressions() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/// @brief isVariableUsedInFormulas check if a variable is referenced by any formula in the pattern.
-/// @param variable_name name of the variable to look for, for example "Line_A_B".
-/// @return true if at least one formula uses the variable.
+/// @brief isAnyVariableUsedInFormulas check if any of the variables is referenced by a formula in the pattern.
+/// @param variable_names names of the variables to look for.
+/// @return true if at least one formula uses one of the variables.
 //---------------------------------------------------------------------------------------------------------------------
 
-bool VAbstractPattern::isVariableUsedInFormulas(const QString &variable_name) const
+bool VAbstractPattern::isAnyVariableUsedInFormulas(const QStringList &variable_names) const
 {
-    if (variable_name.isEmpty())
+    QStringList names = variable_names;
+    names.removeAll(QString());
+
+    if (names.isEmpty())
     {
         return false;
     }
@@ -1881,7 +1884,17 @@ bool VAbstractPattern::isVariableUsedInFormulas(const QString &variable_name) co
     for (int i = 0; i < expressions.size(); ++i)
     {
         // Cheap pre-check. Parsing every formula in the pattern is expensive.
-        if (expressions.at(i).expression.indexOf(variable_name) == -1)
+        bool found = false;
+        for (int j = 0; j < names.size(); ++j)
+        {
+            if (expressions.at(i).expression.indexOf(names.at(j)) != -1)
+            {
+                found = true;
+                break;
+            }
+        }
+
+        if (not found)
         {
             continue;
         }
@@ -1892,9 +1905,13 @@ bool VAbstractPattern::isVariableUsedInFormulas(const QString &variable_name) co
                                                                             false));
 
             // Tokens (variables, measurements)
-            if (cal->GetTokens().values().contains(variable_name))
+            const QList<QString> tokens = cal->GetTokens().values();
+            for (int j = 0; j < names.size(); ++j)
             {
-                return true;
+                if (tokens.contains(names.at(j)))
+                {
+                    return true;
+                }
             }
         }
         catch (const qmu::QmuParserError &)

--- a/src/libs/ifc/xml/vabstractpattern.h
+++ b/src/libs/ifc/xml/vabstractpattern.h
@@ -120,7 +120,7 @@ public:
     QStringList                    ListMeasurements() const;
     QVector<VFormulaField>         ListExpressions() const;
     QVector<VFormulaField>         listVariableExpressions() const;
-    bool                           isVariableUsedInFormulas(const QString &variable_name) const;
+    bool                           isAnyVariableUsedInFormulas(const QStringList &variable_names) const;
 
     virtual void                   CreateEmptyFile()=0;
 

--- a/src/libs/vtools/tools/drawTools/vdrawtool.cpp
+++ b/src/libs/vtools/tools/drawTools/vdrawtool.cpp
@@ -91,6 +91,37 @@ VDrawTool::VDrawTool(VAbstractPattern *doc, VContainer *data, quint32 id, QObjec
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+/// @brief isUsed check if the tool can't be deleted.
+///
+/// Besides the id based reference count, a tool can also be needed through the variables it registered in the
+/// data container, for example the length of an arc or the angles of a spline. Formulas reference those variables
+/// by name, so the reference counter never sees them. VInternalVariable::Filter() tells which variables belong to
+/// this tool, the same test the formula dialog uses to hide a tool's own variables.
+///
+/// @return true if another tool references this tool by id, or a formula uses one of its variables.
+//---------------------------------------------------------------------------------------------------------------------
+
+bool VDrawTool::isUsed() const
+{
+    if (VInteractiveTool::isUsed())
+    {
+        return true;
+    }
+
+    QStringList variable_names;
+    const QHash<QString, QSharedPointer<VInternalVariable>> *variables = data.DataVariables();
+    for (auto i = variables->constBegin(); i != variables->constEnd(); ++i)
+    {
+        if (i.value()->Filter(m_id))
+        {
+            variable_names.append(i.key());
+        }
+    }
+
+    return doc->isAnyVariableUsedInFormulas(variable_names);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 /**
  * @brief ShowTool  highlight tool.
  * @param id object id in container.

--- a/src/libs/vtools/tools/drawTools/vdrawtool.h
+++ b/src/libs/vtools/tools/drawTools/vdrawtool.h
@@ -111,6 +111,7 @@ public:
     virtual void     setLineWeight(const QString &value);
 
     virtual bool     isPointNameVisible(quint32 id) const;
+    virtual bool     isUsed() const override;
 
 signals:
     void             ChangedToolSelection(bool selected, quint32 object, quint32 tool);

--- a/src/libs/vtools/tools/drawTools/vtoolline.cpp
+++ b/src/libs/vtools/tools/drawTools/vtoolline.cpp
@@ -259,12 +259,9 @@ QString VToolLine::SecondPointName() const
 
 bool VToolLine::isUsedInFormula() const
 {
-    const QString first_name  = FirstPointName();
-    const QString second_name = SecondPointName();
-    const QString line_name   = QString("%1_%2").arg(first_name, second_name);
+    const QString line_name = QString("%1_%2").arg(FirstPointName(), SecondPointName());
 
-    return doc->isVariableUsedInFormulas(line_ + line_name)
-        || doc->isVariableUsedInFormulas(angleLine_ + line_name);
+    return doc->isAnyVariableUsedInFormulas(QStringList() << line_ + line_name << angleLine_ + line_name);
 }
 
 //---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
 Follow up to #1364.

Arcs and curves had the same problem as lines: if a formula uses their length or angle, they could still be deleted and the formula would break.

This time the check is generic. Before deleting, the tool checks if any of its variables is used in a formula. If yes, Delete is blocked. This covers arcs splines, spline paths and cut segments in one place, so no need to patch each tool separatelyy