### PR TITLE
test: pin sumTrapezoids to its value, not just its sign

### DIFF
--- a/src/test/Seamly2DTest/tst_vabstractpiece.cpp
+++ b/src/test/Seamly2DTest/tst_vabstractpiece.cpp
@@ -1869,9 +1869,11 @@ QVector<QPointF> TST_VAbstractPiece::OutputPointsCase3() const
 //---------------------------------------------------------------------------------------------------------------------
 void TST_VAbstractPiece::sumTrapezoids() const
 {
-    // Case3 checks that the method 'sumTrapezoids' returns negative value for three clockwise allocated points
-    // Case4 checks that the method 'sumTrapezoids' returns positive value for three counterclock-wise allocated points
-    // Case5 checks that the method 'sumTrapezoids' returns 0 for one point
+    // Case3 checks that the method 'sumTrapezoids' returns twice the negative area for three clockwise
+    // allocated points
+    // Case4 checks that the method 'sumTrapezoids' returns twice the positive area for three
+    // counterclock-wise allocated points
+    // Case5 checks that the method 'sumTrapezoids' returns 0 for fewer than three points
     Case3();
     Case4();
     Case5();
@@ -3118,8 +3120,10 @@ void TST_VAbstractPiece::Case3() const
 {
     const QVector<QPointF> points = InputPointsCase3a(); // Input points.
 
+    // The triangle has an area of 262.5 and its points are clockwise, so the sum is -525.
     const qreal result = VAbstractPiece::sumTrapezoids(points);
     QVERIFY(result < 0);
+    QCOMPARE(result, -525.0);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -3127,17 +3131,20 @@ void TST_VAbstractPiece::Case4() const
 {
     const QVector<QPointF> points = InputPointsCase4a(); // Input points.
 
+    // The triangle has an area of 612.5 and its points are counterclock-wise, so the sum is 1225.
     const qreal result = VAbstractPiece::sumTrapezoids(points);
     QVERIFY(result > 0);
+    QCOMPARE(result, 1225.0);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void TST_VAbstractPiece::Case5() const
 {
-    const QVector<QPointF> points = InputPointsCase5a(); // Input points.
-
-    const qreal result = VAbstractPiece::sumTrapezoids(points);
-    QVERIFY(qFuzzyIsNull(result));
+    // Fewer than three points enclose no area. This case covers the guard in 'sumTrapezoids', so it
+    // has to exercise every size the guard admits, not just one of them.
+    QVERIFY(qFuzzyIsNull(VAbstractPiece::sumTrapezoids(QVector<QPointF>())));  // No points.
+    QVERIFY(qFuzzyIsNull(VAbstractPiece::sumTrapezoids(InputPointsCase5a()))); // One point.
+    QVERIFY(qFuzzyIsNull(VAbstractPiece::sumTrapezoids(InputPointsCase5b()))); // Two points.
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -3506,6 +3513,17 @@ QVector<QPointF> TST_VAbstractPiece::InputPointsCase5a() const
     QVector<QPointF> points;
 
     points += QPointF(35, 35);
+
+    return points;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+QVector<QPointF> TST_VAbstractPiece::InputPointsCase5b() const
+{
+    QVector<QPointF> points;
+
+    points += QPointF(35, 35);
+    points += QPointF(50, 50);
 
     return points;
 }

--- a/src/test/Seamly2DTest/tst_vabstractpiece.h
+++ b/src/test/Seamly2DTest/tst_vabstractpiece.h
@@ -113,6 +113,7 @@ private:
     QVector<QPointF> InputPointsCase3a() const;
     QVector<QPointF> InputPointsCase4a() const;
     QVector<QPointF> InputPointsCase5a() const;
+    QVector<QPointF> InputPointsCase5b() const;
 
     QVector<VSAPoint> InputPointsIssue646() const;
     QVector<QPointF>  OutputPointsIssue646() const;


### PR DESCRIPTION
## What does this PR do?

`TST_VAbstractPiece::sumTrapezoids()` cannot see a wrong area. Double every
result the function returns and the test still passes:

```diff
--- a/src/libs/vlayout/vabstractpiece.cpp
+++ b/src/libs/vlayout/vabstractpiece.cpp
-    return res;
+    return res * 2;
```

```console
PASS   : TST_VAbstractPiece::sumTrapezoids()
```

A 100% error in a polygon area is caught, but only far away, by
`TST_VArc::TestGetPoints` (65 failures) and `TST_VEllipticalArc::TestGetPoints`
(12) — both reach `sumTrapezoids` through `qAbs(sumTrapezoids(points)/2.0)`.
The test named after the function reports nothing.

Cause: `Case3` asserts only `result < 0` and `Case4` only `result > 0`, so any
implementation that keeps the sign passes. `Case5` is stronger still — it has no
falsifier at all. Its input is one point, and the function is

```cpp
    qreal s, res = 0;
    const int n = points.size();

    if(n > 2)
    {
        ...
    }
    return res;
```

so `res` is still 0 whatever the trapezoid formula becomes.
`QVERIFY(qFuzzyIsNull(result))` holds for every possible implementation.

Isolating that: replace the formula *inside* the guard with `s = 0`, leaving the
guard alone.

```console
FAIL!  : TST_VAbstractPiece::sumTrapezoids() 'result < 0' returned FALSE. ()
FAIL!  : TST_VAbstractPiece::sumTrapezoids() 'result > 0' returned FALSE. ()
```

Two of the three `QVERIFY`s report. `Case5` is the one that stays quiet.

## The change

`Case3` and `Case4` now compare the value as well as the sign. `sumTrapezoids`
returns twice the signed area; the two triangles have areas of 262.5 and 612.5,
so the sums are -525 and 1225. I read both off the built function before writing
them down rather than deriving them and hoping:

```console
Case3a (3 pts, clockwise)    n=3  sumTrapezoids= -525.0000  |r|/2=  262.5000
Case4a (3 pts, ccw)          n=3  sumTrapezoids= 1225.0000  |r|/2=  612.5000
```

`Case5` keeps its meaning — fewer than three points enclose no area — but now
covers every size the guard admits (zero, one, two) instead of one of them. That
is a check on the guard, not on the formula; the formula is what `Case3` and
`Case4` now pin.

I did not touch `sumTrapezoids` itself. Its behaviour is correct; only the test
was unable to say so.

## Measured

Qt 6.11.1, clang 21, macOS 26.5 arm64, `develop` @ `6df7ff9`, built with
`qmake Seamly2D.pro && make`.

| `sumTrapezoids` implementation | `sumTrapezoids()` on `develop` | on this branch |
|---|---|---|
| unchanged | PASS | PASS |
| `return res * 2` | **PASS** | **FAIL** |
| formula inside `if (n > 2)` → `s = 0` | FAIL (Case3, Case4 only) | FAIL |

Whole `Seamly2DTests` binary, unmodified vs. this branch — identical:

```console
develop : 32155 passed, 1 failed
branch  : 32155 passed, 1 failed
```

The one failure is `TST_VAbstractPiece::EquidistantRemoveLoop(Issue 646.)`. It
fails the same way on unmodified `develop` on this machine, so it is not
something this branch introduced, and I have not investigated it. CI runs the
suite on Linux; I only have macOS here.

I did not use `CollectionTest`, because I could not get it to run usefully on
this machine at all: one run aborted in `initTestCase()` with "Fail to prepare
test files for testing", another reported "Program crashed" for every case
including ones that only pass a bad path to the binary. `initTestCase()` removes
`tmpTestFolder` as a path relative to the current directory but copies into
`applicationDirPath()`, so a run from a different working directory cannot clean
up after the previous one. This diff is test-only and touches nothing
`CollectionTest` exercises. CI runs the unit tests on Linux only (`ci.yml`, job
`linux-test`).

No user-facing change, so no CHANGELOG entry — say the word if you would prefer one.
