### PR TITLE
Fix macOS build to auto-detect Qt architectures

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -30,7 +30,7 @@ macx{
     # Requirements: Xcode Command Line Tools (which includes the 'lipo' utility)
     # lipo is part of standard Xcode/CLT installation and detects binary architectures.
     # Falls back to arm64 if detection fails to prevent build interruption.
-    QT_ARCHS = $$system(lipo -archs $$[QT_INSTALL_LIBS]/QtCore.framework/QtCore 2>/dev/null || echo "arm64")
+    QT_ARCHS = $$system(lipo -archs $$shell_quote($$[QT_INSTALL_LIBS]/QtCore.framework/QtCore) 2>/dev/null || uname -m)
     QMAKE_APPLE_DEVICE_ARCHS = $$QT_ARCHS
     message("Building for Qt architectures: $$QMAKE_APPLE_DEVICE_ARCHS")
 }

--- a/common.pri
+++ b/common.pri
@@ -24,7 +24,15 @@ unix{
 }
 
 macx{
-    QMAKE_APPLE_DEVICE_ARCHS = x86_64 arm64
+    # Detect available Qt architectures and build for matching native architectures.
+    # This allows users with either x86_64 or arm64 Qt installations to build successfully.
+    # 
+    # Requirements: Xcode Command Line Tools (which includes the 'lipo' utility)
+    # lipo is part of standard Xcode/CLT installation and detects binary architectures.
+    # Falls back to arm64 if detection fails to prevent build interruption.
+    QT_ARCHS = $$system(lipo -archs $$[QT_INSTALL_LIBS]/QtCore.framework/QtCore 2>/dev/null || echo "arm64")
+    QMAKE_APPLE_DEVICE_ARCHS = $$QT_ARCHS
+    message("Building for Qt architectures: $$QMAKE_APPLE_DEVICE_ARCHS")
 }
 
 # See question on StackOwerflow "QSslSocket error when SSL is NOT used" (http://stackoverflow.com/a/31277055/3045403)


### PR DESCRIPTION
## Problem
The project hardcodes `QMAKE_APPLE_DEVICE_ARCHS = x86_64 arm64`, which fails when Qt is only installed for one architecture:
- Users with arm64-only Qt (e.g., Homebrew on Apple Silicon) → build fails with linker errors for x86_64
- Users with x86_64-only Qt → build fails with linker errors for arm64

This prevents building entirely and blocks offering arm64 releases.

## Solution
Auto-detect the Qt installation's available architectures at build time using `lipo`:

```qmake
macx{
    # Detect available Qt architectures and build for matching native architectures.
    # This allows users with either x86_64 or arm64 Qt installations to build successfully.
    # 
    # Requirements: Xcode Command Line Tools (which includes the 'lipo' utility)
    # lipo is part of standard Xcode/CLT installation and detects binary architectures.
    # Falls back to arm64 if detection fails to prevent build interruption.
    QT_ARCHS = $$system(lipo -archs $$[QT_INSTALL_LIBS]/QtCore.framework/QtCore 2>/dev/null || echo "arm64")
    QMAKE_APPLE_DEVICE_ARCHS = $$QT_ARCHS
    message("Building for Qt architectures: $$QMAKE_APPLE_DEVICE_ARCHS")
}
```

The `lipo` command is part of the standard Xcode Command Line Tools, which are already required per [README-DEVELOPER.md](/.github/README-DEVELOPER.md) ("Ensure you have Xcode Command Line Tools installed"). If architecture detection fails for any reason, the build gracefully falls back to `arm64`.

- arm64 users can build with arm64-only Qt installations
- x86_64 users can build with x86_64-only Qt installations
- If users install universal Qt binaries, both architectures will automatically build
- Enables arm64 releases alongside existing x86_64 releases

## Testing
- ✅ Successfully compiled with arm64-only Qt (Homebrew on Apple Silicon)
- ✅ Generated working arm64 binaries for both Seamly2D and SeamlyMe
- ✅ Build outputs include DMG packages and distribution ZIP
