### PR TITLE
fix: reject an unknown unit on a draft image instead of reading it as cm

### DIFF
--- a/src/libs/ifc/schema/pattern/v0.7.4.xsd
+++ b/src/libs/ifc/schema/pattern/v0.7.4.xsd
@@ -718,7 +718,7 @@
                         <xs:attribute name="xPos" type="xs:double" use="required"/>
                         <xs:attribute name="yPos" type="xs:double" use="required"/>
                         <xs:attribute name="locked" type="xs:boolean" use="required"/>
-                        <xs:attribute name="units" type="xs:string" use="required"/>
+                        <xs:attribute name="units" type="imageUnits" use="required"/>
                         <xs:attribute name="opacity" type="xs:double" use="required"/>
                         <xs:attribute name="order" type="xs:double" use="required"/>
                         <xs:attribute name="xOffset" type="xs:double" use="required"/>
@@ -759,6 +759,14 @@
   <xs:simpleType name="formatVersion">
     <xs:restriction base="xs:string">
       <xs:pattern value="(0|([1-9][0-9]*))\.(0|([1-9][0-9]*))\.(0|([1-9][0-9]*))"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="imageUnits">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="mm"/>
+      <xs:enumeration value="cm"/>
+      <xs:enumeration value="inch"/>
+      <xs:enumeration value="px"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="imageExtension">


### PR DESCRIPTION
Fixes #1672.

## What does this PR do?

`<images><image units="...">` is declared `xs:string`, so the schema accepts any
value. `VPattern::parseImageElement()` then hands it to `StrToUnits()`, which
recognises only `mm`, `cm`, `inch` and `px` and returns `Unit::Cm` for everything
else without logging. A pattern carrying `units="in"` opens with no warning and
the image is placed and reported in centimetres.

The same element already refuses a malformed number. Against the shipped
`v0.7.4.xsd`, before this change:

```console
width="abc"      -> fails to validate ('abc' is not a valid xs:double)
units="furlong"  -> validates
```

and against the built function:

```console
StrToUnits("inch") -> Inch
StrToUnits("in")   -> Cm
StrToUnits("INCH") -> Cm
StrToUnits("CM")   -> Cm
```

`"in"` is the abbreviation `ImageDialog::updateUnits()` puts on the spin boxes,
while the format writes `"inch"`.

## The change

Give the attribute an enumerated type, the way the sibling `extension`
attribute in the same element already uses `imageExtension`.

The four values are exactly what `UnitsToStr()` writes, so no file Seamly2D has
ever saved is affected — this rejects only files that were already being read
wrongly.

Only the current schema needs the change. `applyPatches()` validates against
`getSchema(0x000704)` at the end of every upgrade path, and a file already at
0.7.4 is validated against it by `ValidateInputFile()`, so every file arrives at
v0.7.4.xsd whatever version it declares.

I did not change `StrToUnits()` itself. That is the wider fix — a `bool *ok`
out parameter, and `parseImageElement()` raising the error
`GetParametrDouble()` already raises — but it touches a signature used in 20-odd
places and I would rather you chose it than have me assume it. This PR closes
the one path that is reachable from a file; happy to follow up with the other.

## Measured

Qt 6.11.1, clang 21, macOS 26.5 arm64, `develop` @ `6df7ff9`.

`xmllint --noout --schema v0.7.4.xsd` on a minimal pattern whose only variable
is the image's `units`:

| `units` | before | after |
|---|---|---|
| `mm` | validates | validates |
| `cm` | validates | validates |
| `inch` | validates | validates |
| `px` | validates | validates |
| `in` | **validates** | **rejected** |
| `furlong` | **validates** | **rejected** |
| `CM` | **validates** | **rejected** |
| `""` | **validates** | **rejected** |

Whole `Seamly2DTests` binary, unmodified vs. this branch — identical:

```console
develop : 32155 passed, 1 failed
branch  : 32155 passed, 1 failed
```

The one failure is `TST_VAbstractPiece::EquidistantRemoveLoop(Issue 646.)`,
which fails the same way on unmodified `develop` on this machine. Not something
this branch introduced, and I have not investigated it. CI runs the suite on
Linux; I only have macOS here.

None of the 146 `.sm2d`/`.val` files in the repository contains an `<images>`
block or a `units=` attribute, so none of them changes validity under this diff:

```console
$ grep -rl "<images>" --include="*.sm2d" --include="*.val" .
$ grep -rn 'units="'  --include="*.sm2d" --include="*.val" .
$
```

I could not get `CollectionTest` to give a comparable result on this machine, so
I am not offering it as evidence in either direction. With the change present
every case reported "Program crashed"; on unmodified `develop` it did not get
that far, aborting in `initTestCase()` with "Fail to prepare test files for
testing". Both look like the harness rather than the diff — `initTestCase()`
removes `tmpTestFolder` as a path relative to the current directory but copies
into `applicationDirPath()`, so a second run from a different working directory
cannot clean up after the first, and the cases it does reach expect a plain
binary where a macOS build produces an `.app` bundle. CI runs the unit tests on
Linux only (`ci.yml`, job `linux-test`).

## What a user sees after this

The file is refused at load with the schema error, instead of drafting against
an underlay that is off by a factor of 2.54 with nothing said. That is the same
choice as e4df451 — report the real error rather than carry on with input that
could not be used.
