### PR TITLE
fix: prevent crash from warning dialogs shown mid-paint on macOS (#852)

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -33,6 +33,7 @@ Contributors (alphabetical order):
     Castiane Lefeuvre - French translations
     Christine Neupert
     Dan McMahill
+    Enzo Degraeve
     Evgeniy Strelnikov
     Fabrice Salvaire
     Felix Ulber

--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -7236,6 +7236,14 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
         <source>Error creating a backup copy: %1.</source>
         <translation>Chyba při vytváření záložní kopie: %1.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation>Písmo</translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation>Písmo „%1“ neobsahuje žádná písmena ani číslice, takže názvy bodů se v něm nezobrazí. Vyberte prosím jiné písmo.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -7221,6 +7221,14 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <source>Error creating a backup copy: %1.</source>
         <translation>Fehler bei der Erstellung einer Sicherungskopie: %1.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation>Schriftart</translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation>Die Schriftart „%1“ enthält keine Buchstaben oder Ziffern, daher werden Punktnamen damit nicht angezeigt. Bitte wählen Sie eine andere Schriftart.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -7240,6 +7240,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation>Σφάλμα κατά τη δημιουργία αντιγράφου ασφαλείας: %1.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation>Γραμματοσειρά</translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation>Η γραμματοσειρά «%1» δεν έχει γράμματα ή ψηφία, επομένως τα ονόματα σημείων δεν θα εμφανίζονται με αυτήν. Επιλέξτε άλλη γραμματοσειρά.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -7206,6 +7206,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation type="unfinished">Error creating a backup copy: %1.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -7206,6 +7206,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -7206,6 +7206,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation type="unfinished">Error creating a backup copy: %1.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -7221,6 +7221,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -7257,6 +7257,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation>Error al crear una copia de seguridad: %1.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation>Fuente</translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation>La fuente «%1» no tiene letras ni dígitos, por lo que los nombres de los puntos no se mostrarán con ella. Elija otra fuente.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -7238,6 +7238,14 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
         <source>Error creating a backup copy: %1.</source>
         <translation>Virhe luotaessa varmuuskopiota: %1.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation>Fontti</translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation>Fontissa ”%1” ei ole kirjaimia eikä numeroita, joten pisteiden nimiä ei näytetä sillä. Valitse toinen fontti.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -7262,6 +7262,14 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
         <source>Error creating a backup copy: %1.</source>
         <translation>Erreur lors de la création d&apos;un copie de sauvegarde: %1.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation>Police</translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation>La police « %1 » ne contient ni lettres ni chiffres, les noms de points ne seront donc pas affichés avec elle. Veuillez choisir une autre police.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -7202,6 +7202,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation>גופן</translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation>לגופן „%1” אין אותיות או ספרות, ולכן שמות הנקודות לא יוצגו באמצעותו. יש לבחור גופן אחר.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_hu_HU.ts
+++ b/share/translations/seamly2d_hu_HU.ts
@@ -7237,6 +7237,14 @@ Menti a módosításokat?</translation>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Ismeretlen hiba történt, például egy megtelt partíció megakadályozta a zárolási fájl kiírását.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation>Betűtípus</translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation>A(z) „%1” betűtípus nem tartalmaz betűket vagy számjegyeket, ezért a pontnevek nem jelennek meg vele. Válasszon másik betűtípust.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -7238,6 +7238,14 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
         <source>Error creating a backup copy: %1.</source>
         <translation>Gagal membuat salinan cadangan: %1.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation>Font</translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation>Font &quot;%1&quot; tidak memiliki huruf atau angka, sehingga nama titik tidak akan ditampilkan dengannya. Silakan pilih font lain.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -7226,6 +7226,14 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
         <source>Error creating a backup copy: %1.</source>
         <translation>Errore nella creazione di una copia di backup: %1.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation>Carattere</translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation>Il carattere «%1» non contiene lettere o cifre, quindi i nomi dei punti non verranno visualizzati con esso. Scegliere un altro carattere.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -7221,6 +7221,14 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
         <source>Error creating a backup copy: %1.</source>
         <translation>Fout bij het maken van een back-upkopie: %1.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation>Lettertype</translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation>Het lettertype ‘%1’ bevat geen letters of cijfers, dus puntnamen worden er niet mee weergegeven. Kies een ander lettertype.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_pl_PL.ts
+++ b/share/translations/seamly2d_pl_PL.ts
@@ -7238,6 +7238,14 @@ Czy chcesz zapisać zmiany?</translation>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Wystąpił nieznany błąd, na przykład pełna partycja uniemożliwiła zapisanie pliku blokady.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation>Czcionka</translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation>Czcionka „%1” nie zawiera liter ani cyfr, więc nazwy punktów nie będą w niej wyświetlane. Wybierz inną czcionkę.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -7225,6 +7225,14 @@ Prima enter para o adicionar temporariamente à lista.</translation>
         <source>Error creating a backup copy: %1.</source>
         <translation>Erro ao criar uma cópia de backup: %1.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation>Fonte</translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation>A fonte &quot;%1&quot; não possui letras ou dígitos, portanto os nomes dos pontos não serão exibidos com ela. Escolha outra fonte.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -7240,6 +7240,14 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
         <source>Error creating a backup copy: %1.</source>
         <translation>Eroare la crearea unei copii rezervate: %1.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation>Font</translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation>Fontul „%1” nu are litere sau cifre, așa că numele punctelor nu vor fi afișate cu el. Alegeți alt font.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -7242,6 +7242,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation>Ошибка создания резервной копии: %1.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation>Шрифт</translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation>Шрифт «%1» не содержит букв и цифр, поэтому названия точек не будут отображаться с его помощью. Выберите другой шрифт.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -7238,6 +7238,14 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
         <source>Error creating a backup copy: %1.</source>
         <translation>Yedek kopyası oluşturulurken hata oluştu: %1.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation>Yazı tipi</translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation>&quot;%1&quot; yazı tipinde harf veya rakam yok, bu nedenle nokta adları bu yazı tipiyle gösterilmeyecek. Lütfen başka bir yazı tipi seçin.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -7239,6 +7239,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation>Помилка створення резервної копії: %1.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation>Шрифт</translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation>Шрифт «%1» не містить літер або цифр, тому назви точок не відображатимуться з ним. Виберіть інший шрифт.</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -7238,6 +7238,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation>创建备份副本出错:%1.</translation>
     </message>
+    <message>
+        <source>Font</source>
+        <translation>字体</translation>
+    </message>
+    <message>
+        <source>The font &quot;%1&quot; has no letters or digits, so point names will not be shown with it. Please pick another font.</source>
+        <translation>字体“%1”不包含字母或数字，因此点名称将无法使用该字体显示。请选择其他字体。</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/src/app/seamly2d/core/application_2d.cpp
+++ b/src/app/seamly2d/core/application_2d.cpp
@@ -79,6 +79,7 @@
 #include <QThread>
 #include <QDateTime>
 #include <QIcon>
+#include <QTimer>
 
 QT_WARNING_PUSH
 QT_WARNING_DISABLE_CLANG("-Wmissing-prototypes")
@@ -89,6 +90,71 @@ Q_LOGGING_CATEGORY(vApp, "v.application")
 QT_WARNING_POP
 
 constexpr auto DAYS_TO_KEEP_LOGS = 3;
+
+// True from the moment a message dialog is queued until it is closed, so that messages emitted
+// in the meantime are logged without stacking more modal dialogs on top of it.
+static bool isMessageBoxOpen = false;
+
+//---------------------------------------------------------------------------------------------------------------------
+// Shows the modal dialog for a message that reached noisyFailureMsgHandler().
+inline void showNoisyMessageBox(QtMsgType type, const QString &msg)
+{
+    // fixme: trying to make sure that no save/load dialogs are opened, because an error message
+    // during them will lead to a crash
+    if (QApplication::activeModalWidget() != nullptr &&
+            QApplication::activeModalWidget()->inherits("QFileDialog"))
+    {
+        return;
+    }
+
+    QMessageBox messageBox;
+
+    switch (type)
+    {
+        case QtWarningMsg:
+            messageBox.setWindowTitle(QApplication::translate("vNoisyHandler", "Warning"));
+            messageBox.setIcon(QMessageBox::Warning);
+            break;
+        case QtCriticalMsg:
+            messageBox.setWindowTitle(QApplication::translate("vNoisyHandler", "Critical Error"));
+            messageBox.setIcon(QMessageBox::Critical);
+            break;
+        case QtFatalMsg:
+            messageBox.setWindowTitle(QApplication::translate("vNoisyHandler", "Fatal Error"));
+            messageBox.setIcon(QMessageBox::Critical);
+            break;
+        default:
+            return;
+    }
+
+    messageBox.setText(msg);
+    messageBox.setStandardButtons(QMessageBox::Ok);
+    messageBox.setWindowModality(Qt::ApplicationModal);
+    messageBox.setModal(true);
+#ifndef QT_NO_CURSOR
+    QGuiApplication::setOverrideCursor(Qt::ArrowCursor);
+#endif
+    messageBox.setWindowFlags(messageBox.windowFlags() & ~Qt::WindowContextHelpButtonHint);
+    messageBox.exec();
+#ifndef QT_NO_CURSOR
+    QGuiApplication::restoreOverrideCursor();
+#endif
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+// A modal dialog would close any open popup (combo box list, menu) and steal its focus, breaking
+// the interaction the user is in the middle of. Wait for the popup to close before showing it.
+static void showNoisyMessageBoxWhenSafe(QtMsgType type, const QString &msg)
+{
+    if (QApplication::activePopupWidget() != nullptr)
+    {
+        QTimer::singleShot(150, qApp, [type, msg]() { showNoisyMessageBoxWhenSafe(type, msg); });
+        return;
+    }
+
+    showNoisyMessageBox(type, msg);
+    isMessageBoxOpen = false;
+}
 
 //---------------------------------------------------------------------------------------------------------------------
 inline void noisyFailureMsgHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
@@ -132,6 +198,15 @@ inline void noisyFailureMsgHandler(QtMsgType type, const QMessageLogContext &con
 
     // See issue #568
     if (msg.contains(QStringLiteral("Error receiving trust for a CA certificate")))
+    {
+        type = QtDebugMsg;
+    }
+
+    // The pre-installed macOS font "GB18030 Bitmap" is bitmap-only and has no metrics tables,
+    // so Qt cannot compute its bearings. The warning fires every time a font list is populated
+    // and is harmless - keep it in the log only. See issue #852
+    // https://bugreports.qt.io/browse/QTBUG-100170
+    if ((type == QtWarningMsg) && msg.contains(QStringLiteral("minimum bearings")))
     {
         type = QtDebugMsg;
     }
@@ -202,56 +277,30 @@ inline void noisyFailureMsgHandler(QtMsgType type, const QMessageLogContext &con
 
     if (isGuiThread)
     {
-        // fixme: trying to make sure that no save/load dialogs are opened, because an error message
-        // during them will lead to a crash
-        const bool topWinAllowsPop = (QApplication::activeModalWidget() == nullptr) ||
-                !QApplication::activeModalWidget()->inherits("QFileDialog");
-
-        QMessageBox messageBox;
-
-        switch (type)
-        {
-            case QtWarningMsg:
-                messageBox.setWindowTitle(QApplication::translate("vNoisyHandler", "Warning"));
-                messageBox.setIcon(QMessageBox::Warning);
-                break;
-            case QtCriticalMsg:
-                messageBox.setWindowTitle(QApplication::translate("vNoisyHandler", "Critical Error"));
-                messageBox.setIcon(QMessageBox::Critical);
-                break;
-            case QtFatalMsg:
-                messageBox.setWindowTitle(QApplication::translate("vNoisyHandler", "Fatal Error"));
-                messageBox.setIcon(QMessageBox::Critical);
-                break;
-            #if QT_VERSION > QT_VERSION_CHECK(5, 4, 2)
-            case QtInfoMsg:
-                messageBox.setWindowTitle(QApplication::translate("vNoisyHandler", "Information"));
-                messageBox.setIcon(QMessageBox::Information);
-                break;
-            #endif
-            case QtDebugMsg:
-            default:
-                break;
-        }
-
         if (type == QtWarningMsg || type == QtCriticalMsg || type == QtFatalMsg)
         {
             if (Application2D::isGUIMode())
             {
-                if (topWinAllowsPop)
+                // Opening a modal dialog right here spins a nested event loop inside the message
+                // handler. When the message is emitted mid-paint (e.g. while the font combo box
+                // popup is being built - see issue #852 with the macOS "GB18030 Bitmap" font),
+                // that nested loop repaints half-constructed widgets, which emits more warnings,
+                // re-enters this handler and stacks modal dialogs until the application crashes.
+                // Defer the dialog to the next event loop pass, and never open a second one while
+                // the first is still up: the extra messages are still logged above, just without
+                // a popup for each.
+                if (QtFatalMsg == type)
                 {
-                    messageBox.setText(msg);
-                    messageBox.setStandardButtons(QMessageBox::Ok);
-                    messageBox.setWindowModality(Qt::ApplicationModal);
-                    messageBox.setModal(true);
-                #ifndef QT_NO_CURSOR
-                    QGuiApplication::setOverrideCursor(Qt::ArrowCursor);
-                #endif
-                    messageBox.setWindowFlags(messageBox.windowFlags() & ~Qt::WindowContextHelpButtonHint);
-                    messageBox.exec();
-                #ifndef QT_NO_CURSOR
-                    QGuiApplication::restoreOverrideCursor();
-                #endif
+                    // A fatal message aborts below, so its dialog cannot be deferred.
+                    showNoisyMessageBox(type, msg);
+                }
+                else if (!isMessageBoxOpen)
+                {
+                    isMessageBoxOpen = true;
+                    QMetaObject::invokeMethod(qApp, [type, msg]()
+                    {
+                        showNoisyMessageBoxWhenSafe(type, msg);
+                    }, Qt::QueuedConnection);
                 }
             }
         }

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -123,6 +123,7 @@
 #include <QLabel>
 #include <QMessageBox>
 #include <QProcess>
+#include <QRawFont>
 #include <QScrollBar>
 #include <QSettings>
 #include <QSharedPointer>
@@ -153,6 +154,36 @@ const QString autosavePostfix = QStringLiteral(".autosave");
 // Strings for dynamically translating "Ctrl" in the status bar tool tips
 const QString strQShortcut = QStringLiteral("QShortcut");
 const QString strCtrl      = QStringLiteral("Ctrl");
+
+//---------------------------------------------------------------------------------------------------------------------
+/**
+ * @brief fontCanDrawPointNames checks that a font actually holds glyphs for the characters point
+ * names are made of.
+ *
+ * QFontDatabase::writingSystems() and QFontMetrics::inFont() both answer through the font
+ * substitution chain, so they claim coverage a font does not have - the pre-installed macOS
+ * "GB18030 Bitmap" is reported as supporting Latin while its cmap only maps CJK ideographs.
+ * QRawFont bypasses substitution and reports what the font file really contains. See issue #852.
+ */
+static bool fontCanDrawPointNames(const QFont &font)
+{
+    const QRawFont rawFont = QRawFont::fromFont(font);
+    if (!rawFont.isValid())
+    {
+        return true; // Nothing reliable to test against, so don't cry wolf.
+    }
+
+    // Point names are alphanumeric, so a font missing these cannot label a pattern at all.
+    for (const QChar &character : {QChar('A'), QChar('a'), QChar('0')})
+    {
+        if (!rawFont.supportsCharacter(character))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
 
 
 /// @brief Seamly2D MainWindow constructor.
@@ -2416,6 +2447,20 @@ void MainWindow::initializePointNameToolBar()
             {
                 qApp->Seamly2DSettings()->setPointNameFont(font);
                 upDateScenes();
+
+                if (!fontCanDrawPointNames(font))
+                {
+                    // Warn once the combo box popup has closed, otherwise the dialog steals its
+                    // focus and the selection cannot be completed.
+                    const QString family = font.family();
+                    QTimer::singleShot(0, this, [this, family]()
+                    {
+                        QMessageBox::warning(this, tr("Font"),
+                                             tr("The font \"%1\" has no letters or digits, so point "
+                                                "names will not be shown with it. Please pick "
+                                                "another font.").arg(family));
+                    });
+                }
             });
 
     fontSizeComboBox = new QComboBox ;

--- a/src/app/seamlyme/application_me.cpp
+++ b/src/app/seamlyme/application_me.cpp
@@ -79,6 +79,7 @@
 #include <QStandardPaths>
 #include <QStyleHints>
 #include <QThread>
+#include <QTimer>
 
 QT_WARNING_PUSH
 QT_WARNING_DISABLE_CLANG("-Wmissing-prototypes")
@@ -89,6 +90,71 @@ Q_LOGGING_CATEGORY(mApp, "m.application")
 QT_WARNING_POP
 
 #include <QCommandLineParser>
+
+// True from the moment a message dialog is queued until it is closed, so that messages emitted
+// in the meantime are logged without stacking more modal dialogs on top of it.
+static bool isMessageBoxOpen = false;
+
+//---------------------------------------------------------------------------------------------------------------------
+// Shows the modal dialog for a message that reached noisyFailureMsgHandler().
+inline void showNoisyMessageBox(QtMsgType type, const QString &msg)
+{
+    //fixme: trying to make sure there are no save/load dialogs are opened, because error message during them will
+    //lead to crash
+    if (QApplication::activeModalWidget() != nullptr &&
+            QApplication::activeModalWidget()->inherits("QFileDialog"))
+    {
+        return;
+    }
+
+    QMessageBox messageBox;
+
+    switch (type)
+    {
+        case QtWarningMsg:
+            messageBox.setWindowTitle(QApplication::translate("mNoisyHandler", "Warning"));
+            messageBox.setIcon(QMessageBox::Warning);
+            break;
+        case QtCriticalMsg:
+            messageBox.setWindowTitle(QApplication::translate("mNoisyHandler", "Critical Error"));
+            messageBox.setIcon(QMessageBox::Critical);
+            break;
+        case QtFatalMsg:
+            messageBox.setWindowTitle(QApplication::translate("mNoisyHandler", "Fatal Error"));
+            messageBox.setIcon(QMessageBox::Critical);
+            break;
+        default:
+            return;
+    }
+
+    messageBox.setText(msg);
+    messageBox.setStandardButtons(QMessageBox::Ok);
+    messageBox.setWindowModality(Qt::ApplicationModal);
+    messageBox.setModal(true);
+#ifndef QT_NO_CURSOR
+    QGuiApplication::setOverrideCursor(Qt::ArrowCursor);
+#endif
+    messageBox.setWindowFlags(messageBox.windowFlags() & ~Qt::WindowContextHelpButtonHint);
+    messageBox.exec();
+#ifndef QT_NO_CURSOR
+    QGuiApplication::restoreOverrideCursor();
+#endif
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+// A modal dialog would close any open popup (combo box list, menu) and steal its focus, breaking
+// the interaction the user is in the middle of. Wait for the popup to close before showing it.
+static void showNoisyMessageBoxWhenSafe(QtMsgType type, const QString &msg)
+{
+    if (QApplication::activePopupWidget() != nullptr)
+    {
+        QTimer::singleShot(150, qApp, [type, msg]() { showNoisyMessageBoxWhenSafe(type, msg); });
+        return;
+    }
+
+    showNoisyMessageBox(type, msg);
+    isMessageBoxOpen = false;
+}
 
 //---------------------------------------------------------------------------------------------------------------------
 inline void noisyFailureMsgHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
@@ -134,6 +200,15 @@ inline void noisyFailureMsgHandler(QtMsgType type, const QMessageLogContext &con
 
     // See issue #568
     if (msg.contains(QStringLiteral("Error receiving trust for a CA certificate")))
+    {
+        type = QtDebugMsg;
+    }
+
+    // The pre-installed macOS font "GB18030 Bitmap" is bitmap-only and has no metrics tables,
+    // so Qt cannot compute its bearings. The warning fires every time a font list is populated
+    // and is harmless - keep it in the log only. See issue #852
+    // https://bugreports.qt.io/browse/QTBUG-100170
+    if ((type == QtWarningMsg) && msg.contains(QStringLiteral("minimum bearings")))
     {
         type = QtDebugMsg;
     }
@@ -188,57 +263,30 @@ inline void noisyFailureMsgHandler(QtMsgType type, const QMessageLogContext &con
 
     if (isGuiThread)
     {
-        //fixme: trying to make sure there are no save/load dialogs are opened, because error message during them will
-        //lead to crash
-        const bool topWinAllowsPop = (QApplication::activeModalWidget() == nullptr) ||
-                !QApplication::activeModalWidget()->inherits("QFileDialog");
-        QMessageBox messageBox;
-
-        switch (type)
-        {
-            case QtWarningMsg:
-                messageBox.setWindowTitle(QApplication::translate("mNoisyHandler", "Warning"));
-                messageBox.setIcon(QMessageBox::Warning);
-                break;
-            case QtCriticalMsg:
-                messageBox.setWindowTitle(QApplication::translate("mNoisyHandler", "Critical Error"));
-                messageBox.setIcon(QMessageBox::Critical);
-                break;
-            case QtFatalMsg:
-                messageBox.setWindowTitle(QApplication::translate("mNoisyHandler", "Fatal Error"));
-                messageBox.setIcon(QMessageBox::Critical);
-                break;
-            #if QT_VERSION > QT_VERSION_CHECK(5, 4, 2)
-            case QtInfoMsg:
-                messageBox.setWindowTitle(QApplication::translate("mNoisyHandler", "Information"));
-                messageBox.setIcon(QMessageBox::Information);
-                break;
-            #endif
-            case QtDebugMsg:
-                Q_UNREACHABLE(); //-V501
-                break;
-            default:
-                break;
-        }
-
         if (type == QtWarningMsg || type == QtCriticalMsg || type == QtFatalMsg)
         {
             if (!qApp->isTestMode())
             {
-                if (topWinAllowsPop)
+                // Opening a modal dialog right here spins a nested event loop inside the message
+                // handler. When the message is emitted mid-paint (e.g. while the font combo box
+                // popup is being built - see issue #852 with the macOS "GB18030 Bitmap" font),
+                // that nested loop repaints half-constructed widgets, which emits more warnings,
+                // re-enters this handler and stacks modal dialogs until the application crashes.
+                // Defer the dialog to the next event loop pass, and never open a second one while
+                // the first is still up: the extra messages are still logged above, just without
+                // a popup for each.
+                if (QtFatalMsg == type)
                 {
-                    messageBox.setText(msg);
-                    messageBox.setStandardButtons(QMessageBox::Ok);
-                    messageBox.setWindowModality(Qt::ApplicationModal);
-                    messageBox.setModal(true);
-                #ifndef QT_NO_CURSOR
-                    QGuiApplication::setOverrideCursor(Qt::ArrowCursor);
-                #endif
-                    messageBox.setWindowFlags(messageBox.windowFlags() & ~Qt::WindowContextHelpButtonHint);
-                    messageBox.exec();
-                #ifndef QT_NO_CURSOR
-                    QGuiApplication::restoreOverrideCursor();
-                #endif
+                    // A fatal message aborts below, so its dialog cannot be deferred.
+                    showNoisyMessageBox(type, msg);
+                }
+                else if (!isMessageBoxOpen)
+                {
+                    isMessageBoxOpen = true;
+                    QMetaObject::invokeMethod(qApp, [type, msg]()
+                    {
+                        showNoisyMessageBoxWhenSafe(type, msg);
+                    }, Qt::QueuedConnection);
                 }
             }
         }


### PR DESCRIPTION
## Context

As described in #852, on macOS the pre-installed font **GB18030 Bitmap** triggers warning pop-ups when the font combo box is opened. On macOS 15 with Seamly2D 2026.8.3.214 this now ends in a crash:

> I get the following messages (each line seems to trigger a new pop-up):
>
> ```
> Failed to compute left/right minimum bearings for "GB18030 Bitmap"
> QBackingStore::flush() called for QWidgetWindow(0x600000863ea0, name="QComboBoxPrivateContainerClassWindow") which does not have a handle.
> QWidget::mapTo(): parent must be in parent hierarchy
> *CRASH*
> ```
>
> I understand that these messages may only be warnings and that the font issue itself might not be critical. However, the main problem is that these warnings eventually lead to a complete application crash, potentially causing unsaved work to be lost.

The original issue was closed as won't fix because the font was seen as the culprit, but the font can no longer be removed: since macOS Catalina it lives in `/System/Library/Fonts/Supplemental/` on the sealed read-only system volume. Any user with this font installed (it ships with macOS) can hit the crash.

## Root cause

The crash is not the font itself but how `noisyFailureMsgHandler` reacts to the warning. It opened a modal `QMessageBox` directly inside the Qt message handler. When the warning is emitted mid-paint (while the font combo popup is being built), `exec()` spins a nested event loop that repaints the half-constructed popup, which emits more warnings, re-enters the handler and stacks modal dialogs until the application crashes.

The warning itself comes from the font: GB18030 Bitmap is bitmap-only (Apple `bdat`/`bloc` tables) and has no `head`/`hhea`/`hmtx` tables, so Qt cannot compute its minimum bearings (QTBUG-100170).

## Changes

- **`application_2d.cpp` / `application_me.cpp`** — the message handler now defers its dialog to the next event loop pass, waits for any open popup (combo list, menu) to close first, and never stacks a second dialog while one is up. Messages emitted in the meantime are still written to the log and stderr. The fatal path stays synchronous since it aborts.
- Downgrade the harmless "minimum bearings" warning to a log entry, next to the other known-Qt-bug workarounds in the macOS block.
- **`mainwindow.cpp`** — warn the user at the moment they actually *select* a font that cannot draw point names. The check uses `QRawFont::supportsCharacter()`, because `QFontDatabase::writingSystems()` and `QFontMetrics::inFont()` answer through the font substitution chain and report Latin coverage this font does not have (its cmap only maps CJK ideographs).
- The new warning message is translated in the 18 non-English locales.

## Testing

Built and tested on macOS 15 (arm64, Qt 6.11.1) with GB18030 Bitmap present:

- Opening the font combo box: no pop-up, no crash; the warning goes to the log.
- Selecting GB18030 Bitmap: a single translated warning appears after the popup closes, without stealing focus from the selection.
- Selecting a normal font: unchanged behavior.

Ref #852
