### PR TITLE
fix: rebuild dependency counters when a tool reference changes issue(#1521]

### DIFF
--- a/src/libs/tools/images/image_tool.cpp
+++ b/src/libs/tools/images/image_tool.cpp
@@ -298,6 +298,7 @@ void ImageTool::saveChanges()
 
         SaveToolOptions *saveOptions = new SaveToolOptions(domElement, newDomElement, m_doc, id);
         connect(saveOptions, &SaveToolOptions::NeedLiteParsing, m_doc, &VAbstractPattern::LiteParseTree);
+        connect(saveOptions, &SaveToolOptions::NeedFullParsing, m_doc, &VAbstractPattern::NeedFullParsing);
         qApp->getUndoStack()->push(saveOptions);
     }
     else

--- a/src/libs/vtools/tools/drawTools/vdrawtool.cpp
+++ b/src/libs/vtools/tools/drawTools/vdrawtool.cpp
@@ -169,6 +169,7 @@ void VDrawTool::SaveDialogChange()
 
         SaveToolOptions *saveOptions = new SaveToolOptions(oldDomElement, newDomElement, doc, m_id);
         connect(saveOptions, &SaveToolOptions::NeedLiteParsing, doc, &VAbstractPattern::LiteParseTree);
+        connect(saveOptions, &SaveToolOptions::NeedFullParsing, doc, &VAbstractPattern::NeedFullParsing);
         qApp->getUndoStack()->push(saveOptions);
     }
     else
@@ -202,6 +203,7 @@ void VDrawTool::SaveOption(QSharedPointer<VGObject> &obj)
 
         SaveToolOptions *saveOptions = new SaveToolOptions(oldDomElement, newDomElement, doc, m_id);
         connect(saveOptions, &SaveToolOptions::NeedLiteParsing, doc, &VAbstractPattern::LiteParseTree);
+        connect(saveOptions, &SaveToolOptions::NeedFullParsing, doc, &VAbstractPattern::NeedFullParsing);
         qApp->getUndoStack()->push(saveOptions);
     }
     else

--- a/src/libs/vtools/undocommands/savetooloptions.cpp
+++ b/src/libs/vtools/undocommands/savetooloptions.cpp
@@ -52,11 +52,78 @@
 #include "savetooloptions.h"
 
 #include <QDomNode>
+#include <QStringList>
+#include <QTextStream>
 
 #include "../vmisc/def.h"
 #include "../vmisc/logging.h"
+#include "../ifc/ifcdef.h"
 #include "../ifc/xml/vabstractpattern.h"
 #include "vundocommand.h"
+
+namespace
+{
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief childElements serialize the child elements of a tool element.
+///
+/// Some tools keep object references in child elements instead of attributes, for example the points of a
+/// spline path. Text nodes are skipped.
+///
+/// @param element tool element.
+/// @return the child elements as one string.
+//---------------------------------------------------------------------------------------------------------------------
+
+QString childElements(const QDomElement &element)
+{
+    QString dump;
+    QTextStream stream(&dump);
+
+    QDomElement child = element.firstChildElement();
+    while (!child.isNull())
+    {
+        child.save(stream, 0);
+        child = child.nextSiblingElement();
+    }
+    return dump;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief referencesChanged check if a tool option change replaced a referenced object.
+///
+/// The reference counters that guard deletion are only set when a tool is created during a full parse.
+/// When an option change replaces a referenced object the counters become stale, so the caller has to
+/// request a full parse to rebuild them. See issue #1521.
+///
+/// @param oldXml tool element before the change.
+/// @param newXml tool element after the change.
+/// @return true if an object reference changed.
+//---------------------------------------------------------------------------------------------------------------------
+
+bool referencesChanged(const QDomElement &oldXml, const QDomElement &newXml)
+{
+    // Attributes of the draw tools that store the id of another object.
+    static const QStringList reference_attributes = QStringList()
+        << AttrBasePoint << AttrFirstPoint << AttrSecondPoint << AttrThirdPoint
+        << AttrCenter << AttrCCenter << AttrC1Center << AttrC2Center
+        << AttrArc << AttrFirstArc << AttrSecondArc
+        << AttrCurve << AttrCurve1 << AttrCurve2
+        << AttrPoint1 << AttrPoint2 << AttrPoint3 << AttrPoint4
+        << AttrP1Line << AttrP2Line << AttrP1Line1 << AttrP2Line1 << AttrP1Line2 << AttrP2Line2
+        << AttrAxisP1 << AttrAxisP2 << AttrTangent << AttrPShoulder
+        << AttrDartP1 << AttrDartP2 << AttrDartP3
+        << AttrBaseLineP1 << AttrBaseLineP2;
+
+    for (int i = 0; i < reference_attributes.size(); ++i)
+    {
+        if (oldXml.attribute(reference_attributes.at(i)) != newXml.attribute(reference_attributes.at(i)))
+        {
+            return true;
+        }
+    }
+
+    return childElements(oldXml) != childElements(newXml);
+}
+} // anonymous namespace
 
 //---------------------------------------------------------------------------------------------------------------------
 SaveToolOptions::SaveToolOptions(const QDomElement &oldXml, const QDomElement &newXml, VAbstractPattern *doc,
@@ -81,7 +148,15 @@ void SaveToolOptions::undo()
     {
         domElement.parentNode().replaceChild(oldXml, domElement);
 
-        emit NeedLiteParsing(Document::LiteParse);
+        if (referencesChanged(oldXml, newXml))
+        {
+            // A referenced object changed. Only a full parse rebuilds the reference counters. See issue #1521.
+            emit NeedFullParsing();
+        }
+        else
+        {
+            emit NeedLiteParsing(Document::LiteParse);
+        }
     }
     else
     {
@@ -100,7 +175,15 @@ void SaveToolOptions::redo()
     {
         domElement.parentNode().replaceChild(newXml, domElement);
 
-        emit NeedLiteParsing(Document::LiteParse);
+        if (referencesChanged(oldXml, newXml))
+        {
+            // A referenced object changed. Only a full parse rebuilds the reference counters. See issue #1521.
+            emit NeedFullParsing();
+        }
+        else
+        {
+            emit NeedLiteParsing(Document::LiteParse);
+        }
     }
     else
     {


### PR DESCRIPTION
 The counters that protect a point from being deleted are only set when the pattern is fully parsed, and only lowered when a tool is deleted. Changing a base point in a dialog did neither. So the old point stayed locked until you closed and reopened the file, and worse, the new point was left unprotected and could be deleted while in use.

The fix: when a tool option change swaps a referenced object, the pattern now does a full parse, which rebuilds all counters, the same thing reopening the file does. Cosmetic and formula edits keep the fast lite parse, so nothing gets slower in normal editing.

This also answers the open question in the issue: it was never specific to one tool, it affected every tool, because no tool updated the counters on a reference change.

Closes #1521 