### PR TITLE
feat: Add delete draftblock menu item

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -7236,6 +7236,22 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
         <source>Error creating a backup copy: %1.</source>
         <translation>Chyba při vytváření záložní kopie: %1.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation>Smazat blok konceptu</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>Vymazat</translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation>Potvrdit smazání</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation>Opravdu chcete smazat základní bod a aktuální blok konceptu?</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -7221,6 +7221,22 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <source>Error creating a backup copy: %1.</source>
         <translation>Fehler bei der Erstellung einer Sicherungskopie: %1.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation>Entwurfblock löschen</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>Del</translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation>Löschen bestätigen</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation>Sind Sie sicher, dass Sie den Basispunkt und den aktuellen Entwurfsblock löschen möchten?</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -7240,6 +7240,22 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation>Σφάλμα κατά τη δημιουργία αντιγράφου ασφαλείας: %1.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation>Διαγραφή προσχεδίου μπλοκ</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>Διαγραφή</translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation>Επιβεβαίωση διαγραφής</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation>Είστε σίγουροι ότι θέλετε να διαγράψετε το σημείο βάσης και το τρέχον προσχέδιο μπλοκ?</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -7206,6 +7206,22 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation type="unfinished">Error creating a backup copy: %1.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -7206,6 +7206,22 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -7206,6 +7206,22 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation type="unfinished">Error creating a backup copy: %1.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -7221,6 +7221,22 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -7257,6 +7257,22 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation>Error al crear una copia de seguridad: %1.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation>Eliminar bloque de borrador</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>Suprimir</translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation>Confirmar eliminación</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation>¿Está seguro de que desea eliminar el punto base y el bloque de borrador actual?</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -7238,6 +7238,22 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
         <source>Error creating a backup copy: %1.</source>
         <translation>Virhe luotaessa varmuuskopiota: %1.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation>Poista luonnoslohko</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>Del</translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation>Vahvista poistaminen</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation>Haluatko varmasti poistaa peruspisteen ja nykyisen luonnoslohkon?</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -7262,6 +7262,22 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
         <source>Error creating a backup copy: %1.</source>
         <translation>Erreur lors de la création d&apos;un copie de sauvegarde: %1.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation>Supprimer le bloc de brouillon</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>Del</translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation>Confirmer la suppression</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation>Êtes-vous sûr de vouloir supprimer le point de base et le bloc de brouillon actuel ?</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -7202,6 +7202,22 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_hu_HU.ts
+++ b/share/translations/seamly2d_hu_HU.ts
@@ -7237,6 +7237,22 @@ Menti a módosításokat?</translation>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Ismeretlen hiba történt, például egy megtelt partíció megakadályozta a zárolási fájl kiírását.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation>Vázlattömb törlése</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>Törlés</translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation>Törlés megerősítése</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation>Biztosan törölni szeretné a bázispontot és a jelenlegi vázlattömböt?</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -7238,6 +7238,22 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
         <source>Error creating a backup copy: %1.</source>
         <translation>Gagal membuat salinan cadangan: %1.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation>Hapus blok draf</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>Hapus</translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation>Konfirmasi hapus</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation>Apakah Anda yakin ingin menghapus titik acuan dan blok draf saat ini?</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -7226,6 +7226,22 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
         <source>Error creating a backup copy: %1.</source>
         <translation>Errore nella creazione di una copia di backup: %1.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation>Elimina blocco bozza</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>Del</translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation>Confirma eliminazione</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation>Sei sicuro di voler eliminare il punto base e il blocco bozza corrente?</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -7221,6 +7221,22 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
         <source>Error creating a backup copy: %1.</source>
         <translation>Fout bij het maken van een back-upkopie: %1.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation>Conceptblok verwijderen</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>Del</translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation>Verwijdering bevestigen</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation>Weet u zeker dat u het basispunt en het huidige conceptblok wilt verwijderen?</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_pl_PL.ts
+++ b/share/translations/seamly2d_pl_PL.ts
@@ -7238,6 +7238,22 @@ Czy chcesz zapisać zmiany?</translation>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Wystąpił nieznany błąd, na przykład pełna partycja uniemożliwiła zapisanie pliku blokady.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation>Usuń blok szkicu</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>Del</translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation>Potwierdź usunięcie</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation>Czy na pewno chcesz usunąć punkt bazowy i bieżący blok szkicu?</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -7225,6 +7225,22 @@ Prima enter para o adicionar temporariamente à lista.</translation>
         <source>Error creating a backup copy: %1.</source>
         <translation>Erro ao criar uma cópia de backup: %1.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation>Excluir bloco de rascunho</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>Del</translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation>Confirmar exclusão</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation>Tem certeza de que deseja excluir o ponto base e o bloco de rascunho atual?</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -7240,6 +7240,22 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
         <source>Error creating a backup copy: %1.</source>
         <translation>Eroare la crearea unei copii rezervate: %1.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation>Șterge blocul de schiță</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>Șterge</translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation>Confirmă ștergerea</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation>Sigur doriți să ștergeți punctul de bază și blocul de schiță curent?</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -7242,6 +7242,22 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation>Ошибка создания резервной копии: %1.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation>Удалить блок черновика</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>Удалить</translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation>Подтвердить удаление</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation>Вы уверены, что хотите удалить базовую точку и текущий блок черновика?</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -7238,6 +7238,22 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
         <source>Error creating a backup copy: %1.</source>
         <translation>Yedek kopyası oluşturulurken hata oluştu: %1.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation>Taslak bloğunu sil</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>Sil</translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation>Silmeyi onayla</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation>Taban noktasını ve mevcut taslak bloğunu silmek istediğinizden emin misiniz?</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -7239,6 +7239,22 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation>Помилка створення резервної копії: %1.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation>Видалити блок чернетки</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>Διαγραφή</translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation>Підтвердити видалення</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation>Ви впевнені, що хочете видалити базову точку та поточний блок чернетки?</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -7238,6 +7238,22 @@ Press enter to temporarily add it to the list.</source>
         <source>Error creating a backup copy: %1.</source>
         <translation>创建备份副本出错:%1.</translation>
     </message>
+    <message>
+        <source>Delete Draft Block</source>
+        <translation>删除草稿块</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>的</translation>
+    </message>
+    <message>
+        <source>Confirm Delete</source>
+        <translation>确认删除</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete basepoint and current draft block?</source>
+        <translation>您确定要删除基准点和当前的草稿块吗?</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -91,6 +91,7 @@
 #include "../vtools/tools/nodeDetails/internal_path_tool.h"
 #include "../vtools/undocommands/addgroup.h"
 #include "../vtools/undocommands/rename_draftblock.h"
+#include "../vtools/undocommands/delete_draftblock.h"
 #include "../vtools/undocommands/label/showpointname.h"
 #include "../vwidgets/mouse_coordinates.h"
 #include "../vwidgets/vmaingraphicsscene.h"
@@ -420,6 +421,30 @@ void MainWindow::addDraftBlock(const QString &blockName)
     groupsWidget->updateGroups();
 }
 
+//---------------------------------------------------------------------------------------------------------------------
+void MainWindow::deleteDraftBlock()
+{
+    if (doc->draftBlockCount() == 1)
+    {
+        return;
+    }
+
+    qApp->getSceneView()->itemClicked(nullptr);
+    const auto answer = QMessageBox::question(this, tr("Confirm Delete"),
+                                              tr("Are you sure you want to delete basepoint and current draft block?"),
+                                              QMessageBox::Yes|QMessageBox::No, QMessageBox::No);
+    if (answer == QMessageBox::No)
+    {
+        return;
+    }
+
+    DeleteDraftBlock *command = new DeleteDraftBlock(doc, doc->getActiveDraftBlockName());
+    connect(command, &DeleteDraftBlock::NeedFullParsing, doc, &VAbstractPattern::NeedFullParsing);
+    connect(command, &DeleteDraftBlock::NeedFullParsing, this, [this](){setWidgetsEnabled(true);});
+    qApp->getUndoStack()->push(command);
+
+    setWidgetsEnabled(true);
+}
 
 /// @brief draftBlockStartPosition Set start position for draft block.
 ///
@@ -4369,6 +4394,8 @@ void MainWindow::Clear()
     ui->layoutMode_Action->setEnabled(false);
     ui->newDraft_Action->setEnabled(false);
     ui->renameDraft_Action->setEnabled(false);
+    ui->delete_draft_action->setEnabled(false);
+
     ui->save_Action->setEnabled(false);
     ui->saveAs_Action->setEnabled(false);
     ui->patternPreferences_Action->setEnabled(false);
@@ -4728,7 +4755,8 @@ void MainWindow::setWidgetsEnabled(bool enable)
 
     //enable tool menu actions
     ui->newDraft_Action->setEnabled(enable && draftStage);
-    ui->renameDraft_Action->setEnabled(enable && draftStage);
+    ui->renameDraft_Action->setEnabled(enable && draftStage && (doc->draftBlockCount() > 0));
+    ui->delete_draft_action->setEnabled(enable && draftStage && (doc->draftBlockCount() > 1));
 
     //enable measurement menu actions
     ui->loadIndividual_Action->setEnabled(enable && designStage);
@@ -5956,6 +5984,8 @@ void MainWindow::createActions()
 
         addDraftBlock(draftBlockName);
     });
+
+    connect(ui->delete_draft_action, &QAction::triggered, this,&MainWindow::deleteDraftBlock);
 
     //Tools->Point submenu actions
     connect(ui->midpoint_Action, &QAction::triggered, this, [this]

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -433,6 +433,7 @@ private:
     QStringList        getUnlockedRestoreFileList()const;
 
     void               addDraftBlock(const QString &blockName);
+    void               deleteDraftBlock();
     QPointF            draftBlockStartPosition() const;
 
     void               initializeScenes();

--- a/src/app/seamly2d/mainwindow.ui
+++ b/src/app/seamly2d/mainwindow.ui
@@ -322,6 +322,7 @@
     </widget>
     <addaction name="newDraft_Action"/>
     <addaction name="renameDraft_Action"/>
+    <addaction name="delete_draft_action"/>
     <addaction name="separator"/>
     <addaction name="points_Menu"/>
     <addaction name="lines_Menu"/>
@@ -4837,6 +4838,18 @@
     <string notr="true">Ctrl+PgDown</string>
    </property>
   </action>
+  <action name="delete_draft_action">
+   <property name="icon">
+    <iconset resource="../../libs/vmisc/share/resources/theme.qrc">
+     <normaloff>:/icons/win.icon.theme/16x16/actions/edit-delete.png</normaloff>:/icons/win.icon.theme/16x16/actions/edit-delete.png</iconset>
+   </property>
+   <property name="text">
+    <string>Delete Draft Block</string>
+   </property>
+   <property name="shortcut">
+    <string>Del</string>
+   </property>
+  </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
@@ -4848,8 +4861,8 @@
  </customwidgets>
  <resources>
   <include location="share/resources/toolicon.qrc"/>
-  <include location="../../libs/vmisc/share/resources/icon.qrc"/>
   <include location="../../libs/vmisc/share/resources/theme.qrc"/>
+  <include location="../../libs/vmisc/share/resources/icon.qrc"/>
  </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
This PR simply adds a "Delete Draft Block" to the Tools menu. 

<img width="321" height="102" alt="image" src="https://github.com/user-attachments/assets/c7c5ac36-5baa-49f3-ba91-536b26786dfa" />

It also handles the update of the menu item enabled state when a block is deleted, and subsequently restored via the Undo in the case where the Delete only leaves 1 block left.

It should be noted the Delete Draft Block is only enabled if there is more than 1 draft blocks in a pattern. 

An lupdate is also included. 

closes issue #1674 