### PR TITLE
fix: Use show notch settings when creating default notch

### DIFF
--- a/src/libs/vtools/tools/nodeDetails/vnodepoint.cpp
+++ b/src/libs/vtools/tools/nodeDetails/vnodepoint.cpp
@@ -550,8 +550,8 @@ void VNodePoint::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
                 notchWidth   = qApp->Settings()->getDefaultNotchWidth();
                 notchCount   = 1;
                 isNotch      = true;
-                showCutline  = true;
-                showSeamline = true;
+                showCutline  = qApp->Settings()->showSeamAllowanceNotch();
+                showSeamline = qApp->Settings()->showSeamlineNotch();
             }
 
             if (selectedAction == actionSlit)


### PR DESCRIPTION
Properly use default setting from app config when creating a default notch