### PR TITLE
Feat: Use native dialogs

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -9360,6 +9360,10 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
         <source>Auto clear formula</source>
         <translation>Automatické vymazání vzorce</translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Používejte nativní dialogová okna</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10130,6 +10134,14 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
     <message>
         <source>Measurements</source>
         <translation>Míry</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation>Dialogy</translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Používejte nativní dialogová okna</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -9346,6 +9346,10 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <source>Auto clear formula</source>
         <translation>Formel automatisch löschen</translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Native Dialogfelder verwenden</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10116,6 +10120,14 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     <message>
         <source>Measurements</source>
         <translation>Maße</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation>Dialoge</translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Native Dialogfelder verwenden</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -9364,6 +9364,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Auto clear formula</source>
         <translation>Φόρμουλα αυτόματης διαγραφής</translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Χρήση εγγενών παραθύρων διαλόγου</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10134,6 +10138,14 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Measurements</source>
         <translation>Μετρήσεις</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation>Διάλογοι</translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Χρήση εγγενών παραθύρων διαλόγου</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -9330,6 +9330,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Auto clear formula</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10100,6 +10104,14 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Measurements</source>
         <translation type="unfinished">Measurements</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -9330,6 +9330,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Auto clear formula</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10100,6 +10104,14 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Measurements</source>
         <translation type="unfinished">Measurements</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -9330,6 +9330,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Auto clear formula</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10100,6 +10104,14 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Measurements</source>
         <translation type="unfinished">Measurements</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -9345,6 +9345,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Auto clear formula</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10115,6 +10119,14 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Measurements</source>
         <translation type="unfinished">Measurements</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -9400,6 +9400,10 @@ actualización:</translation>
         <source>Auto clear formula</source>
         <translation>Fórmula de borrado automático</translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Utilizar cuadros de diálogo nativos</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10171,6 +10175,14 @@ actualización:</translation>
     <message>
         <source>Measurements</source>
         <translation>Medidas</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation>Diálogos</translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Utilizar cuadros de diálogo nativos</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -9362,6 +9362,10 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
         <source>Auto clear formula</source>
         <translation>Tyhjennä matemaattinenkaava automaattisesti</translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Käytä järjestelmän omia valintaikkunoita</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10132,6 +10136,14 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
     <message>
         <source>Measurements</source>
         <translation>Mitat</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation>Valintaikkunat</translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Käytä järjestelmän omia valintaikkunoita</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -9388,6 +9388,10 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
         <source>Auto clear formula</source>
         <translation>Formule de suppression automatique</translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Utiliser les boîtes de dialogue natives</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10160,6 +10164,14 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
     <message>
         <source>Measurements</source>
         <translation>Mesures</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation>Dialogues</translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Utiliser les boîtes de dialogue natives</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -9326,6 +9326,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Auto clear formula</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10095,6 +10099,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Measurements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_hu_HU.ts
+++ b/share/translations/seamly2d_hu_HU.ts
@@ -9361,6 +9361,10 @@ Menti a módosításokat?</translation>
         <source>Auto clear formula</source>
         <translation>Automatikusan törlődő képlet</translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Használjon natív párbeszédablakokat</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10131,6 +10135,14 @@ Menti a módosításokat?</translation>
     <message>
         <source>Measurements</source>
         <translation>Mérések</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation>Párbeszédablakok</translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Használjon natív párbeszédablakokat</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -9362,6 +9362,10 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
         <source>Auto clear formula</source>
         <translation>Rumus pembersihan otomatis</translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Gunakan kotak dialog bawaan</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10132,6 +10136,14 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
     <message>
         <source>Measurements</source>
         <translation>pengukuran</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation>Dialog</translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation><Gunakan kotak dialog bawaan/translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -10143,7 +10143,7 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
     </message>
     <message>
         <source>Use native dialogs</source>
-        <translation><Gunakan kotak dialog bawaan/translation>
+        <translation>Gunakan kotak dialog bawaan</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -9350,6 +9350,10 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
         <source>Auto clear formula</source>
         <translation>Formula di pulizia automatica</translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Utilizza le finestre di dialogo native</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10120,6 +10124,14 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
     <message>
         <source>Measurements</source>
         <translation>Misure</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation>Dialoghi</translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Utilizza le finestre di dialogo native</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -9345,6 +9345,10 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
         <source>Auto clear formula</source>
         <translation>Formule automatisch wissen</translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Gebruik standaarddialoogvensters</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10115,6 +10119,14 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
     <message>
         <source>Measurements</source>
         <translation>Maten</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation>Dialogen</translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Gebruik standaarddialoogvensters</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_pl_PL.ts
+++ b/share/translations/seamly2d_pl_PL.ts
@@ -9362,6 +9362,10 @@ Czy chcesz zapisać zmiany?</translation>
         <source>Auto clear formula</source>
         <translation>Automatyczne czyszczenie formuły</translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Korzystaj z natywnych okien dialogowych</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10132,6 +10136,14 @@ Czy chcesz zapisać zmiany?</translation>
     <message>
         <source>Measurements</source>
         <translation>Pomiary</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation>Dialogi</translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Korzystaj z natywnych okien dialogowych</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -9350,6 +9350,10 @@ Prima enter para o adicionar temporariamente à lista.</translation>
         <source>Auto clear formula</source>
         <translation>Fórmula de limpeza automática</translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Use caixas de diálogo nativas</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10120,6 +10124,14 @@ Prima enter para o adicionar temporariamente à lista.</translation>
     <message>
         <source>Measurements</source>
         <translation>Medidas</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation>Diâlogos</translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Use caixas de diálogo nativas</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -9364,6 +9364,10 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
         <source>Auto clear formula</source>
         <translation>Formula cu auto-claritate</translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Utilizați ferestrele de dialog native</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10134,6 +10138,14 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
     <message>
         <source>Measurements</source>
         <translation>Măsurători</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation>Dialoguri</translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Utilizați ferestrele de dialog native</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -9369,6 +9369,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Auto clear formula</source>
         <translation>Автоматическое удаление формулы</translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Используйте встроенные диалоговые окна</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10139,6 +10143,14 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Measurements</source>
         <translation>Мерки</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation>Диалоги</translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Используйте встроенные диалоговые окна</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -9362,6 +9362,10 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
         <source>Auto clear formula</source>
         <translation>Otomatik temizleme formülü</translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Yerel diyalog pencerelerini kullanın</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10132,6 +10136,14 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
     <message>
         <source>Measurements</source>
         <translation>Ölçümler</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation>Diyaloglar</translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Yerel diyalog pencerelerini kullanın</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -9363,6 +9363,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Auto clear formula</source>
         <translation>Автоматичне очищення формули</translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Використовуйте вбудовані діалогові вікна</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10133,6 +10137,14 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Measurements</source>
         <translation>вимірювань</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation>Διάλογοι</translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>Використовуйте вбудовані діалогові вікна</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -9362,6 +9362,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Auto clear formula</source>
         <translation>自动清除公式</translation>
     </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>使用原生对话框</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10132,6 +10136,14 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Measurements</source>
         <translation>测量数据</translation>
+    </message>
+    <message>
+        <source>Dialogs</source>
+        <translation>对话框</translation>
+    </message>
+    <message>
+        <source>Use native dialogs</source>
+        <translation>使用原生对话框</translation>
     </message>
 </context>
 <context>

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.cpp
@@ -66,6 +66,7 @@ PreferencesGraphicsViewPage::PreferencesGraphicsViewPage (QWidget *parent)
     ui->detailsToolbar_CheckBox->setChecked(qApp->Seamly2DSettings()->getShowDetailsToolBar());
     ui->layoutToolbar_CheckBox->setChecked(qApp->Seamly2DSettings()->getShowLayoutToolBar());
 
+    ui->use_native_checkbox->setChecked(qApp->Seamly2DSettings()->useNativeDialogs());
     ui->useSecondMonitor_CheckBox->setChecked(qApp->Seamly2DSettings()->useSecondMonitor());
 
     int id = qApp->Seamly2DSettings()->getDialogPosition();
@@ -276,6 +277,7 @@ void PreferencesGraphicsViewPage::Apply()
     settings->setShowDetailsToolBar(ui->detailsToolbar_CheckBox->isChecked());
     settings->setShowLayoutToolBar(ui->layoutToolbar_CheckBox->isChecked());
 
+    settings->setUseNativeDialogs(ui->use_native_checkbox->isChecked());
     settings->setUseSecondMonitor(ui->useSecondMonitor_CheckBox->isChecked());
     settings->setDialogPosition(ui->position_ButtonGroup->checkedId());
     settings->setXOffset(ui->xOffset_SpinBox->value());

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
@@ -75,7 +75,7 @@
       <enum>QTabWidget::West</enum>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="appearanceTab">
       <attribute name="title">
@@ -415,6 +415,16 @@
          <layout class="QVBoxLayout" name="verticalLayout_25">
           <item>
            <layout class="QVBoxLayout" name="verticalLayout_24">
+            <item>
+             <widget class="QCheckBox" name="use_native_checkbox">
+              <property name="text">
+               <string>Use native dialogs</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
             <item>
              <widget class="QCheckBox" name="useSecondMonitor_CheckBox">
               <property name="sizePolicy">

--- a/src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp
@@ -195,7 +195,7 @@ void PreferencesPathPage::editPath()
     QString filename = fileDialog(this, tr("Open Directory"), path, QString(""), nullptr,
                                                               QFileDialog::ShowDirsOnly |
                                                               QFileDialog::DontResolveSymlinks |
-                                                              FILEDIALOG_OPTIONS,
+                                                              qApp->Seamly2DSettings()->getUseNativeFileDialogs(),
                                                               QFileDialog::Directory, QFileDialog::AcceptOpen);
 
     const QString dir = QFileInfo(filename).filePath();

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp
@@ -262,7 +262,7 @@ void PreferencesPatternPage::setDefaultTemplate()
     QString filter(tr("Label template") + QLatin1String("(*.xml)"));
     const QString fileName = QFileDialog::getOpenFileName(this, tr("Import template"),
                                                           settings->getLabelTemplatePath(), filter, nullptr,
-                                                          FILEDIALOG_OPTIONS);
+                                                          qApp->Seamly2DSettings()->getUseNativeFileDialogs());
 
 
     if (button == ui->patternTemplate_ToolButton)

--- a/src/app/seamly2d/dialogs/dialogpatternproperties.cpp
+++ b/src/app/seamly2d/dialogs/dialogpatternproperties.cpp
@@ -840,7 +840,7 @@ void DialogPatternProperties::ChangeImage()
 {
     const QString filter = tr("Images") + QLatin1String(" (*.png *.jpg *.jpeg *.bmp)");
     const QString fileName = QFileDialog::getOpenFileName(this, tr("Image for pattern"), QString(), filter, nullptr,
-                                                          FILEDIALOG_OPTIONS);
+                                                          qApp->Seamly2DSettings()->getUseNativeFileDialogs());
     QImage image;
     if (fileName.isEmpty())
     {
@@ -886,7 +886,7 @@ void DialogPatternProperties::SaveImage()
     const QString extension = QLatin1String(".") + doc->GetImageExtension();
     QString filter = tr("Images") + QLatin1String(" (*") + extension + QLatin1String(")");
     QString filename = QFileDialog::getSaveFileName(this, tr("Save File"), tr("untitled"), filter, &filter,
-                                                    FILEDIALOG_OPTIONS);
+                                                    qApp->Seamly2DSettings()->getUseNativeFileDialogs());
     if (not filename.isEmpty())
     {
         if (not filename.endsWith(extension.toUpper()))

--- a/src/app/seamly2d/dialogs/export_layout_dialog.cpp
+++ b/src/app/seamly2d/dialogs/export_layout_dialog.cpp
@@ -185,7 +185,7 @@ ExportLayoutDialog::ExportLayoutDialog(int count, Draw mode, const QString &file
         const QString dir = QFileDialog::getExistingDirectory(this, tr("Select folder"), dirPath,
                                                               QFileDialog::ShowDirsOnly
                                                               | QFileDialog::DontResolveSymlinks
-                                                              | FILEDIALOG_OPTIONS);
+                                                              | qApp->Seamly2DSettings()->getUseNativeFileDialogs());
         if (!dir.isEmpty())
         {// If the paths are equal the slot will not be called, we will do this manually
             dir == ui->path_LineEdit->text() ? pathChanged(dir) : ui->path_LineEdit->setText(dir);

--- a/src/app/seamly2d/dialogs/pieces_widget.cpp
+++ b/src/app/seamly2d/dialogs/pieces_widget.cpp
@@ -56,6 +56,7 @@
 #include "../vpatterndb/floatItemData/vpiecelabeldata.h"
 #include "../vpatterndb/vcontainer.h"
 #include "../vmisc/vabstractapplication.h"
+#include "../vmisc/vcommonsettings.h"
 #include "../vtools/tools/pattern_piece_tool.h"
 #include "../vtools/undocommands/togglepieceinlayout.h"
 #include "../vtools/undocommands/toggle_piecelock.h"
@@ -696,7 +697,8 @@ void PiecesWidget::unlockAllPieces()
 
 void PiecesWidget::editPieceColor(quint32 id)
 {
-    const QColor color = QColorDialog::getColor(Qt::white, this, tr("Select Color"), COLORDIALOG_OPTIONS);
+    const QColor color = QColorDialog::getColor(Qt::white, this, tr("Select Color"),
+                                                qApp->Settings()->getUseNativeColorDialogs());
     if (color.isValid())
     {
         SetPieceColor *command = new SetPieceColor(id, color.name(), m_data, m_doc);

--- a/src/app/seamly2d/dialogs/shortcuts_dialog.cpp
+++ b/src/app/seamly2d/dialogs/shortcuts_dialog.cpp
@@ -419,7 +419,8 @@ void ShortcutsDialog::sendToPrinter()
 void ShortcutsDialog::exportPdf()
 {
     QString filename = QFileDialog::getSaveFileName(nullptr, tr("Export PDF"), QString(),
-                                                    "*.pdf", nullptr, FILEDIALOG_OPTIONS);
+                                                    "*.pdf", nullptr,
+                                                    qApp->Seamly2DSettings()->getUseNativeFileDialogs());
 
     if (QFileInfo(filename).suffix().isEmpty())
     {

--- a/src/app/seamly2d/dialogs/show_info_dialog.cpp
+++ b/src/app/seamly2d/dialogs/show_info_dialog.cpp
@@ -177,7 +177,8 @@ void ShowInfoDialog::exportPdf()
     QString filters(tr("Info files") + QLatin1String("(*.pdf)"));
     QString filename = QFileDialog::getSaveFileName(this, tr("Export PDF"),
                                                     doc->GetPatternName() + tr("_info") + QLatin1String(".pdf"),
-                                                    filters, nullptr, FILEDIALOG_OPTIONS);
+                                                    filters, nullptr,
+                                                    qApp->Seamly2DSettings()->getUseNativeFileDialogs());
 
     if (QFileInfo(filename).suffix().isEmpty())
     {

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -2070,7 +2070,8 @@ void MainWindow::LoadIndividual()
 
     QDir directory(dir);
 
-    const QString filename = fileDialog(this, tr("Open file"), dir, filter, nullptr, FILEDIALOG_OPTIONS,
+    const QString filename = fileDialog(this, tr("Open file"), dir, filter, nullptr,
+                                        qApp->Settings()->getUseNativeFileDialogs(),
                                         QFileDialog::ExistingFile, QFileDialog::AcceptOpen);
 
 
@@ -2110,7 +2111,8 @@ void MainWindow::LoadMultisize()
     QString dir = qApp->Seamly2DSettings()->getMultisizePath();
     dir = VCommonSettings::prepareMultisizeTables(dir);
 
-    const QString filename = fileDialog(this, tr("Open file"), dir, filter, nullptr, FILEDIALOG_OPTIONS,
+    const QString filename = fileDialog(this, tr("Open file"), dir, filter, nullptr,
+                                        qApp->Settings()->getUseNativeFileDialogs(),
                                         QFileDialog::ExistingFile, QFileDialog::AcceptOpen);
 
     if (!filename.isEmpty())
@@ -4137,8 +4139,8 @@ bool MainWindow::SaveAs()
 
     fileName = fileDialog(this, tr("Save as"),
                                         dir + QLatin1String("/") + fileName + QLatin1String(".") + sm2dExt,
-                                        filters, nullptr, FILEDIALOG_OPTIONS, QFileDialog::AnyFile,
-                                        QFileDialog::AcceptSave);
+                                        filters, nullptr, qApp->Settings()->getUseNativeFileDialogs(),
+                                        QFileDialog::AnyFile, QFileDialog::AcceptSave);
 
     if (fileName.isEmpty())
     {
@@ -4325,7 +4327,8 @@ void MainWindow::Open()
     }
     qCDebug(vMainWindow, "Run QFileDialog::getOpenFileName: dir = %s.", qUtf8Printable(dir));
 
-    const QString filename = fileDialog(this, tr("Open file"), dir, filter, nullptr, FILEDIALOG_OPTIONS,
+    const QString filename = fileDialog(this, tr("Open file"), dir, filter, nullptr,
+                                        qApp->Settings()->getUseNativeFileDialogs(),
                                         QFileDialog::ExistingFile, QFileDialog::AcceptOpen);
 
     if (filename.isEmpty())
@@ -7511,7 +7514,8 @@ QString MainWindow::checkPathToMeasurements(const QString &patternPath, const QS
                     //Use standard path to multisize measurements
                     QString dir = qApp->Seamly2DSettings()->getMultisizePath();
                     dir = VCommonSettings::prepareMultisizeTables(dir);
-                    filename = fileDialog(this, tr("Open file"), dir, filter, nullptr, FILEDIALOG_OPTIONS,
+                    filename = fileDialog(this, tr("Open file"), dir, filter, nullptr,
+                                          qApp->Settings()->getUseNativeFileDialogs(),
                                           QFileDialog::ExistingFile, QFileDialog::AcceptOpen);
 
                 }
@@ -7531,7 +7535,8 @@ QString MainWindow::checkPathToMeasurements(const QString &patternPath, const QS
                         usedNotExistedDir = directory.mkpath(".");
                     }
 
-                    filename = fileDialog(this, tr("Open file"), dir, filter, nullptr, FILEDIALOG_OPTIONS,
+                    filename = fileDialog(this, tr("Open file"), dir, filter, nullptr,
+                                          qApp->Settings()->getUseNativeFileDialogs(),
                                           QFileDialog::ExistingFile, QFileDialog::AcceptOpen);
 
                     if (usedNotExistedDir)
@@ -7560,7 +7565,8 @@ QString MainWindow::checkPathToMeasurements(const QString &patternPath, const QS
                         usedNotExistedDir = directory.mkpath(".");
                     }
 
-                    filename = fileDialog(this, tr("Open file"), dir, filter, nullptr, FILEDIALOG_OPTIONS,
+                    filename = fileDialog(this, tr("Open file"), dir, filter, nullptr,
+                                          qApp->Settings()->getUseNativeFileDialogs(),
                                           QFileDialog::ExistingFile, QFileDialog::AcceptOpen);
 
                     if (usedNotExistedDir)

--- a/src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp
+++ b/src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp
@@ -149,6 +149,10 @@ SeamlyMePreferencesConfigurationPage::SeamlyMePreferencesConfigurationPage(QWidg
     //----------------------- Toolbar
     ui->toolBarStyle_CheckBox->setChecked(qApp->seamlyMeSettings()->getToolBarStyle());
 
+    // ----------------------- Dialogs
+    ui->use_native_checkox->setChecked(qApp->seamlyMeSettings()->useNativeDialogs());
+
+
     //---------------------------Default height and size
     ui->defHeightCombo->addItems(MeasurementVariable::WholeListHeights(Unit::Cm));
     index = ui->defHeightCombo->findText(QString().setNum(qApp->seamlyMeSettings()->GetDefHeight()));
@@ -206,6 +210,8 @@ void SeamlyMePreferencesConfigurationPage::Apply()
         settings->setOsSeparator(true);
     }
     settings->setToolBarStyle(ui->toolBarStyle_CheckBox->isChecked());
+
+    settings->setUseNativeDialogs(ui->use_native_checkox->isChecked());
 
     if (m_themeChanged)
     {

--- a/src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui
+++ b/src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui
@@ -315,6 +315,43 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="dialogs_groupbox">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>10</pointsize>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="title">
+          <string>Dialogs</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QCheckBox" name="use_native_checkox">
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Use native dialogs</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp
+++ b/src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp
@@ -167,7 +167,7 @@ void SeamlyMePreferencesPathPage::editPath()
     QString filename = fileDialog(this, tr("Open Directory"), path, QString(""), nullptr,
                                                               QFileDialog::ShowDirsOnly |
                                                               QFileDialog::DontResolveSymlinks |
-                                                              FILEDIALOG_OPTIONS,
+                                                              qApp->seamlyMeSettings()->getUseNativeFileDialogs(),
                                                               QFileDialog::Directory, QFileDialog::AcceptOpen);
 
     const QString dir = QFileInfo(filename).filePath();

--- a/src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp
+++ b/src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp
@@ -160,7 +160,8 @@ void MeShortcutsDialog::sendToPrinter()
 void MeShortcutsDialog::exportPdf()
 {
     QString filename = QFileDialog::getSaveFileName(nullptr, tr("Export PDF"), QString(),
-                                                    "*.pdf", nullptr, FILEDIALOG_OPTIONS);
+                                                    "*.pdf", nullptr,
+                                                    qApp->seamlyMeSettings()->getUseNativeFileDialogs());
 
     if (QFileInfo(filename).suffix().isEmpty())
     {

--- a/src/app/seamlyme/tmainwindow.cpp
+++ b/src/app/seamlyme/tmainwindow.cpp
@@ -526,7 +526,8 @@ void TMainWindow::CreateFromExisting()
 		usedNotExistedDir = directory.mkpath(".");
 	}
 
-    const QString filename = fileDialog(this, tr("Select file"), dir, filter, nullptr, FILEDIALOG_OPTIONS,
+    const QString filename = fileDialog(this, tr("Select file"), dir, filter, nullptr,
+                                        qApp->seamlyMeSettings()->getUseNativeFileDialogs(),
                                         QFileDialog::ExistingFile, QFileDialog::AcceptOpen);
 
 	if (!filename.isEmpty())
@@ -564,7 +565,8 @@ void TMainWindow::handleBodyScanner1()
         usedNotExistedDir = directory.mkpath(".");
     }
 
-    const QString filename = fileDialog(this, tr("Import body scan"), dir, filter, nullptr, FILEDIALOG_OPTIONS,
+    const QString filename = fileDialog(this, tr("Import body scan"), dir, filter, nullptr,
+                                        qApp->seamlyMeSettings()->getUseNativeFileDialogs(),
                                         QFileDialog::ExistingFile, QFileDialog::AcceptOpen);
 
     QMessageBox messageBox(this);
@@ -1144,7 +1146,7 @@ bool TMainWindow::FileSaveAs()
 	}
 
     fileName = fileDialog(this, tr("Save as"), dir + QLatin1String("/") + fileName,
-                                        filters, nullptr, FILEDIALOG_OPTIONS,
+                                        filters, nullptr, qApp->seamlyMeSettings()->getUseNativeFileDialogs(),
                                         QFileDialog::AnyFile, QFileDialog::AcceptSave);
 
 	auto RemoveTempDir = [usedNotExistedDir, dir]()
@@ -1655,7 +1657,8 @@ void TMainWindow::ImportFromPattern()
 	dir = VCommonSettings::PrepareStandardTemplates(dir);
 
     const QString filename = fileDialog(this, tr("Import from a pattern"), dir, filter, nullptr,
-                                        FILEDIALOG_OPTIONS, QFileDialog::ExistingFile,
+                                        qApp->seamlyMeSettings()->getUseNativeFileDialogs(),
+                                        QFileDialog::ExistingFile,
                                         QFileDialog::AcceptOpen);
 
 	if (filename.isEmpty())
@@ -3055,7 +3058,8 @@ bool TMainWindow::EvalFormula(const QString &formula, bool fromUser, VContainer 
 //---------------------------------------------------------------------------------------------------------------------
 void TMainWindow::Open(const QString &dir, const QString &filter)
 {
-    const QString filename = fileDialog(this, tr("Open file"), dir, filter, nullptr, FILEDIALOG_OPTIONS,
+    const QString filename = fileDialog(this, tr("Open file"), dir, filter, nullptr,
+                                        qApp->seamlyMeSettings()->getUseNativeFileDialogs(),
                                         QFileDialog::ExistingFile, QFileDialog::AcceptOpen);
 
 	if (!filename.isEmpty())

--- a/src/libs/tools/images/image_tool.cpp
+++ b/src/libs/tools/images/image_tool.cpp
@@ -71,7 +71,7 @@ QString getImageFilename(QWidget *parent)
     }
 
     const QString filename = QFileDialog::getOpenFileName(parent, QObject::tr("Open Image File"), path, filter, nullptr,
-                                                          FILEDIALOG_OPTIONS);
+                                                          qApp->Seamly2DSettings()->getUseNativeFileDialogs());
 
     return filename;
 }

--- a/src/libs/vmisc/def.h
+++ b/src/libs/vmisc/def.h
@@ -47,19 +47,6 @@
     #include <windows.h>
 #endif /* Q_OS_WIN */
 
-/*
- * Platform-dependent native dialog options.
- * On Windows, use non-native dialogs (DontUseNativeDialog) for better consistency.
- * On Linux and macOS, use native dialogs for a more native look and feel.
- */
-#ifdef Q_OS_WIN
-    const QFileDialog::Options  FILEDIALOG_OPTIONS  = QFileDialog::DontUseNativeDialog;
-    const QColorDialog::ColorDialogOptions COLORDIALOG_OPTIONS = QColorDialog::DontUseNativeDialog;
-#else
-    const QFileDialog::Options  FILEDIALOG_OPTIONS  = QFileDialog::Options();
-    const QColorDialog::ColorDialogOptions COLORDIALOG_OPTIONS = QColorDialog::ColorDialogOptions();
-#endif
-
 #include "debugbreak.h"
 
 template <class T> class QSharedPointer;
@@ -87,7 +74,7 @@ enum DialogSource : quint16
     MeasurementDialog = 257  // 0000 0001 0000 0001
 };
 
-enum class AppTheme 
+enum class AppTheme
 {
     LightFusion = 0,
     DarkFusion,

--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -55,6 +55,8 @@
 #include <QApplication>
 #include <QDate>
 #include <QDir>
+#include <QColorDialog>
+#include <QFileDialog>
 #include <QFont>
 #include <QtGlobal>
 #include <QLocale>
@@ -128,6 +130,7 @@ const QString settingGraphicsViewShowLayoutToolBar       = QStringLiteral("graph
 const QString settingGraphicsAutoClearFx                 = QStringLiteral("graphicsview/autoClearFx");
 
 const QString settingGraphicsViewDialogPosition          = QStringLiteral("graphicsview/dialogPosition");
+const QString settingGraphicsUseNativeDialogs            = QStringLiteral("graphicsview/useNativeDialogs");
 const QString settingGraphicsUseSecondMonitor            = QStringLiteral("graphicsview/useSecondMonitor");
 const QString settingGraphicsViewXOffset                 = QStringLiteral("graphicsview/xOffset");
 const QString settingGraphicsViewYOffset                 = QStringLiteral("graphicsview/yOffset");
@@ -961,6 +964,40 @@ bool VCommonSettings::getShowLayoutToolBar() const
 void VCommonSettings::setShowLayoutToolBar(const bool &value)
 {
     setValue(settingGraphicsViewShowLayoutToolBar, value);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+bool VCommonSettings::useNativeDialogs() const
+{
+    return value(settingGraphicsUseNativeDialogs, true).toBool();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VCommonSettings::setUseNativeDialogs(const bool &value)
+{
+    setValue(settingGraphicsUseNativeDialogs, value);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+QFileDialog::Options VCommonSettings::getUseNativeFileDialogs() const
+{
+    QFileDialog::Options options = QFileDialog::Options();
+    if (!value(settingGraphicsUseNativeDialogs, true).toBool())
+    {
+        options = QFileDialog::DontUseNativeDialog;
+    }
+    return options;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+QColorDialog::ColorDialogOptions VCommonSettings::getUseNativeColorDialogs() const
+{
+    QColorDialog::ColorDialogOptions options = QColorDialog::ColorDialogOptions();
+    if (!value(settingGraphicsUseNativeDialogs, true).toBool())
+    {
+        options = QColorDialog::DontUseNativeDialog;
+    }
+    return options;
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vmisc/vcommonsettings.h
+++ b/src/libs/vmisc/vcommonsettings.h
@@ -54,6 +54,8 @@
 #define VCOMMONSETTINGS_H
 
 #include <QByteArray>
+#include <QColorDialog>
+#include <QFileDialog>
 #include <QMetaObject>
 #include <QObject>
 #include <QSettings>
@@ -203,6 +205,11 @@ public:
 
     bool                 getShowLayoutToolBar() const;
     void                 setShowLayoutToolBar(const bool &value);
+
+    bool                 useNativeDialogs() const;
+    void                 setUseNativeDialogs(const bool &value);
+    QFileDialog::Options getUseNativeFileDialogs() const;
+    QColorDialog::ColorDialogOptions getUseNativeColorDialogs() const;
 
     bool                 useSecondMonitor() const;
     void                 setUseSecondMonitor(const bool &value);

--- a/src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp
+++ b/src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp
@@ -39,6 +39,8 @@
 #include <Qt>
 
 #include "../vmisc/def.h"
+#include "../vmisc/vabstractapplication.h"
+#include "../vmisc/vcommonsettings.h"
 
 VPE::VFileEditWidget::VFileEditWidget(QWidget *parent, bool is_directory)
     : QWidget(parent), CurrentFilePath(), ToolButton(nullptr), FileLineEdit(nullptr), FileDialogFilter(), FilterList(),
@@ -115,10 +117,10 @@ void VPE::VFileEditWidget::onToolButtonClicked()
 {
     QString filepath = (Directory ? QFileDialog::getExistingDirectory(nullptr, tr("Directory"), CurrentFilePath,
                                                                       QFileDialog::ShowDirsOnly
-                                                                      | FILEDIALOG_OPTIONS)
+                                                                      | qApp->Settings()->getUseNativeFileDialogs())
                                   : QFileDialog::getOpenFileName(nullptr, tr("Open File"), CurrentFilePath,
                                                                  FileDialogFilter, nullptr,
-                                                                 FILEDIALOG_OPTIONS));
+                                                                 qApp->Settings()->getUseNativeFileDialogs()));
     if (filepath.isNull() == false)
     {
         setFile(filepath, true);

--- a/src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp
+++ b/src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp
@@ -51,6 +51,7 @@
 #include "editlabeltemplate_dialog.h"
 #include "ui_editlabeltemplate_dialog.h"
 #include "../vmisc/vabstractapplication.h"
+#include "../vmisc/vcommonsettings.h"
 #include "../vformat/vlabeltemplate.h"
 #include "../ifc/xml/vlabeltemplateconverter.h"
 #include "../ifc/xml/vabstractpattern.h"
@@ -321,7 +322,7 @@ void EditLabelTemplateDialog::ExportTemplate()
 
     QString fileName = QFileDialog::getSaveFileName(this, tr("Export label template"),
                                                     dir + QLatin1String("/") + tr("template") + QLatin1String(".xml"),
-                                                    filters, nullptr, FILEDIALOG_OPTIONS);
+                                                    filters, nullptr, qApp->Settings()->getUseNativeFileDialogs());
 
     auto RemoveTempDir = [usedNotExistedDir, dir]()
     {
@@ -382,7 +383,7 @@ void EditLabelTemplateDialog::ImportTemplate()
     QString filter(tr("Label template") + QLatin1String("(*.xml)"));
     const QString fileName = QFileDialog::getOpenFileName(this, tr("Import template"),
                                                           qApp->Settings()->getLabelTemplatePath(), filter, nullptr,
-                                                          FILEDIALOG_OPTIONS);
+                                                          qApp->Settings()->getUseNativeFileDialogs());
     if (fileName.isEmpty())
     {
         return;
@@ -483,7 +484,7 @@ void EditLabelTemplateDialog::InitPlaceholdersMenu()
         ++i;
     }
 
-    // Insert sorted items into popup menu. 
+    // Insert sorted items into popup menu.
     auto j = sortedItems.constBegin();
     while (j != sortedItems.constEnd())
     {

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
@@ -819,7 +819,8 @@ void PatternPieceDialog::pieceNameChanged()
 //---------------------------------------------------------------------------------------------------------------------
 void PatternPieceDialog::pieceColorChanged()
 {
-    const QColor color = QColorDialog::getColor(Qt::white, this, tr("Select Color"), COLORDIALOG_OPTIONS);
+    const QColor color = QColorDialog::getColor(Qt::white, this, tr("Select Color"),
+                                                qApp->Settings()->getUseNativeColorDialogs());
 
     if (color.isValid())
     {

--- a/src/libs/vwidgets/vabstractmainwindow.cpp
+++ b/src/libs/vwidgets/vabstractmainwindow.cpp
@@ -124,7 +124,7 @@ void VAbstractMainWindow::exportToCSV(QString &file)
     const QString path = QDir::homePath() + QLatin1String("/") + file + QLatin1String(".") + suffix;
 
     QString fileName = QFileDialog::getSaveFileName(this, tr("Export to CSV"), path, filters, nullptr,
-                                                    FILEDIALOG_OPTIONS);
+                                                    qApp->Settings()->getUseNativeFileDialogs());
 
     if (fileName.isEmpty())
     {


### PR DESCRIPTION
This PR addresses issue #1667 and adds the following:

- Preference to Seamly2D and SeamlyMe to use the Native dialogs. The preference is checked by default. The purpose of the preference is for users that have the OS set to Dark mode, and don't like having a dialog pop up in Dark mode when they have Seamly in Light mode... or vice versa. 

  <img width="805" height="657" alt="image" src="https://github.com/user-attachments/assets/9e2099c0-c8fb-49e9-98e4-f1df3655d546" />

  <img width="655" height="419" alt="image" src="https://github.com/user-attachments/assets/b74a6a55-7b6f-40d4-a9d5-bac4e69ec2c7" />

- Using the native file dialog will now display the full list of Quick Access folders:

<img width="833" height="474" alt="image" src="https://github.com/user-attachments/assets/613d256b-4d34-4354-8bbb-cbc1d28762f9" />

- Preference covers both file and color selection dialogs. Note that the Native and Non Native color dialog is the same on Windows.

- lupdate. 

Closes issue #1667 
