### PR TITLE
fix mac font issues

### DIFF
--- a/src/app/seamly2d/mainwindowsnogui.cpp
+++ b/src/app/seamly2d/mainwindowsnogui.cpp
@@ -536,14 +536,16 @@ void MainWindowsNoGUI::PrintPages(QPrinter *printer)
     const double yscale = pageRect.height() / printerPageRect.height();
     const double scale = qMin(xscale, yscale);
 
+    QFont appFont;
+    appFont.setPointSize(8);
+
     QPainter painter;
     if (!painter.begin(printer))
     { // failed to open file
         qWarning("failed to open file, is it writable?");
         return;
     }
-
-    painter.setFont( QFont( "Arial", 8, QFont::Normal ) );
+    painter.setFont(appFont);
     painter.setRenderHint(QPainter::Antialiasing, true);
     painter.setPen(QPen(Qt::black, widthMainLine, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
     painter.setBrush ( QBrush ( Qt::NoBrush ) );
@@ -814,8 +816,12 @@ QIcon MainWindowsNoGUI::ScenePreview(int i) const
         if (!image.isNull())
         {
             image.fill(Qt::white);
+
+            QFont appFont;
+            appFont.setPointSize(8);
+
             QPainter painter(&image);
-            painter.setFont( QFont( "Arial", 8, QFont::Normal ) );
+            painter.setFont(appFont);
             painter.setRenderHint(QPainter::Antialiasing, true);
             painter.setPen(QPen(Qt::black, widthMainLine, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
             painter.setBrush ( QBrush ( Qt::NoBrush ) );
@@ -1040,13 +1046,16 @@ void MainWindowsNoGUI::exportPDF(const QString &name, QGraphicsRectItem *paper, 
         }
     }
 
+    QFont appFont;
+    appFont.setPointSize(8);
+
     QPainter painter;
     if (painter.begin(&printer) == false)
     {
         qCritical("%s", qUtf8Printable(tr("Can't open printer %1").arg(name))); // failed to open file
         return;
     }
-    painter.setFont(QFont( "Arial", 8, QFont::Normal));
+    painter.setFont(appFont);
     painter.setRenderHint(QPainter::Antialiasing, true);
     painter.setPen(QPen(Qt::black, widthMainLine, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
     painter.setBrush(QBrush(Qt::NoBrush));

--- a/src/libs/vformat/svg_generator.cpp
+++ b/src/libs/vformat/svg_generator.cpp
@@ -30,6 +30,7 @@
 #include "svg_generator.h"
 #include <QFile>
 #include <QDebug>
+#include <QFont>
 #include <QSvgGenerator>
 #include <QGraphicsItem>
 #include <QPainter>
@@ -204,9 +205,12 @@ void SvgGenerator::addSvgFromScene(QGraphicsScene *scene, QGraphicsItem *item)
     svgGenerator.setDescription(QString());
     svgGenerator.setResolution(m_resolution);
 
+    QFont appFont; 
+    appFont.setPointSize(8);
+
     QPainter painter;
     painter.begin(&svgGenerator);
-    painter.setFont( QFont( "Arial", 8, QFont::Normal ) );
+    painter.setFont(appFont);
     painter.setRenderHint(QPainter::Antialiasing, true);
     painter.setBrush ( QBrush ( Qt::NoBrush ) );
     scene->render(&painter, m_paper->rect(), m_paper->rect(), Qt::IgnoreAspectRatio);


### PR DESCRIPTION
This PR fixes the issue with the MacOs release throwing a warning for replacing missing fonts with aliases. 

The fix is to remove any use of the "Arial" font and have the app use the default application font which is native to each OS. The benefits of using the default Qfont() constructor:

> QFont appFont;
> appFont.setPointSize(8);
> painter.setFont(appFont);

**QApplication::font() (Pointer-Based Memory Copy)**
This approach copies the underlying, pre-resolved binary structure that Qt already built at application startup.

- What happens: It bypasses the string matching engine entirely. Instead of searching by a name string, it performs a highly efficient pointer copy of the existing system font data (d-pointer) through Qt's Implicit Sharing mechanism.

- The Benefit: It is guaranteed to be faster, completely eliminates any chance of a font mapping warning, and preserves any hidden platform-specific font properties that cannot be fully expressed by a simple family name string.

Closes issue #1653 