### PR TITLE
fix: ignore Qt Wayland text input warning issue-#1641

### DIFF
--- a/src/app/seamly2d/core/application_2d.cpp
+++ b/src/app/seamly2d/core/application_2d.cpp
@@ -93,6 +93,15 @@ constexpr auto DAYS_TO_KEEP_LOGS = 3;
 //---------------------------------------------------------------------------------------------------------------------
 inline void noisyFailureMsgHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
+    // Qt's Wayland plugin warns on every focus change when the compositor sends a text input leave
+    // event for a surface it isn't tracking. The plugin carries on as normal after logging it, so
+    // it is noise. Drop it instead of logging it and popping up a dialog on every interaction.
+    if ((type == QtWarningMsg) && msg.contains(QStringLiteral("zwp_text_input_v3_leave"))
+            && msg.contains(QStringLiteral("Got leave event for surface")))
+    {
+        return;
+    }
+
     // Why on earth didn't Qt want to make failed signal/slot connections qWarning?
     if ((type == QtDebugMsg) && msg.contains(QStringLiteral("::connect")))
     {

--- a/src/app/seamlyme/application_me.cpp
+++ b/src/app/seamlyme/application_me.cpp
@@ -95,6 +95,15 @@ inline void noisyFailureMsgHandler(QtMsgType type, const QMessageLogContext &con
 {
     Q_UNUSED(context)
 
+    // Qt's Wayland plugin warns on every focus change when the compositor sends a text input leave
+    // event for a surface it isn't tracking. The plugin carries on as normal after logging it, so
+    // it is noise. Drop it instead of logging it and popping up a dialog on every interaction.
+    if ((type == QtWarningMsg) && msg.contains(QStringLiteral("zwp_text_input_v3_leave"))
+            && msg.contains(QStringLiteral("Got leave event for surface")))
+    {
+        return;
+    }
+
     // Why on earth didn't Qt want to make failed signal/slot connections qWarning?
     if ((type == QtDebugMsg) && msg.contains(QStringLiteral("::connect")))
     {


### PR DESCRIPTION

The error itself is just noise from Qt's Wayland code so The real problem is on our
side  Seamly2D shows every Qt warning as a dialog  that's why it pops on every click.

This drops that message completely no popup and no log....

Closes #1641