### PR TITLE
docs: correct and complete Linux build dependencies

### DIFF
--- a/.github/README-DEVELOPER.md
+++ b/.github/README-DEVELOPER.md
@@ -85,11 +85,15 @@ Read [.github\CONTRIBUTING.md](.github\CONTRIBUTING.md) to get started on GitFlo
 * Install Additional libraries
 
   * gnu compiler
-  * poppler (pdftops)
-  * Example for Ubuntu 22.04:
+  * poppler (pdftops) - required to create PS or EPS layout files
+  * xerces-c - required to build the `ifc` library
+  * OpenGL and xkbcommon headers - required to build against Qt GUI
+  * libxcb-cursor0 - required at runtime by the Qt xcb platform plugin (Qt 6.5 and later)
+  * Example for Ubuntu 22.04 and 24.04:
 
 ```bash
-sudo apt install -y build-essential git poppler-tools
+sudo apt install -y build-essential git poppler-utils \
+    libxerces-c-dev libgl1-mesa-dev libxkbcommon-dev libxcb-cursor0
 ```
 
 * Build and install:


### PR DESCRIPTION
## Problem

The documented Linux dependency command in `.github/README-DEVELOPER.md` fails on a clean Ubuntu system:

```
$ sudo apt install -y build-essential git poppler-tools
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package poppler-tools
```

`poppler-tools` does not exist. The package that provides `pdftops` is `poppler-utils`. Because apt aborts on the first unlocatable package, a new contributor is stopped at the very first step.

Four genuinely required packages were also missing from the list:

| Package | Why it's needed | Failure without it |
|---|---|---|
| `libxerces-c-dev` | `src/libs/ifc/xml/vdomdocument.cpp` includes `<xercesc/...>`; `src/libs/libs.pri` notes Linux takes xerces from the package manager | compile error building `ifc` |
| `libgl1-mesa-dev` | Qt's `qopengl.h` requires `GL/gl.h` | `fatal error: GL/gl.h: No such file or directory` at the precompiled-header step of every library |
| `libxkbcommon-dev` | Qt GUI link dependency | link failure |
| `libxcb-cursor0` | runtime dependency of the Qt xcb platform plugin on Qt 6.5+ | builds fine, but the GUI cannot open a window: `Could not load the Qt platform plugin "xcb"` |

## Why CI doesn't catch this

`.github/workflows/ci.yml` installs `libxerces-c-dev` from its own separate list, and GitHub runners already ship the GL and xcb libraries. So the documented instructions are never exercised by CI and can drift without the build going red.

## Verification

Verified by building from a clean Ubuntu 24.04 install against Qt 6.11.1 (the version CI targets), hitting each failure in sequence, and confirming the corrected command produces a working build:

```
Seamly2D 0.6.0.1
INFO:Based on Qt 6.11.1 (GCC 13.3.0, 64 bit)
```

All seven packages confirmed to resolve via `apt-cache policy`. Package names are identical on Ubuntu 22.04 and 24.04, so the heading now covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)