### PR TITLE
fix: abort and report the real error for unusable measurement files issue-#1275

### DIFF
--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -543,8 +543,13 @@ void MainWindow::initializeScenes()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QSharedPointer<MeasurementDoc> MainWindow::openMeasurementFile(const QString &fileName)
+QSharedPointer<MeasurementDoc> MainWindow::openMeasurementFile(const QString &fileName, bool *usable)
 {
+    if (usable != nullptr)
+    {
+        *usable = true;
+    }
+
     QSharedPointer<MeasurementDoc> measurements;
     if (fileName.isEmpty())
     {
@@ -603,6 +608,15 @@ QSharedPointer<MeasurementDoc> MainWindow::openMeasurementFile(const QString &fi
     {
         qCCritical(vMainWindow, "%s\n\n%s\n\n%s", qUtf8Printable(tr("File exception.")),
                     qUtf8Printable(exception.ErrorMessage()), qUtf8Printable(exception.DetailedInformation()));
+
+        // The document keeps the content read so far - clearing it here would make
+        // updateMeasurements() fail and bring back the sync error fixed in 4193356f6e.
+        // Only the callers that load a file report the failure, through 'usable'.
+        if (usable != nullptr)
+        {
+            *usable = false;
+        }
+
         if (!Application2D::isGUIMode())
         {
             qApp->exit(V_EX_NOINPUT);
@@ -618,9 +632,11 @@ bool MainWindow::loadMeasurements(const QString &fileName)
     // remove any extraneous LF's or trailing white space.
     removeEmptyLinesText(fileName, false);
 
-    m_measurements = openMeasurementFile(fileName);
+    bool usable = true;
+    m_measurements = openMeasurementFile(fileName, &usable);
 
-    if (m_measurements->isNull())
+    // An unusable file keeps its parsed content, so isNull() alone doesn't detect the failure.
+    if (m_measurements->isNull() || !usable)
     {
         return false;
     }
@@ -6581,8 +6597,8 @@ bool MainWindow::LoadPattern(const QString &fileName, const QString &customMeasu
 
             if (!loadMeasurements(newPath))
             {
-                qCCritical(vMainWindow, "%s", qUtf8Printable(tr("The measurements file '%1' could not be found.")
-                                                             .arg(newPath)));
+                // The file was found, so don't claim otherwise. loadMeasurements() has
+                // already reported the specific reason it couldn't be used.
                 qApp->setOpeningPattern();// End opening file
                 Clear();
                 if (!Application2D::isGUIMode())

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -437,7 +437,7 @@ private:
 
     void               initializeScenes();
 
-    QSharedPointer<MeasurementDoc> openMeasurementFile(const QString &fileName);
+    QSharedPointer<MeasurementDoc> openMeasurementFile(const QString &fileName, bool *usable = nullptr);
     bool               loadMeasurements(const QString &fileName);
     bool               updateMeasurements(const QString &fileName, int size, int height);
     void               checkRequiredMeasurements(const MeasurementDoc *m);

--- a/src/test/CollectionTest/CollectionTest.pro
+++ b/src/test/CollectionTest/CollectionTest.pro
@@ -175,6 +175,7 @@ SEAMLY2D_TEST_FILES += \
     share/issue_256/issue_256_correct.smms \
     share/issue_256/issue_256_wrong.smms \
     share/issue_1275/issue_1275.sm2d \
+    share/issue_1275/issue_1275.smis \
     tst_seamly2d/empty.sm2d \
     tst_seamly2d/issue_372.sm2d \
     tst_seamly2d/wrong_obj_type.sm2d \

--- a/src/test/CollectionTest/CollectionTest.pro
+++ b/src/test/CollectionTest/CollectionTest.pro
@@ -174,6 +174,7 @@ SEAMLY2D_TEST_FILES += \
     share/issue_256/issue_256_wrong.smis \
     share/issue_256/issue_256_correct.smms \
     share/issue_256/issue_256_wrong.smms \
+    share/issue_1275/issue_1275.sm2d \
     tst_seamly2d/empty.sm2d \
     tst_seamly2d/issue_372.sm2d \
     tst_seamly2d/wrong_obj_type.sm2d \

--- a/src/test/CollectionTest/share/issue_1275/issue_1275.sm2d
+++ b/src/test/CollectionTest/share/issue_1275/issue_1275.sm2d
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<pattern>
+    <!--Pattern created with Seamly2D (https://seamly.io/).-->
+    <version>0.2.2</version>
+    <unit>cm</unit>
+    <author/>
+    <description/>
+    <notes/>
+    <measurements>issue_256_correct.smis</measurements>
+    <increments>
+        <increment description="Uses a measurement only from an increment formula." formula="height_scapula/10" name="#Test"/>
+    </increments>
+    <draw name="Pattern piece 1">
+        <calculation>
+            <point type="single" x="1.34938" y="1.24354" id="1" name="A" mx="0.132292" my="0.264583"/>
+            <point type="endLine" typeLine="hair" id="2" name="A1" basePoint="1" mx="0.175422" lineColor="black" angle="0" my="0.27896" length="10"/>
+            <point type="endLine" typeLine="hair" id="3" name="A2" basePoint="1" mx="0.132292" lineColor="black" angle="269.719" my="0.264583" length="Line_A_A1"/>
+            <point type="pointOfIntersection" id="4" name="A3" firstPoint="2" secondPoint="3" mx="0.132292" my="0.264583"/>
+            <line typeLine="hair" id="5" firstPoint="3" secondPoint="4" lineColor="black"/>
+            <line typeLine="hair" id="6" firstPoint="2" secondPoint="4" lineColor="black"/>
+        </calculation>
+        <modeling>
+            <point type="modeling" id="7" idObject="1" mx="0.0264587" my="0.291041"/>
+            <point type="modeling" id="8" idObject="2" mx="-1.85208" my="0.264583"/>
+            <point type="modeling" id="9" idObject="4" mx="-2.03729" my="-1.71979"/>
+            <point type="modeling" id="10" idObject="3" mx="0.47625" my="-1.95792"/>
+            <point type="modeling" id="11" idObject="1" mx="0.0264587" my="0.291041"/>
+        </modeling>
+        <details>
+            <detail closed="1" id="12" name="Detail" supplement="1" width="1" mx="0.185208" my="-0.079375">
+                <node type="NodePoint" nodeType="Contour" idObject="7" mx="0" my="0"/>
+                <node type="NodePoint" nodeType="Contour" idObject="8" mx="0" my="0"/>
+                <node type="NodePoint" nodeType="Contour" idObject="9" mx="0" my="0"/>
+                <node type="NodePoint" nodeType="Contour" idObject="10" mx="0" my="0"/>
+                <node type="NodePoint" nodeType="Contour" idObject="11" mx="0" my="0"/>
+            </detail>
+        </details>
+    </draw>
+</pattern>

--- a/src/test/CollectionTest/share/issue_1275/issue_1275.sm2d
+++ b/src/test/CollectionTest/share/issue_1275/issue_1275.sm2d
@@ -1,39 +1,24 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <pattern>
     <!--Pattern created with Seamly2D (https://seamly.io/).-->
-    <version>0.2.2</version>
+    <version>0.7.4</version>
     <unit>cm</unit>
-    <author/>
     <description/>
-    <notes/>
-    <measurements>issue_256_correct.smis</measurements>
-    <increments>
-        <increment description="Uses a measurement only from an increment formula." formula="height_scapula/10" name="#Test"/>
-    </increments>
-    <draw name="Pattern piece 1">
+    <notes>The variable needs height_scapula, which issue_1275.smis does not provide. Keeping the measurement out of the draft block formulas is what makes the missing measurement itself the only reason the file cannot be used.</notes>
+    <measurements>issue_1275.smis</measurements>
+    <variables>
+        <variable description="Uses a measurement no measurement file of this test provides." formula="height_scapula/10" name="#Test"/>
+    </variables>
+    <draftBlock name="Draft block 1">
         <calculation>
             <point type="single" x="1.34938" y="1.24354" id="1" name="A" mx="0.132292" my="0.264583"/>
-            <point type="endLine" typeLine="hair" id="2" name="A1" basePoint="1" mx="0.175422" lineColor="black" angle="0" my="0.27896" length="10"/>
-            <point type="endLine" typeLine="hair" id="3" name="A2" basePoint="1" mx="0.132292" lineColor="black" angle="269.719" my="0.264583" length="Line_A_A1"/>
-            <point type="pointOfIntersection" id="4" name="A3" firstPoint="2" secondPoint="3" mx="0.132292" my="0.264583"/>
-            <line typeLine="hair" id="5" firstPoint="3" secondPoint="4" lineColor="black"/>
-            <line typeLine="hair" id="6" firstPoint="2" secondPoint="4" lineColor="black"/>
+            <point type="endLine" lineType="solidLine" lineWeight="0.35" id="2" name="A1" basePoint="1" mx="0.175422" lineColor="black" angle="0" my="0.27896" length="10"/>
+            <point type="endLine" lineType="solidLine" lineWeight="0.35" id="3" name="A2" basePoint="1" mx="0.132292" lineColor="black" angle="269.719" my="0.264583" length="Line_A_A1"/>
+            <point type="intersectXY" lineType="dashLine" lineWeight="0.35" lineColor="black" id="4" name="A3" firstPoint="2" secondPoint="3" mx="0.132292" my="0.264583"/>
+            <line lineType="solidLine" lineWeight="0.35" id="5" firstPoint="3" secondPoint="4" lineColor="black"/>
+            <line lineType="solidLine" lineWeight="0.35" id="6" firstPoint="2" secondPoint="4" lineColor="black"/>
         </calculation>
-        <modeling>
-            <point type="modeling" id="7" idObject="1" mx="0.0264587" my="0.291041"/>
-            <point type="modeling" id="8" idObject="2" mx="-1.85208" my="0.264583"/>
-            <point type="modeling" id="9" idObject="4" mx="-2.03729" my="-1.71979"/>
-            <point type="modeling" id="10" idObject="3" mx="0.47625" my="-1.95792"/>
-            <point type="modeling" id="11" idObject="1" mx="0.0264587" my="0.291041"/>
-        </modeling>
-        <details>
-            <detail closed="1" id="12" name="Detail" supplement="1" width="1" mx="0.185208" my="-0.079375">
-                <node type="NodePoint" nodeType="Contour" idObject="7" mx="0" my="0"/>
-                <node type="NodePoint" nodeType="Contour" idObject="8" mx="0" my="0"/>
-                <node type="NodePoint" nodeType="Contour" idObject="9" mx="0" my="0"/>
-                <node type="NodePoint" nodeType="Contour" idObject="10" mx="0" my="0"/>
-                <node type="NodePoint" nodeType="Contour" idObject="11" mx="0" my="0"/>
-            </detail>
-        </details>
-    </draw>
+        <modeling/>
+        <pieces/>
+    </draftBlock>
 </pattern>

--- a/src/test/CollectionTest/share/issue_1275/issue_1275.smis
+++ b/src/test/CollectionTest/share/issue_1275/issue_1275.smis
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<smis>
+    <!--Measurements created with Seamly2D (https://seamly.io/).-->
+    <version>0.3.4</version>
+    <read-only>false</read-only>
+    <notes>Deliberately missing height_scapula, the measurement the pattern needs.</notes>
+    <unit>cm</unit>
+    <pm_system>998</pm_system>
+    <personal>
+        <family-name/>
+        <given-name/>
+        <birth-date>1900-01-01</birth-date>
+        <gender>female</gender>
+        <email/>
+    </personal>
+    <body-measurements>
+        <m name="height" value="167.64" description="Vertical distance from top of Head to Floor" full_name="Height-&gt;Total"/>
+        <m name="height_neck_back" value="141.5" description="Vertical distance from Neck Back (Nape) to Floor" full_name="Height-&gt;Neck Back (Nape)"/>
+        <m name="height_waist_side" value="101" description="Vertical distance from Waist Side to Floor" full_name="Height-&gt;Waist Side"/>
+        <m name="height_knee" value="42" description="Vertical distance from Knee to Floor" full_name="Height-&gt;Knee"/>
+    </body-measurements>
+</smis>

--- a/src/test/CollectionTest/tst_seamly2dcommandline.cpp
+++ b/src/test/CollectionTest/tst_seamly2dcommandline.cpp
@@ -230,7 +230,7 @@ void TST_Seamly2DCommandLine::TestMode_data() const
     QTest::newRow("Issue #1275. Individual measurements missing a required measurement.")
                                << "issue_1275.sm2d"
                                << QString("--test;;-m;;%1").arg(tmp + QDir::separator() +
-                                                                QLatin1String("issue_256_wrong.smis"))
+                                                                QLatin1String("issue_1275.smis"))
                                << V_EX_NOINPUT;
 
     QTest::newRow("Wrong formula.")<< "wrong_formula.sm2d"

--- a/src/test/CollectionTest/tst_seamly2dcommandline.cpp
+++ b/src/test/CollectionTest/tst_seamly2dcommandline.cpp
@@ -227,6 +227,12 @@ void TST_Seamly2DCommandLine::TestMode_data() const
                                                                 QLatin1String("issue_256_wrong.smms"))
                                << V_EX_NOINPUT;
 
+    QTest::newRow("Issue #1275. Individual measurements missing a required measurement.")
+                               << "issue_1275.sm2d"
+                               << QString("--test;;-m;;%1").arg(tmp + QDir::separator() +
+                                                                QLatin1String("issue_256_wrong.smis"))
+                               << V_EX_NOINPUT;
+
     QTest::newRow("Wrong formula.")<< "wrong_formula.sm2d"
                                << QString("--test")
                                << V_EX_DATAERR;


### PR DESCRIPTION
Closes #1275

## Problem

Running Seamly2D from the command line with a measurement file that exists but is missing a
measurement the pattern needs logs a critical error and then carries on: it exports a
pattern built from incomplete measurements and exits `0`.

```
$ Seamly2D --exportOnlyDetails -m missing.smis -f 1 -p 5 male_shirt.sm2d -b out1 -d out/
CRITICAL:File exception.
Exception: Measurement file doesn't include all the required measurements.
Please provide additional measurements: hip_circ
INFO:Individual file .../missing.smis was loaded.      <-- claims success
EXIT=0                                                 <-- V_EX_OK
out1_pieces.pdf                                        <-- written anyway
```

Exporting the same pattern to BMP twice, once with the complete measurement file and once
with the incomplete one, gives two different rasters — both runs exit `0`, so the wrong
result is handed back as a success.

The issue as originally filed also reported a second, contradictory message,
`The measurements file '<path>' could not be found.`, printed right after the real error.
That message is still wrong, and it is what the caller reaches as soon as the swallowed
failure above is corrected, so both halves are fixed here.

## Root cause

`MainWindow::openMeasurementFile()` reported a failed load only through `qCCritical()` and
`qApp->exit(V_EX_NOINPUT)`. The `MeasurementDoc` it returned still held the content parsed
by `setXMLContent()` before `checkRequiredMeasurements()` threw, so `isNull()` was `false`
— and `isNull()` was `loadMeasurements()`'s only failure signal. `loadMeasurements()`
therefore returned `true`, `LoadPattern()` returned `true`, `processCommandLine()` skipped
its early `return` for a failed load and fell through to `qApp->exit(V_EX_OK)`, discarding
the requested exit code 66.

Separately, `LoadPattern()` logged `The measurements file '%1' could not be found.` in the
`!loadMeasurements(newPath)` branch. That branch is only reached with a path that
`checkPathToMeasurements()` already resolved, i.e. the file *was* found, and the actual
reason had already been logged.

## Fix

* `openMeasurementFile()` takes an optional `bool *usable` out parameter and clears it on
  the `VException` path. `loadMeasurements()` passes it and now fails on
  `m_measurements->isNull() || !usable`.
* The parsed content is deliberately **not** cleared. `measurements->clear()` used to be
  there and was removed on purpose in 4193356f6e ("fix sync critical error"); re-adding it
  would make `updateMeasurements()` fail, and `syncMeasurements()` only resets `m_changes`
  on success, so an unusable file would pop stacked modal boxes on every focus-in forever.
  Routing the signal through `usable` leaves `updateMeasurements()` — and with it
  `syncMeasurements()`, batch export and the size restore — behaving exactly as today.
* `LoadPattern()` no longer logs the "could not be found" message when
  `loadMeasurements()` fails. Every path that makes it fail already logs its own specific
  reason. The genuine not-found case a few lines above is untouched, and since that string
  is still used there, no `.ts` files change.

## Tests

New `CollectionTest` case, added to `TestMode_data()`:

```cpp
QTest::newRow("Issue #1275. Individual measurements missing a required measurement.")
        << "issue_1275.sm2d"
        << QString("--test;;-m;;%1").arg(tmp + QDir::separator() +
                                         QLatin1String("issue_1275.smis"))
        << V_EX_NOINPUT;
```

with two new fixtures in `share/issue_1275/`: the pattern `issue_1275.sm2d` (pattern format
`0.7.4`) and the individual measurements `issue_1275.smis` (format `0.3.4`), which is
deliberately missing `height_scapula`. Both validate against the current schemas in
`src/libs/ifc/schema`.

The pattern references `height_scapula` **only from a `<variables>` formula**. That matters:
the existing row `TestMode(Issue #256. Wrong individual measurements.)` passes today only
because `issue_256.sm2d` uses that measurement as a point length, so the run aborts later in
`fullParseFile()`. Going through a variable removes the downstream abort —
`VPattern::EvalFormula()` returns `0` with `ok == false` and `parseVariablesElement()`
tolerates it — so the new case asserts the missing-measurement handling itself. Measured on a
build of `develop`: the variable fixture exits `0` (the bug), while the same measurement moved
into the `A1` length formula exits `66` even without the fix, because parsing then fails with
`Error creating or updating point of end line`.

One limit worth stating: `AbstractTest::Run()` compares exit codes only, so the removal of the
misleading `could not be found` message has no automated guard.

## Verification

Built with Qt 6.11.1 (clang, arm64) and run against the built binaries.

* New test case before the fix: **FAIL** (exit `0` instead of `66`).
* New test case after the fix: **PASS**.
* `CollectionTest` (full: SeamlyMe CLI, `OpenPatterns`, `ExportMode`, `TestMode`,
  `TestOpenCollection`): 17 passed / 0 failed, then 43 passed / 1 failed. The single
  failure, `TestMode(Wrong formula.)`, is **pre-existing on `develop`** (the app crashes on
  `wrong_formula.sm2d`) and is unrelated to this change.
* `Seamly2DTests`: 32 / 15 / 5 / 6959 / 7574 passed, 0 failed.
* Manual re-check of the case from the issue: exit `66`, only the correct error, no
  `could not be found` line, no export written. A genuinely absent measurement file still
  exits `66` with the correct "could not be found" message, and a valid one still exits `0`.
