### PR TITLE
feat: add multiple node selection in piece path lists

### DIFF
--- a/src/libs/vtools/dialogs/tools/dialogtool.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogtool.cpp
@@ -1309,10 +1309,16 @@ QString DialogTool::getPointName() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-// Returns the selected items sorted by row. Falls back to the current item when nothing is selected.
-static QList<QListWidgetItem *> selectedRowItems(QListWidget *list)
+// Returns the selected items sorted by row, including the anchor item (the right clicked or current
+// row) when it is not part of the selection. Falls back to the current item when nothing is selected.
+QList<QListWidgetItem *> DialogTool::selectedRowItems(QListWidget *list, QListWidgetItem *anchor)
 {
+    SCASSERT(list != nullptr)
     QList<QListWidgetItem *> items = list->selectedItems();
+    if (anchor != nullptr && !items.contains(anchor))
+    {
+        items.append(anchor);
+    }
     if (items.isEmpty() && list->currentItem() != nullptr)
     {
         items.append(list->currentItem());

--- a/src/libs/vtools/dialogs/tools/dialogtool.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogtool.cpp
@@ -58,6 +58,7 @@
 #include <QGuiApplication>
 #include <QHash>
 #include <QIcon>
+#include <QItemSelectionModel>
 #include <QKeyEvent>
 #include <QLabel>
 #include <QLineEdit>
@@ -77,10 +78,12 @@
 #include <QSize>
 #include <QTextCursor>
 #include <QTimer>
+#include <QToolButton>
 #include <QWidget>
 #include <Qt>
 #include <QtDebug>
 #include <QtMath>
+#include <algorithm>
 #include <new>
 #include <QBuffer>
 #include <QFont>
@@ -1306,59 +1309,128 @@ QString DialogTool::getPointName() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+// Returns the selected items sorted by row. Falls back to the current item when nothing is selected.
+static QList<QListWidgetItem *> selectedRowItems(QListWidget *list)
+{
+    QList<QListWidgetItem *> items = list->selectedItems();
+    if (items.isEmpty() && list->currentItem() != nullptr)
+    {
+        items.append(list->currentItem());
+    }
+    std::sort(items.begin(), items.end(), [list](QListWidgetItem *a, QListWidgetItem *b)
+    {
+        return list->row(a) < list->row(b);
+    });
+    return items;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+// Reselects the moved items and keeps the current item on one of them so consecutive moves work.
+static void restoreSelection(QListWidget *list, const QList<QListWidgetItem *> &items, QListWidgetItem *current)
+{
+    list->clearSelection();
+    for (QListWidgetItem *item : items)
+    {
+        item->setSelected(true);
+    }
+    if (!items.contains(current))
+    {
+        current = items.first();
+    }
+    list->setCurrentItem(current, QItemSelectionModel::NoUpdate);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 void DialogTool::moveListRowTop(QListWidget *list)
 {
     SCASSERT(list != nullptr)
-    const int currentIndex = list->currentRow();
-    if (QListWidgetItem *currentItem = list->takeItem(currentIndex))
+    const QList<QListWidgetItem *> items = selectedRowItems(list);
+    if (items.isEmpty())
     {
-        list->insertItem(0, currentItem);
-        list->setCurrentRow(0);
+        return;
     }
+    QListWidgetItem *current = list->currentItem();
+    for (QListWidgetItem *item : items)
+    {
+        list->takeItem(list->row(item));
+    }
+    for (int i = 0; i < items.size(); ++i)
+    {
+        list->insertItem(i, items.at(i));
+    }
+    restoreSelection(list, items, current);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void DialogTool::moveListRowUp(QListWidget *list)
 {
     SCASSERT(list != nullptr)
-    int currentIndex = list->currentRow();
-    if (QListWidgetItem *currentItem = list->takeItem(currentIndex--))
+    const QList<QListWidgetItem *> items = selectedRowItems(list);
+    if (items.isEmpty() || list->row(items.first()) == 0)
     {
-        if (currentIndex < 0)
-        {
-            currentIndex = 0;
-        }
-        list->insertItem(currentIndex, currentItem);
-        list->setCurrentRow(currentIndex);
+        return;
     }
+    QListWidgetItem *current = list->currentItem();
+    for (QListWidgetItem *item : items)
+    {
+        const int row = list->row(item);
+        list->takeItem(row);
+        list->insertItem(row - 1, item);
+    }
+    restoreSelection(list, items, current);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void DialogTool::moveListRowDown(QListWidget *list)
 {
     SCASSERT(list != nullptr)
-    int currentIndex = list->currentRow();
-    if (QListWidgetItem *currentItem = list->takeItem(currentIndex++))
+    const QList<QListWidgetItem *> items = selectedRowItems(list);
+    if (items.isEmpty() || list->row(items.last()) == list->count() - 1)
     {
-        if (currentIndex > list->count())
-        {
-            currentIndex = list->count();
-        }
-        list->insertItem(currentIndex, currentItem);
-        list->setCurrentRow(currentIndex);
+        return;
     }
+    QListWidgetItem *current = list->currentItem();
+    for (int i = items.size() - 1; i >= 0; --i)
+    {
+        const int row = list->row(items.at(i));
+        list->takeItem(row);
+        list->insertItem(row + 1, items.at(i));
+    }
+    restoreSelection(list, items, current);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void DialogTool::moveListRowBottom(QListWidget *list)
 {
     SCASSERT(list != nullptr)
-    const int currentIndex = list->currentRow();
-    if (QListWidgetItem *currentItem = list->takeItem(currentIndex))
+    const QList<QListWidgetItem *> items = selectedRowItems(list);
+    if (items.isEmpty())
     {
-        list->insertItem(list->count(), currentItem);
-        list->setCurrentRow(list->count()-1);
+        return;
     }
+    QListWidgetItem *current = list->currentItem();
+    for (QListWidgetItem *item : items)
+    {
+        list->takeItem(list->row(item));
+        list->insertItem(list->count(), item);
+    }
+    restoreSelection(list, items, current);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void DialogTool::setMoveButtonState(QListWidget *list, QToolButton *top, QToolButton *up,
+                                    QToolButton *down, QToolButton *bottom)
+{
+    SCASSERT(list != nullptr)
+    const QList<QListWidgetItem *> items = selectedRowItems(list);
+    const bool has_selection = list->count() > 1 && !items.isEmpty();
+    const bool can_move_up   = has_selection && list->row(items.first()) > 0;
+    const bool can_move_down = has_selection && list->row(items.last()) < list->count() - 1;
+
+    top->setEnabled(can_move_up);
+    up->setEnabled(can_move_up);
+    down->setEnabled(can_move_down);
+    bottom->setEnabled(can_move_down);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogtool.h
+++ b/src/libs/vtools/dialogs/tools/dialogtool.h
@@ -92,6 +92,7 @@ Q_DECLARE_LOGGING_CATEGORY(vDialog)
 class QDoubleSpinBox;
 class QLabel;
 class QPlainTextEdit;
+class QToolButton;
 class VAbstractTool;
 
 enum class FillComboBox : char {Whole, NoChildren};
@@ -123,6 +124,8 @@ public:
     static void      moveListRowUp(QListWidget *list);
     static void      moveListRowDown(QListWidget *list);
     static void      moveListRowBottom(QListWidget *list);
+    static void      setMoveButtonState(QListWidget *list, QToolButton *top, QToolButton *up,
+                                        QToolButton *down, QToolButton *bottom);
 
 signals:
     /**

--- a/src/libs/vtools/dialogs/tools/dialogtool.h
+++ b/src/libs/vtools/dialogs/tools/dialogtool.h
@@ -126,6 +126,7 @@ public:
     static void      moveListRowBottom(QListWidget *list);
     static void      setMoveButtonState(QListWidget *list, QToolButton *top, QToolButton *up,
                                         QToolButton *down, QToolButton *bottom);
+    static QList<QListWidgetItem *> selectedRowItems(QListWidget *list, QListWidgetItem *anchor = nullptr);
 
 signals:
     /**

--- a/src/libs/vtools/dialogs/tools/piece/internal_path_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/internal_path_dialog.cpp
@@ -305,7 +305,12 @@ void InternalPathDialog::showContextMenu(const QPoint &pos)
     QAction *selectedAction = menu->exec(ui->listWidget->viewport()->mapToGlobal(pos));
     if (selectedAction == actionDelete)
     {
-        delete ui->listWidget->item(row);
+        QList<QListWidgetItem *> items = ui->listWidget->selectedItems();
+        if (!items.contains(rowItem))
+        {
+            items.append(rowItem); // the right clicked row may not be part of the selection
+        }
+        qDeleteAll(items); // deleting an item also removes it from the list
     }
     else if (rowNode.GetTypeTool() != Tool::NodePoint && selectedAction == actionReverse)
     {

--- a/src/libs/vtools/dialogs/tools/piece/internal_path_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/internal_path_dialog.cpp
@@ -1376,31 +1376,8 @@ QString InternalPathDialog::getSeamAllowanceWidthFormulaAfter() const
 //---------------------------------------------------------------------------------------------------------------------
 void InternalPathDialog::setMoveExclusions()
 {
-    ui->moveTop_ToolButton->setEnabled(false);
-    ui->moveUp_ToolButton->setEnabled(false);
-    ui->moveDown_ToolButton->setEnabled(false);
-    ui->moveBottom_ToolButton->setEnabled(false);
-
-    if (ui->listWidget->count() > 1)
-    {
-        if (ui->listWidget->currentRow() == 0)
-        {
-            ui->moveDown_ToolButton->setEnabled(true);
-            ui->moveBottom_ToolButton->setEnabled(true);
-        }
-        else if (ui->listWidget->currentRow() == ui->listWidget->count() - 1)
-        {
-            ui->moveTop_ToolButton->setEnabled(true);
-            ui->moveUp_ToolButton->setEnabled(true);
-        }
-        else
-        {
-            ui->moveTop_ToolButton->setEnabled(true);
-            ui->moveUp_ToolButton->setEnabled(true);
-            ui->moveDown_ToolButton->setEnabled(true);
-            ui->moveBottom_ToolButton->setEnabled(true);
-        }
-    }
+    setMoveButtonState(ui->listWidget, ui->moveTop_ToolButton, ui->moveUp_ToolButton,
+                       ui->moveDown_ToolButton, ui->moveBottom_ToolButton);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/piece/internal_path_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/internal_path_dialog.cpp
@@ -303,22 +303,33 @@ void InternalPathDialog::showContextMenu(const QPoint &pos)
     QAction *actionDelete = menu->addAction(QIcon::fromTheme("edit-delete"), tr("Delete"));
 
     QAction *selectedAction = menu->exec(ui->listWidget->viewport()->mapToGlobal(pos));
+    if (selectedAction == nullptr)
+    {
+        return; // menu dismissed
+    }
+
+    const QList<QListWidgetItem *> items = selectedRowItems(ui->listWidget, rowItem);
+
     if (selectedAction == actionDelete)
     {
-        QList<QListWidgetItem *> items = ui->listWidget->selectedItems();
-        if (!items.contains(rowItem))
-        {
-            items.append(rowItem); // the right clicked row may not be part of the selection
-        }
         qDeleteAll(items); // deleting an item also removes it from the list
     }
     else if (rowNode.GetTypeTool() != Tool::NodePoint && selectedAction == actionReverse)
     {
-        rowNode.SetReverse(!rowNode.GetReverse());
-        info = getNodeInfo(rowNode, true);
-        rowItem->setData(Qt::UserRole, QVariant::fromValue(rowNode));
-        rowItem->setIcon(QIcon(info.icon));
-        rowItem->setText(info.name);
+        const bool reverse = !rowNode.GetReverse();
+        for (QListWidgetItem *item : items)
+        {
+            VPieceNode node = qvariant_cast<VPieceNode>(item->data(Qt::UserRole));
+            if (node.GetTypeTool() == Tool::NodePoint)
+            {
+                continue;
+            }
+            node.SetReverse(reverse);
+            info = getNodeInfo(node, true);
+            item->setData(Qt::UserRole, QVariant::fromValue(node));
+            item->setIcon(QIcon(info.icon));
+            item->setText(info.name);
+        }
     }
     //else if (selectedAction == actionNotch)
     //{

--- a/src/libs/vtools/dialogs/tools/piece/internal_path_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/piece/internal_path_dialog.ui
@@ -174,6 +174,9 @@
             <property name="dragDropMode">
              <enum>QAbstractItemView::InternalMove</enum>
             </property>
+            <property name="selectionMode">
+             <enum>QAbstractItemView::ExtendedSelection</enum>
+            </property>
            </widget>
           </item>
           <item>

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
@@ -617,9 +617,31 @@ bool PatternPieceDialog::eventFilter(QObject *object, QEvent *event)
 
             QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
 
+            switch (keyEvent->key())
+            {
+                case Qt::Key_Up:
+                case Qt::Key_Down:
+                case Qt::Key_Left:
+                case Qt::Key_Right:
+                case Qt::Key_Home:
+                case Qt::Key_End:
+                case Qt::Key_PageUp:
+                case Qt::Key_PageDown:
+                    return false; // let the list widget handle navigation and range selection
+                default:
+                    break;
+            }
+            if (keyEvent->matches(QKeySequence::SelectAll))
+            {
+                return false; // let the list widget handle select all
+            }
+
             if (keyEvent->key() == Qt::Key_Delete)
             {
-                delete rowItem;
+                qDeleteAll(list->selectedItems()); // deleting an item also removes it from the list
+                validateObjects(isMainPathValid());
+                nodeListChanged();
+                return true; // items are gone - do not fall through
             }
             if (keyEvent->modifiers() & Qt::ControlModifier)
             {
@@ -3653,31 +3675,8 @@ void PatternPieceDialog::showAnchorPoints()
 //---------------------------------------------------------------------------------------------------------------------
 void PatternPieceDialog::setMoveExclusions()
 {
-    ui->moveTop_ToolButton->setEnabled(false);
-    ui->moveUp_ToolButton->setEnabled(false);
-    ui->moveDown_ToolButton->setEnabled(false);
-    ui->moveBottom_ToolButton->setEnabled(false);
-
-    if (ui->mainPath_ListWidget->count() > 1)
-    {
-        if (ui->mainPath_ListWidget->currentRow() == 0)
-        {
-            ui->moveDown_ToolButton->setEnabled(true);
-            ui->moveBottom_ToolButton->setEnabled(true);
-        }
-        else if (ui->mainPath_ListWidget->currentRow() == ui->mainPath_ListWidget->count() - 1)
-        {
-            ui->moveTop_ToolButton->setEnabled(true);
-            ui->moveUp_ToolButton->setEnabled(true);
-        }
-        else
-        {
-            ui->moveTop_ToolButton->setEnabled(true);
-            ui->moveUp_ToolButton->setEnabled(true);
-            ui->moveDown_ToolButton->setEnabled(true);
-            ui->moveBottom_ToolButton->setEnabled(true);
-        }
-    }
+    setMoveButtonState(ui->mainPath_ListWidget, ui->moveTop_ToolButton, ui->moveUp_ToolButton,
+                       ui->moveDown_ToolButton, ui->moveBottom_ToolButton);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
@@ -957,7 +957,15 @@ void PatternPieceDialog::showMainPathContextMenu(const QPoint &pos)
     QAction *selectedAction = menu->exec(ui->mainPath_ListWidget->viewport()->mapToGlobal(pos));
     if (selectedAction == actionDelete)
     {
-        delete ui->mainPath_ListWidget->item(row);
+        QList<QListWidgetItem *> items = ui->mainPath_ListWidget->selectedItems();
+        if (!items.contains(rowItem))
+        {
+            items.append(rowItem); // the right clicked row may not be part of the selection
+        }
+        qDeleteAll(items); // deleting an item also removes it from the list
+        validateObjects(isMainPathValid());
+        nodeListChanged();
+        return; // items are gone - do not fall through to setNotch
     }
     else if (rowNode.GetTypeTool() != Tool::NodePoint && selectedAction == actionReverse)
     {

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
@@ -638,107 +638,106 @@ bool PatternPieceDialog::eventFilter(QObject *object, QEvent *event)
 
             if (keyEvent->key() == Qt::Key_Delete)
             {
-                qDeleteAll(list->selectedItems()); // deleting an item also removes it from the list
+                qDeleteAll(selectedRowItems(list, rowItem)); // deleting an item also removes it from the list
                 validateObjects(isMainPathValid());
                 nodeListChanged();
                 return true; // items are gone - do not fall through
             }
             if (keyEvent->modifiers() & Qt::ControlModifier)
             {
+                const QList<QListWidgetItem *> items = selectedRowItems(list, rowItem);
+                const VPieceNode rowNode = qvariant_cast<VPieceNode>(rowItem->data(Qt::UserRole));
+
                 switch (keyEvent->key())
                 {
                     case Qt::Key_R:
                     {
-                        reverseNode(rowItem);
+                        if (rowNode.GetTypeTool() != Tool::NodePoint) // a point cannot anchor the reverse state
+                        {
+                            const bool reverse = !rowNode.GetReverse();
+                            for (QListWidgetItem *item : items)
+                            {
+                                reverseNode(item, reverse); // skips point nodes
+                            }
+                        }
                         break;
                     }
                     case Qt::Key_D:
                     {
-                        duplicateNode(rowItem);
+                        for (QListWidgetItem *item : items)
+                        {
+                            duplicateNode(item); // skips point nodes
+                        }
                         break;
                     }
                     case Qt::Key_E:
                     {
-                        excludeNode(rowItem);
+                        const bool exclude = !rowNode.isExcluded();
+                        for (QListWidgetItem *item : items)
+                        {
+                            excludeNode(item, exclude);
+                        }
                         break;
                     }
                 }
             }
             else if (keyEvent->modifiers() & Qt::ShiftModifier)
             {
-                VPieceNode rowNode        = qvariant_cast<VPieceNode>(rowItem->data(Qt::UserRole));
-                bool showCutline          = rowNode.showNotch();
-                bool showSeamline         = rowNode.showSeamlineNotch();
-                NotchType notchType       = rowNode.getNotchType();
-                NotchSubType notchSubType = rowNode.getNotchSubType();
-                qreal notchLength         = rowNode.getNotchLength();
-                qreal notchWidth          = rowNode.getNotchWidth();
-                int notchCount            = rowNode.getNotchCount();
-
-                switch (keyEvent->key())
+                const QList<QListWidgetItem *> items = selectedRowItems(list, rowItem);
+                for (QListWidgetItem *item : items)
                 {
-                    case Qt::Key_S:
+                    VPieceNode node = qvariant_cast<VPieceNode>(item->data(Qt::UserRole));
+                    if (node.GetTypeTool() != Tool::NodePoint)
                     {
-                        setNotch(rowItem, true, showCutline, showSeamline, NotchType::Slit,
-                                 notchSubType, notchLength, notchWidth, notchCount);
-                        break;
+                        continue;
                     }
-                    case Qt::Key_T:
+
+                    bool showCutline          = node.showNotch();
+                    bool showSeamline         = node.showSeamlineNotch();
+                    NotchType notchType       = node.getNotchType();
+                    NotchSubType notchSubType = node.getNotchSubType();
+                    qreal notchLength         = node.getNotchLength();
+                    qreal notchWidth          = node.getNotchWidth();
+                    int notchCount            = node.getNotchCount();
+
+                    switch (keyEvent->key())
                     {
-                        setNotch(rowItem,true, showCutline, showSeamline, NotchType::TNotch,
-                                 notchSubType, notchLength, notchWidth, notchCount);
-                        break;
+                        case Qt::Key_S:
+                            notchType = NotchType::Slit;
+                            break;
+                        case Qt::Key_T:
+                            notchType = NotchType::TNotch;
+                            break;
+                        case Qt::Key_U:
+                            notchType = NotchType::UNotch;
+                            break;
+                        case Qt::Key_I:
+                            notchType = NotchType::VInternal;
+                            break;
+                        case Qt::Key_E:
+                            notchType = NotchType::VExternal;
+                            break;
+                        case Qt::Key_C:
+                            notchType = NotchType::Castle;
+                            break;
+                        case Qt::Key_D:
+                            notchType = NotchType::Diamond;
+                            break;
+                        case Qt::Key_F:
+                            notchSubType = NotchSubType::Straightforward;
+                            break;
+                        case Qt::Key_B:
+                            notchSubType = NotchSubType::Bisector;
+                            break;
+                        case Qt::Key_X:
+                            notchSubType = NotchSubType::Intersection;
+                            break;
+                        default:
+                            continue; // not a notch shortcut
                     }
-                    case Qt::Key_U:
-                    {
-                        setNotch(rowItem,true, showCutline, showSeamline, NotchType::UNotch,
-                                 notchSubType, notchLength, notchWidth, notchCount);
-                        break;
-                    }
-                    case Qt::Key_I:
-                    {
-                        setNotch(rowItem,true, showCutline, showSeamline, NotchType::VInternal,
-                                 notchSubType, notchLength, notchWidth, notchCount);
-                        break;
-                    }
-                    case Qt::Key_E:
-                    {
-                        setNotch(rowItem,true, showCutline, showSeamline, NotchType::VExternal,
-                                 notchSubType, notchLength, notchWidth, notchCount);
-                        break;
-                    }
-                    case Qt::Key_C:
-                    {
-                        setNotch(rowItem,true, showCutline, showSeamline, NotchType::Castle,
-                                 notchSubType, notchLength, notchWidth, notchCount);
-                        break;
-                    }
-                    case Qt::Key_D:
-                    {
-                        setNotch(rowItem,true, showCutline, showSeamline, NotchType::Diamond,
-                                 notchSubType, notchLength, notchWidth, notchCount);
-                        break;
-                    }
-                    case Qt::Key_F:
-                    {
-                        setNotch(rowItem,true, showCutline, showSeamline, notchType,
-                                 NotchSubType::Straightforward, notchLength, notchWidth, notchCount);
-                        break;
-                    }
-                    case Qt::Key_B:
-                    {
-                        setNotch(rowItem,true, showCutline, showSeamline, notchType,
-                                 NotchSubType::Bisector, notchLength, notchWidth, notchCount);
-                        break;
-                    }
-                    case Qt::Key_X:
-                    {
-                        setNotch(rowItem,true, showCutline, showSeamline, notchType,
-                                 NotchSubType::Intersection, notchLength, notchWidth, notchCount);
-                        break;
-                    }
-                    default:
-                        break;
+
+                    setNotch(item, true, showCutline, showSeamline, notchType,
+                             notchSubType, notchLength, notchWidth, notchCount);
                 }
             }
             validateObjects(isMainPathValid());
@@ -860,15 +859,6 @@ void PatternPieceDialog::showMainPathContextMenu(const QPoint &pos)
 
     // workaround for https://bugreports.qt.io/browse/QTBUG-97559: assign parent to QMenu
     QScopedPointer<QMenu> menu(new QMenu(ui->mainPath_ListWidget));
-    NodeInfo info;
-    NotchType notchType       = rowNode.getNotchType();
-    NotchSubType notchSubType = rowNode.getNotchSubType();
-    qreal notchLength         = rowNode.getNotchLength();
-    qreal notchWidth          = rowNode.getNotchWidth();
-    int notchCount            = rowNode.getNotchCount();
-    bool isNotch              = rowNode.isNotch();
-    bool showCutline          = rowNode.showNotch();
-    bool showSeamline         = rowNode.showSeamlineNotch();
 
     QAction *actionShowCutNotch   = nullptr;
     QAction *actionShowSeamNotch  = nullptr;
@@ -908,19 +898,19 @@ void PatternPieceDialog::showMainPathContextMenu(const QPoint &pos)
     {
         actionShowCutNotch = menu->addAction(checkIcon, tr("Show Cut Line Notch"));
         actionShowCutNotch->setCheckable(true);
-        actionShowCutNotch->setChecked(showCutline && isNotch);
-        actionShowCutNotch->setEnabled(isNotch);
+        actionShowCutNotch->setChecked(rowNode.showNotch() && rowNode.isNotch());
+        actionShowCutNotch->setEnabled(rowNode.isNotch());
 
         actionShowSeamNotch = menu->addAction(checkIcon, tr("Show Seam Line Notch"));
         actionShowSeamNotch->setCheckable(true);
-        actionShowSeamNotch->setChecked(showSeamline && isNotch);
-        actionShowSeamNotch->setEnabled(isNotch && !isBuiltInSA && !isHideSeamline);
+        actionShowSeamNotch->setChecked(rowNode.showSeamlineNotch() && rowNode.isNotch());
+        actionShowSeamNotch->setEnabled(rowNode.isNotch() && !isBuiltInSA && !isHideSeamline);
 
         actionDefaultNotch = menu->addAction(tr("Make Default Notch"));
 
         QMenu *notchMenu = menu->addMenu(tr("Edit Notch"));
         actionNotch = notchMenu->menuAction();
-        notchMenu->setEnabled(isNotch);
+        notchMenu->setEnabled(rowNode.isNotch());
 
         QMenu *notchTypeMenu = notchMenu->addMenu(tr("Type"));
         actionSlit      = notchTypeMenu->addAction(QIcon("://icon/24x24/slit_notch.png"),       tr("Slit") + QStringLiteral("\tShift + S"));
@@ -955,126 +945,168 @@ void PatternPieceDialog::showMainPathContextMenu(const QPoint &pos)
     QAction *actionDelete = menu->addAction(QIcon::fromTheme("edit-delete"), tr("Delete") + QStringLiteral("\tDel"));
 
     QAction *selectedAction = menu->exec(ui->mainPath_ListWidget->viewport()->mapToGlobal(pos));
+    if (selectedAction == nullptr)
+    {
+        return; // menu dismissed - on curve rows the notch actions are null and would falsely match below
+    }
+
+    const QList<QListWidgetItem *> items = selectedRowItems(ui->mainPath_ListWidget, rowItem);
+
     if (selectedAction == actionDelete)
     {
-        QList<QListWidgetItem *> items = ui->mainPath_ListWidget->selectedItems();
-        if (!items.contains(rowItem))
-        {
-            items.append(rowItem); // the right clicked row may not be part of the selection
-        }
         qDeleteAll(items); // deleting an item also removes it from the list
         validateObjects(isMainPathValid());
         nodeListChanged();
-        return; // items are gone - do not fall through to setNotch
+        return; // items are gone - do not fall through
     }
     else if (rowNode.GetTypeTool() != Tool::NodePoint && selectedAction == actionReverse)
     {
-        reverseNode(rowItem);
+        const bool reverse = !rowNode.GetReverse();
+        for (QListWidgetItem *item : items)
+        {
+            reverseNode(item, reverse); // skips point nodes
+        }
     }
     else if (rowNode.GetTypeTool() != Tool::NodePoint && selectedAction == actionDuplicate)
     {
-        duplicateNode(rowItem);
+        for (QListWidgetItem *item : items)
+        {
+            duplicateNode(item); // skips point nodes
+        }
     }
     else if (selectedAction == actionExcluded)
     {
-        excludeNode(rowItem);
+        const bool exclude = !rowNode.isExcluded();
+        for (QListWidgetItem *item : items)
+        {
+            excludeNode(item, exclude);
+        }
     }
-    else if (selectedAction == actionShowCutNotch)
+    else // notch actions - apply to every selected point node, keeping its other notch settings
     {
-        showCutline = !showCutline;
-    }
+        const bool newShowCutline  = !rowNode.showNotch();
+        const bool newShowSeamline = !rowNode.showSeamlineNotch();
 
-    else if (selectedAction == actionShowSeamNotch)
-    {
-        showSeamline = !showSeamline;
-    }
+        for (QListWidgetItem *item : items)
+        {
+            VPieceNode node = qvariant_cast<VPieceNode>(item->data(Qt::UserRole));
+            if (node.GetTypeTool() != Tool::NodePoint)
+            {
+                continue;
+            }
 
-    else if (selectedAction == actionDefaultNotch)
-    {
-        notchType    = stringToNotchType(qApp->Settings()->getDefaultNotchType());
-        notchSubType = NotchSubType::Straightforward;
-        notchLength  = qApp->Settings()->getDefaultNotchLength();
-        notchWidth   = qApp->Settings()->getDefaultNotchWidth();
-        notchCount   = 1;
-        isNotch      = true;
-        showCutline  = true;
-        showSeamline = true;
-    }
+            NotchType notchType       = node.getNotchType();
+            NotchSubType notchSubType = node.getNotchSubType();
+            qreal notchLength         = node.getNotchLength();
+            qreal notchWidth          = node.getNotchWidth();
+            int notchCount            = node.getNotchCount();
+            bool isNotch              = node.isNotch();
+            bool showCutline          = node.showNotch();
+            bool showSeamline         = node.showSeamlineNotch();
 
-    else if (selectedAction == actionSlit)
-    {
-        isNotch = true;
-        notchType = NotchType::Slit;
-    }
-    else if (selectedAction == actionTNotch)
-    {
-        isNotch = true;
-        notchType = NotchType::TNotch;
-    }
-    else if (selectedAction == actionUNotch)
-    {
-        isNotch = true;
-        notchType = NotchType::UNotch;
-    }
-    else if (selectedAction == actionVInternal)
-    {
-        isNotch = true;
-        notchType = NotchType::VInternal;
-    }
-    else if (selectedAction == actionVExternal)
-    {
-        isNotch = true;
-        notchType = NotchType::VExternal;
-    }
-    else if (selectedAction == actionCastle)
-    {
-        isNotch = true;
-        notchType = NotchType::Castle;
-    }
-    else if (selectedAction == actionDiamond)
-    {
-        isNotch = true;
-        notchType = NotchType::Diamond;
-    }
-    else if (selectedAction == actionStraightforward)
-    {
-        isNotch = true;
-        notchSubType = NotchSubType::Straightforward;
-    }
-    else if (selectedAction == actionBisector)
-    {
-        isNotch = true;
-        notchSubType = NotchSubType::Bisector;
-    }
-    else if (selectedAction == actionIntersection)
-    {
-        isNotch = true;
-        notchSubType = NotchSubType::Intersection;
-    }
-    else if (selectedAction == action1Notch)
-    {
-        isNotch = true;
-        notchCount = 1;
-    }
-    else if (selectedAction == action2Notch)
-    {
-        isNotch = true;
-        notchCount = 2;
-    }
-    else if (selectedAction == action3Notch)
-    {
-        isNotch = true;
-        notchCount = 3;
-    }
-    else if (selectedAction == actionRemoveNotch)
-    {
-        isNotch      = false;
-        showCutline  = true;
-        showSeamline = true;
-    }
+            if (selectedAction == actionShowCutNotch)
+            {
+                if (!isNotch)
+                {
+                    continue; // only meaningful on nodes that have a notch
+                }
+                showCutline = newShowCutline;
+            }
+            else if (selectedAction == actionShowSeamNotch)
+            {
+                if (!isNotch)
+                {
+                    continue;
+                }
+                showSeamline = newShowSeamline;
+            }
+            else if (selectedAction == actionDefaultNotch)
+            {
+                notchType    = stringToNotchType(qApp->Settings()->getDefaultNotchType());
+                notchSubType = NotchSubType::Straightforward;
+                notchLength  = qApp->Settings()->getDefaultNotchLength();
+                notchWidth   = qApp->Settings()->getDefaultNotchWidth();
+                notchCount   = 1;
+                isNotch      = true;
+                showCutline  = true;
+                showSeamline = true;
+            }
+            else if (selectedAction == actionSlit)
+            {
+                isNotch = true;
+                notchType = NotchType::Slit;
+            }
+            else if (selectedAction == actionTNotch)
+            {
+                isNotch = true;
+                notchType = NotchType::TNotch;
+            }
+            else if (selectedAction == actionUNotch)
+            {
+                isNotch = true;
+                notchType = NotchType::UNotch;
+            }
+            else if (selectedAction == actionVInternal)
+            {
+                isNotch = true;
+                notchType = NotchType::VInternal;
+            }
+            else if (selectedAction == actionVExternal)
+            {
+                isNotch = true;
+                notchType = NotchType::VExternal;
+            }
+            else if (selectedAction == actionCastle)
+            {
+                isNotch = true;
+                notchType = NotchType::Castle;
+            }
+            else if (selectedAction == actionDiamond)
+            {
+                isNotch = true;
+                notchType = NotchType::Diamond;
+            }
+            else if (selectedAction == actionStraightforward)
+            {
+                isNotch = true;
+                notchSubType = NotchSubType::Straightforward;
+            }
+            else if (selectedAction == actionBisector)
+            {
+                isNotch = true;
+                notchSubType = NotchSubType::Bisector;
+            }
+            else if (selectedAction == actionIntersection)
+            {
+                isNotch = true;
+                notchSubType = NotchSubType::Intersection;
+            }
+            else if (selectedAction == action1Notch)
+            {
+                isNotch = true;
+                notchCount = 1;
+            }
+            else if (selectedAction == action2Notch)
+            {
+                isNotch = true;
+                notchCount = 2;
+            }
+            else if (selectedAction == action3Notch)
+            {
+                isNotch = true;
+                notchCount = 3;
+            }
+            else if (selectedAction == actionRemoveNotch)
+            {
+                isNotch      = false;
+                showCutline  = true;
+                showSeamline = true;
+            }
 
-    setNotch(rowItem, isNotch, showCutline, showSeamline, notchType,
-             notchSubType, notchLength, notchWidth, notchCount);
+            setNotch(item, isNotch, showCutline, showSeamline, notchType,
+                     notchSubType, notchLength, notchWidth, notchCount);
+        }
+    }
 
     validateObjects(isMainPathValid());
     nodeListChanged();
@@ -3710,15 +3742,16 @@ QString PatternPieceDialog::createPieceName() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/// @brief Reverses the selected node points if the node is a curve.
+/// @brief Sets the reverse state of the node if the node is a curve.
 /// @param rowItem list widget item of the selected row.
+/// @param reverse new reverse state.
 //---------------------------------------------------------------------------------------------------------------------
- void PatternPieceDialog::reverseNode(QListWidgetItem *rowItem)
+ void PatternPieceDialog::reverseNode(QListWidgetItem *rowItem, bool reverse)
 {
     VPieceNode rowNode = qvariant_cast<VPieceNode>(rowItem->data(Qt::UserRole));
     if (rowNode.GetTypeTool() != Tool::NodePoint)
     {
-        rowNode.SetReverse(!rowNode.GetReverse());
+        rowNode.SetReverse(reverse);
         NodeInfo info;
         info = getNodeInfo(rowNode, true);
         rowItem->setData(Qt::UserRole, QVariant::fromValue(rowNode));
@@ -3742,14 +3775,15 @@ QString PatternPieceDialog::createPieceName() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/// @brief Toggles the exclude state of the selected node.
+/// @brief Sets the exclude state of the node.
 /// @param rowItem list widget item of the selected row.
+/// @param exclude new exclude state.
 //---------------------------------------------------------------------------------------------------------------------
- void PatternPieceDialog::excludeNode(QListWidgetItem *rowItem)
+ void PatternPieceDialog::excludeNode(QListWidgetItem *rowItem, bool exclude)
 {
     NodeInfo info;
     VPieceNode rowNode = qvariant_cast<VPieceNode>(rowItem->data(Qt::UserRole));
-    rowNode.SetExcluded(!rowNode.isExcluded());
+    rowNode.SetExcluded(exclude);
     info = getNodeInfo(rowNode, true);
     rowItem->setData(Qt::UserRole, QVariant::fromValue(rowNode));
     rowItem->setIcon(QIcon(info.icon));

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.h
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.h
@@ -286,9 +286,9 @@ private:
     void                        setMoveExclusions();
 
     QString                     createPieceName() const;
-    void                        reverseNode(QListWidgetItem *rowItem);
+    void                        reverseNode(QListWidgetItem *rowItem, bool reverse);
     void                        duplicateNode(QListWidgetItem *rowItem);
-    void                        excludeNode(QListWidgetItem *rowItem);
+    void                        excludeNode(QListWidgetItem *rowItem, bool exclude);
     void                        setNotch(QListWidgetItem *rowItem, bool isNotch, bool showCutline, bool showSeamline,
                                          NotchType notchType, NotchSubType notchSubType, qreal notchLength,
                                          qreal notchWidth, int notchCount);

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
@@ -1132,6 +1132,9 @@ QListWidget::item:selected {
                <property name="dragDropMode">
                 <enum>QAbstractItemView::InternalMove</enum>
                </property>
+               <property name="selectionMode">
+                <enum>QAbstractItemView::ExtendedSelection</enum>
+               </property>
               </widget>
              </item>
              <item>


### PR DESCRIPTION


You can now Ctrl or Shift select several rows in the main path list
and move them together with the move buttons, drag them as a group
or delete them in one go. Works in the internal paths dialog too
since both share the same code.

Single selection behaves exactly like before.

Btw I found two hidden crashes while working on the delete key, both
were deleting a row then still using the freed pointer, one on
Shift+Delete and one on every right click Delete.  i Fixed both  :)



and I watched the recap of the last meeting  @DSCaskey @slspencer I was happy
guys when you talked about my big fix....

And about my last PR I also learned that the hard way :/  @DSCaskey 

Closes #1466 