### PR TITLE
Fix: font comboboxes on MacOS

### DIFF
--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.cpp
@@ -41,6 +41,7 @@
 #include <QDirIterator>
 #include <QDoubleSpinBox>
 #include <QFontComboBox>
+#include <QLabel>
 #include <QMessageBox>
 #include <QPixmap>
 #include <QTimer>
@@ -154,74 +155,27 @@ PreferencesGraphicsViewPage::PreferencesGraphicsViewPage (QWidget *parent)
 
     // Font preferences
     // Pattern piece labels font
-    QFont labelFont = qApp->Seamly2DSettings()->getLabelFont();
-    labelFont.setPointSize(12);
-    ui->labelFont_ComboBox->setCurrentFont(labelFont);
-    ui->label_Label->setFont(labelFont);
-
-    connect(ui->labelFont_ComboBox,
-            static_cast<void(QFontComboBox::*)(const QFont &)>(&QFontComboBox::currentFontChanged),
-            this, [this](QFont labelFont)
-    {
-        labelFont.setPointSize(12);
-        ui->label_Label->setFont(labelFont);
-    });
+    setupFontComboBox(ui->labelFont_ComboBox, ui->label_Label, qApp->Seamly2DSettings()->getLabelFont(), nullptr, 12);
 
     // Point name font
-    QFont nameFont = qApp->Seamly2DSettings()->getPointNameFont();
-    ui->pointNameFont_ComboBox->setCurrentFont(nameFont);
-
     int index = ui->pointNameFontSize_ComboBox->findText(QString().setNum(qApp->Seamly2DSettings()->getPointNameSize()));
     if (index != -1)
     {
         ui->pointNameFontSize_ComboBox->setCurrentIndex(index);
     }
 
-    nameFont.setPointSize(ui->pointNameFontSize_ComboBox->currentText().toInt());
-    ui->pointName_Label->setFont(nameFont);
-
-    connect(ui->pointNameFont_ComboBox,
-            static_cast<void(QFontComboBox::*)(const QFont &)>(&QFontComboBox::currentFontChanged),
-            this, [this](QFont nameFont)
-    {
-        nameFont.setPointSize(ui->pointNameFontSize_ComboBox->currentText().toInt());
-        ui->pointName_Label->setFont(nameFont);
-    });
-
-    connect(ui->pointNameFontSize_ComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this]()
-    {
-        QFont labelFont = ui->pointName_Label->font();
-        labelFont.setPointSize(ui->pointNameFontSize_ComboBox->currentText().toInt());
-        ui->pointName_Label->setFont(labelFont);
-    });
+    setupFontComboBox(ui->pointNameFont_ComboBox, ui->pointName_Label, qApp->Seamly2DSettings()->getPointNameFont(),
+                      ui->pointNameFontSize_ComboBox, 0);
 
     // GUI font
-    QFont guiFont = qApp->Seamly2DSettings()->getGuiFont();
-    ui->guiFont_ComboBox->setCurrentFont(guiFont);
-
     index = ui->guiFontSize_ComboBox->findText(QString().setNum(qApp->Seamly2DSettings()->getGuiFontSize()));
     if (index != -1)
     {
         ui->guiFontSize_ComboBox->setCurrentIndex(index);
     }
 
-    guiFont.setPointSize(ui->guiFontSize_ComboBox->currentText().toInt());
-    ui->gui_Label->setFont(guiFont);
-
-    connect(ui->guiFont_ComboBox,
-            static_cast<void(QFontComboBox::*)(const QFont &)>(&QFontComboBox::currentFontChanged),
-            this, [this](QFont guiFont)
-    {
-        guiFont.setPointSize(ui->guiFontSize_ComboBox->currentText().toInt());
-        ui->gui_Label->setFont(guiFont);
-    });
-
-    connect(ui->guiFontSize_ComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this]()
-    {
-        QFont guiFont = ui->gui_Label->font();
-        guiFont.setPointSize(ui->guiFontSize_ComboBox->currentText().toInt());
-        ui->gui_Label->setFont(guiFont);
-    });
+    setupFontComboBox(ui->guiFont_ComboBox, ui->gui_Label, qApp->Seamly2DSettings()->getGuiFont(),
+                      ui->guiFontSize_ComboBox, 0);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -345,12 +299,15 @@ void PreferencesGraphicsViewPage::Apply()
     settings->setAutoClearFx(ui->autoClearFx_CheckBox->isChecked());
 
     //Fonts
-    settings->setLabelFont(ui->labelFont_ComboBox->currentFont());
+    settings->setLabelFont(ui->labelFont_ComboBox->itemData(ui->labelFont_ComboBox->currentIndex(),
+                                                            Qt::FontRole).value<QFont>());
 
-    settings->setGuiFont(ui->guiFont_ComboBox->currentFont());
+    settings->setGuiFont(ui->guiFont_ComboBox->itemData(ui->guiFont_ComboBox->currentIndex(),
+                                                        Qt::FontRole).value<QFont>());
     settings->setGuiFontSize(ui->guiFontSize_ComboBox->currentText().toInt());
 
-    settings->setPointNameFont(ui->pointNameFont_ComboBox->currentFont());
+    settings->setPointNameFont(ui->pointNameFont_ComboBox->itemData(ui->pointNameFont_ComboBox->currentIndex(),
+                                                                    Qt::FontRole).value<QFont>());
     settings->setPointNameSize(ui->pointNameFontSize_ComboBox->currentText().toInt());
 }
 
@@ -366,4 +323,118 @@ void PreferencesGraphicsViewPage::setIndex(QComboBox *box, const QString &text)
     {
         box->setCurrentIndex(box->findText(text));
     }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+// @brief Configures a raw QComboBox to act as a locked, filtered font selector.
+// @param combo_box The target font QComboBox to populate.
+// @param label The companion preview QLabel to style.
+// @param initial_font The initial saved QFont setting.
+// @param size_combo_box Optional companion size QComboBox (pass nullptr if not used).
+// @param fixed_size Optional explicit font size override (set to 0 to use dynamic sizing).
+//---------------------------------------------------------------------------------------------------------------------
+void PreferencesGraphicsViewPage::setupFontComboBox(QComboBox *combo_box, QLabel *label, const QFont &initial_font, QComboBox *size_combo_box, int fixed_size)
+{
+    if (!combo_box || !label)
+    {
+        return;
+    }
+
+    // Configure stable horizontal layout policies
+    combo_box->setSizeAdjustPolicy(QComboBox::AdjustToContentsOnFirstShow);
+    combo_box->setEnabled(true);
+
+    // Populate and filter fonts safely
+    QFontDatabase font_database;
+    QStringList font_families = font_database.families();
+    int fallback_size = initial_font.pointSize();
+
+    for (int i = 0; i < font_families.count(); ++i)
+    {
+        QString font_name = font_families.at(i);
+
+        // Enforce vector outlines across all platforms
+        if (font_database.isSmoothlyScalable(font_name))
+        {
+            // Defensive cross-platform check to drop explicit bitmap containers
+            if (font_name.contains("bitmap", Qt::CaseInsensitive) ||
+                font_name.contains("GB18030", Qt::CaseInsensitive))
+            {
+                continue;
+            }
+
+            combo_box->addItem(font_name);
+            int inserted_index = combo_box->count() - 1;
+
+            // Set individual dropdown row preview text style (fixed to 10pt for clean scannability)
+            QFont row_font(font_name, 10);
+            combo_box->setItemData(inserted_index, row_font, Qt::FontRole);
+        }
+    }
+
+    // Set up initial current font choices
+    int font_index = combo_box->findText(initial_font.family());
+    if (font_index >= 0)
+    {
+        combo_box->setCurrentIndex(font_index);
+    }
+
+    // Enforce standardized point size for the main layout boxes to avoid layout shifting
+    QFont base_font = initial_font;
+    base_font.setPointSize(10);
+    combo_box->setFont(base_font);
+
+    // Style the preview label to match the baseline font setting
+    int initial_target_size = getTargetSize(size_combo_box, fixed_size, fallback_size);
+    QFont preview_font = initial_font;
+    preview_font.setPointSize(initial_target_size);
+    label->setFont(preview_font);
+
+    // Handle runtime font family changes
+    connect(combo_box, &QComboBox::currentTextChanged, label, [this, combo_box, label,
+            size_combo_box, fixed_size, fallback_size](const QString &family)
+    {
+        // Adjust the closed combo box to prevent visual size bouncing
+        QFont closed_box_font(family);
+        closed_box_font.setPointSize(10);
+        combo_box->setFont(closed_box_font);
+
+        // Adjust the companion preview text label style using the class method
+        int dynamic_size = getTargetSize(size_combo_box, fixed_size, fallback_size);
+        QFont display_font(family);
+        display_font.setPointSize(dynamic_size);
+        label->setFont(display_font);
+    });
+
+    // Handle runtime font size changes (if a companion size box exists)
+    if (size_combo_box)
+    {
+        connect(size_combo_box, &QComboBox::currentTextChanged, label, [this, label, size_combo_box,
+               fixed_size, fallback_size]()
+        {
+            int dynamic_size = getTargetSize(size_combo_box, fixed_size, fallback_size);
+            QFont label_font = label->font();
+            label_font.setPointSize(dynamic_size);
+            label->setFont(label_font);
+        });
+    }
+
+    // Lock visual box vertical layout dimensions perfectly
+    combo_box->ensurePolished();
+    label->ensurePolished();
+
+    //combo_box->setFixedHeight(22);
+}
+
+int PreferencesGraphicsViewPage::getTargetSize(QComboBox * size_combo_box, int fixed_size, int fallback_size)
+{
+    if (fixed_size > 0)
+    {
+        return fixed_size;
+    }
+    if (size_combo_box)
+    {
+        return size_combo_box->currentText().toInt();
+    }
+    return fallback_size;
 }

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.h
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.h
@@ -29,6 +29,7 @@
 
 #include <QWidget>
 #include <QComboBox>
+#include <QLabel>
 
 namespace Ui
 {
@@ -54,6 +55,11 @@ private:
     Ui::PreferencesGraphicsViewPage  *ui;
 
     void                              setIndex(QComboBox *box, const QString &text);
+    void                              setupFontComboBox(QComboBox *combo_box, QLabel *label, const QFont &initial_font,
+                                                        QComboBox *size_combo_box = nullptr, int fixed_size = 0);
+
+    int                               getTargetSize(QComboBox * size_combo_box, int fixed_size, int fallback_size);
+
 };
 
 #endif // PREFERENCES_GRAPHICSVIEWPAGE_H

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
@@ -817,26 +817,7 @@
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QFontComboBox" name="labelFont_ComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="styleSheet">
-               <string notr="true"/>
-              </property>
-              <property name="fontFilters">
-               <set>QFontComboBox::ScalableFonts</set>
-              </property>
-             </widget>
+             <widget class="QComboBox" name="labelFont_ComboBox"/>
             </item>
            </layout>
           </item>
@@ -873,7 +854,7 @@
          <property name="minimumSize">
           <size>
            <width>420</width>
-           <height>120</height>
+           <height>0</height>
           </size>
          </property>
          <property name="font">
@@ -917,32 +898,7 @@
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QFontComboBox" name="pointNameFont_ComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="styleSheet">
-               <string notr="true"/>
-              </property>
-              <property name="fontFilters">
-               <set>QFontComboBox::ScalableFonts</set>
-              </property>
-             </widget>
+             <widget class="QComboBox" name="pointNameFont_ComboBox"/>
             </item>
             <item row="1" column="0">
              <widget class="QLabel" name="pointNameFontSize_Label">
@@ -1186,7 +1142,7 @@
          <property name="minimumSize">
           <size>
            <width>420</width>
-           <height>120</height>
+           <height>0</height>
           </size>
          </property>
          <property name="font">
@@ -1230,32 +1186,7 @@
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QFontComboBox" name="guiFont_ComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="styleSheet">
-               <string notr="true"/>
-              </property>
-              <property name="fontFilters">
-               <set>QFontComboBox::ScalableFonts</set>
-              </property>
-             </widget>
+             <widget class="QComboBox" name="guiFont_ComboBox"/>
             </item>
             <item row="1" column="0">
              <widget class="QLabel" name="guiFontSize_Label">

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -2442,46 +2442,84 @@ void MainWindow::initializeModesToolBar()
 
 #ifdef Q_OS_MAC
 #include <CoreText/CoreText.h>
+#include <QSortFilterProxyModel>
+
+// Inline proxy to seamlessly intercept and drop SFNT-wrapped bitmap fonts from the UI view
+class MacBitmapFontFilterProxy : public QSortFilterProxyModel
+{
+protected:
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override
+    {
+        QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
+        QString familyName = sourceModel()->data(index).toString();
+
+        // Return true to keep the font, false to hide it seamlessly from the UI
+        return !MainWindow::hasEmbeddedBitmapTables(familyName);
+    }
+};
 
 // Helper to inspect raw binary font tables on macOS
 bool MainWindow::hasEmbeddedBitmapTables(const QString &familyName)
 {
-    bool hasBitmaps = false;
     CFStringRef cfFamilyName = familyName.toCFString();
-
     CFStringRef keys[] = { kCTFontFamilyNameAttribute };
     CFTypeRef values[] = { cfFamilyName };
-    CFDictionaryRef attributes = CFDictionaryCreate(kCTFontAllocatorDefault, (const void**)keys, (const void**)values, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+    CFDictionaryRef attributes = CFDictionaryCreate(
+        kCFAllocatorDefault,
+        (const void**)keys,
+        (const void**)values,
+        1,
+        &kCTTypeDictionaryKeyCallBacks,
+        &kCTTypeDictionaryValueCallBacks
+    );
+
     CTFontDescriptorRef descriptor = CTFontDescriptorCreateWithAttributes(attributes);
     CFRelease(attributes);
     CFRelease(cfFamilyName);
 
-    if (descriptor)
+    // Guard 1: Exit early if the font descriptor failed to create
+    if (!descriptor)
     {
-        CTFontRef font = CTFontCreateWithFontDescriptor(descriptor, 12.0, nullptr);
-        if (font)
-        {
-            CFArrayRef tags = CTFontCopyAvailableTables(font, kCTFontTableOptionNoOptions);
-            if (tags)
-            {
-                CFIndex count = CFArrayGetCount(tags);
-                for (CFIndex i = 0; i < count; ++i)
-                {
-                    CTFontTableTag tag = (CTFontTableTag)(uintptr_t)CFArrayGetValueAtIndex(tags, i);
-
-                    // Blocks 'sbix'/'CBDT' (Color) and 'EBLC'/'EBDT' (Monochrome/GB18030)
-                    if (tag == 'sbix' || tag == 'CBDT' || tag == 'EBLC' || tag == 'EBDT')
-                    {
-                        hasBitmaps = true;
-                        break;
-                    }
-                }
-                CFRelease(tags);
-            }
-            CFRelease(font);
-        }
-        CFRelease(descriptor);
+        return false;
     }
+
+    CTFontRef font = CTFontCreateWithFontDescriptor(descriptor, 12.0, nullptr);
+    CFRelease(descriptor);
+
+    // Exit early if the font could not be resolved
+    if (!font)
+    {
+        return false;
+    }
+
+    CFArrayRef tags = CTFontCopyAvailableTables(font, kCTFontTableOptionNoOptions);
+    CFRelease(font);
+
+    // Exit early if the font has no available tables
+    if (!tags)
+    {
+        return false;
+    }
+
+    bool hasBitmaps = false;
+    CFIndex count = CFArrayGetCount(tags);
+
+    for (CFIndex i = 0; i < count; ++i)
+    {
+        uintptr_t value = (uintptr_t)CFArrayGetValueAtIndex(tags, i);
+        CTFontTableTag tag = (CTFontTableTag)value;
+
+        // 'sbix' = 0x73626978 | 'CBDT' = 0x43424454
+        // 'EBLC' = 0x45424C43 | 'EBDT' = 0x45424454
+        if (tag == 0x73626978 || tag == 0x43424454 || tag == 0x45424C43 || tag == 0x45424454)
+        {
+            hasBitmaps = true;
+            break;
+        }
+    }
+
+    CFRelease(tags);
     return hasBitmaps;
 }
 #endif
@@ -2495,21 +2533,15 @@ void MainWindow::initializePointNameToolBar()
     fontComboBox = new QFontComboBox ;
     fontComboBox->setFontFilters(QFontComboBox::ScalableFonts);
 
-// Filter out bitmap fonts contaained in a tff wrapper.
+    // Intercept fonts containing a bitmap wrapper using the proxy filter on macOS
 #ifdef Q_OS_MAC
-    QAbstractItemModel *fontModel = fontCombo->model();
+    QAbstractItemModel *fontModel = fontComboBox->model();
+
     if (fontModel)
     {
-        // Loop backwards to safely remove rows from the internal model
-        for (int i = fontModel->rowCount() - 1; i >= 0; --i)
-        {
-            QString familyName = fontModel->data(fontModel->index(i, 0)).toString();
-
-            if (hasEmbeddedBitmapTables(familyName))
-            {
-                fontModel->removeRow(i);
-            }
-        }
+        MacBitmapFontFilterProxy *proxy = new MacBitmapFontFilterProxy(fontComboBox);
+        proxy->setSourceModel(fontModel);
+        fontComboBox->setModel(proxy);
     }
 #endif
 

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -96,6 +96,7 @@
 #include "../vwidgets/vmaingraphicsscene.h"
 #include "../vwidgets/vwidgetpopup.h"
 
+#include <QAbstractItemModel>
 #include <QInputDialog>
 #include <QtDebug>
 #include <QMessageBox>
@@ -113,7 +114,6 @@
 #include <QAction>
 #include <QComboBox>
 #include <QDateTime>
-#include <QFontComboBox>
 #include <QDoubleSpinBox>
 #include <QFileDialog>
 #include <QFileSystemWatcher>
@@ -2415,6 +2415,51 @@ void MainWindow::initializeModesToolBar()
     ui->mode_ToolBar->insertWidget(ui->layoutMode_Action, rightGoToStage);
 }
 
+#ifdef Q_OS_MAC
+#include <CoreText/CoreText.h>
+
+// Helper to inspect raw binary font tables on macOS
+bool MainWindow::hasEmbeddedBitmapTables(const QString &familyName)
+{
+    bool hasBitmaps = false;
+    CFStringRef cfFamilyName = familyName.toCFString();
+
+    CFStringRef keys[] = { kCTFontFamilyNameAttribute };
+    CFTypeRef values[] = { cfFamilyName };
+    CFDictionaryRef attributes = CFDictionaryCreate(kCTFontAllocatorDefault, (const void**)keys, (const void**)values, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CTFontDescriptorRef descriptor = CTFontDescriptorCreateWithAttributes(attributes);
+    CFRelease(attributes);
+    CFRelease(cfFamilyName);
+
+    if (descriptor)
+    {
+        CTFontRef font = CTFontCreateWithFontDescriptor(descriptor, 12.0, nullptr);
+        if (font)
+        {
+            CFArrayRef tags = CTFontCopyAvailableTables(font, kCTFontTableOptionNoOptions);
+            if (tags)
+            {
+                CFIndex count = CFArrayGetCount(tags);
+                for (CFIndex i = 0; i < count; ++i)
+                {
+                    CTFontTableTag tag = (CTFontTableTag)(uintptr_t)CFArrayGetValueAtIndex(tags, i);
+
+                    // Blocks 'sbix'/'CBDT' (Color) and 'EBLC'/'EBDT' (Monochrome/GB18030)
+                    if (tag == 'sbix' || tag == 'CBDT' || tag == 'EBLC' || tag == 'EBDT')
+                    {
+                        hasBitmaps = true;
+                        break;
+                    }
+                }
+                CFRelease(tags);
+            }
+            CFRelease(font);
+        }
+        CFRelease(descriptor);
+    }
+    return hasBitmaps;
+}
+#endif
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
@@ -2424,6 +2469,25 @@ void MainWindow::initializePointNameToolBar()
 {
     fontComboBox = new QFontComboBox ;
     fontComboBox->setFontFilters(QFontComboBox::ScalableFonts);
+
+// Filter out bitmap fonts contaained in a tff wrapper.
+#ifdef Q_OS_MAC
+    QAbstractItemModel *fontModel = fontCombo->model();
+    if (fontModel)
+    {
+        // Loop backwards to safely remove rows from the internal model
+        for (int i = fontModel->rowCount() - 1; i >= 0; --i)
+        {
+            QString familyName = fontModel->data(fontModel->index(i, 0)).toString();
+
+            if (hasEmbeddedBitmapTables(familyName))
+            {
+                fontModel->removeRow(i);
+            }
+        }
+    }
+#endif
+
     fontComboBox->setCurrentFont(qApp->Seamly2DSettings()->getPointNameFont());
     ui->pointName_ToolBar->insertWidget(ui->showPointNames_Action,fontComboBox);
     fontComboBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -97,6 +97,7 @@
 #include "../vwidgets/vmaingraphicsscene.h"
 #include "../vwidgets/vwidgetpopup.h"
 
+#include <QAbstractItemModel>
 #include <QInputDialog>
 #include <QtDebug>
 #include <QMessageBox>
@@ -114,7 +115,6 @@
 #include <QAction>
 #include <QComboBox>
 #include <QDateTime>
-#include <QFontComboBox>
 #include <QDoubleSpinBox>
 #include <QFileDialog>
 #include <QFileSystemWatcher>
@@ -2440,6 +2440,51 @@ void MainWindow::initializeModesToolBar()
     ui->mode_ToolBar->insertWidget(ui->layoutMode_Action, rightGoToStage);
 }
 
+#ifdef Q_OS_MAC
+#include <CoreText/CoreText.h>
+
+// Helper to inspect raw binary font tables on macOS
+bool MainWindow::hasEmbeddedBitmapTables(const QString &familyName)
+{
+    bool hasBitmaps = false;
+    CFStringRef cfFamilyName = familyName.toCFString();
+
+    CFStringRef keys[] = { kCTFontFamilyNameAttribute };
+    CFTypeRef values[] = { cfFamilyName };
+    CFDictionaryRef attributes = CFDictionaryCreate(kCTFontAllocatorDefault, (const void**)keys, (const void**)values, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CTFontDescriptorRef descriptor = CTFontDescriptorCreateWithAttributes(attributes);
+    CFRelease(attributes);
+    CFRelease(cfFamilyName);
+
+    if (descriptor)
+    {
+        CTFontRef font = CTFontCreateWithFontDescriptor(descriptor, 12.0, nullptr);
+        if (font)
+        {
+            CFArrayRef tags = CTFontCopyAvailableTables(font, kCTFontTableOptionNoOptions);
+            if (tags)
+            {
+                CFIndex count = CFArrayGetCount(tags);
+                for (CFIndex i = 0; i < count; ++i)
+                {
+                    CTFontTableTag tag = (CTFontTableTag)(uintptr_t)CFArrayGetValueAtIndex(tags, i);
+
+                    // Blocks 'sbix'/'CBDT' (Color) and 'EBLC'/'EBDT' (Monochrome/GB18030)
+                    if (tag == 'sbix' || tag == 'CBDT' || tag == 'EBLC' || tag == 'EBDT')
+                    {
+                        hasBitmaps = true;
+                        break;
+                    }
+                }
+                CFRelease(tags);
+            }
+            CFRelease(font);
+        }
+        CFRelease(descriptor);
+    }
+    return hasBitmaps;
+}
+#endif
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
@@ -2449,6 +2494,25 @@ void MainWindow::initializePointNameToolBar()
 {
     fontComboBox = new QFontComboBox ;
     fontComboBox->setFontFilters(QFontComboBox::ScalableFonts);
+
+// Filter out bitmap fonts contaained in a tff wrapper.
+#ifdef Q_OS_MAC
+    QAbstractItemModel *fontModel = fontCombo->model();
+    if (fontModel)
+    {
+        // Loop backwards to safely remove rows from the internal model
+        for (int i = fontModel->rowCount() - 1; i >= 0; --i)
+        {
+            QString familyName = fontModel->data(fontModel->index(i, 0)).toString();
+
+            if (hasEmbeddedBitmapTables(familyName))
+            {
+                fontModel->removeRow(i);
+            }
+        }
+    }
+#endif
+
     fontComboBox->setCurrentFont(qApp->Seamly2DSettings()->getPointNameFont());
     ui->pointName_ToolBar->insertWidget(ui->showPointNames_Action,fontComboBox);
     fontComboBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -179,8 +179,8 @@ MainWindow::MainWindow(QWidget *parent)
     , dialogTable(nullptr)
     , dialogTool()
     , historyDialog(nullptr)
-    , fontComboBox(nullptr)
-    , fontSizeComboBox(nullptr)
+    , font_combo_box(nullptr)
+    , font_size_combo_box(nullptr)
     , draftBlockComboBox(nullptr)
     , draftBlockLabel(nullptr)
     , currentBlockIndex(0)
@@ -2440,197 +2440,123 @@ void MainWindow::initializeModesToolBar()
     ui->mode_ToolBar->insertWidget(ui->layoutMode_Action, rightGoToStage);
 }
 
-#ifdef Q_OS_MAC
-#include <CoreText/CoreText.h>
-#include <QSortFilterProxyModel>
+//---------------------------------------------------------------------------------------------------------------------
+//
+// @brief MainWindow::initializePointNameToolBar enable Point Name toolbar.
+//---------------------------------------------------------------------------------------------------------------------
+ void MainWindow::initializePointNameToolBar()
+ {
+     font_combo_box = new QComboBox(this);
+     QFontDatabase font_database;
+     QStringList font_families = font_database.families();
 
-// Inline proxy to seamlessly intercept and drop SFNT-wrapped bitmap fonts from the UI view
-class MacBitmapFontFilterProxy : public QSortFilterProxyModel
-{
-protected:
-    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override
-    {
-        QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
-        QString familyName = sourceModel()->data(index).toString();
+     // Loop through each item and apply its respective font to the FontRole
+     for (int i = 0; i < font_families.count(); ++i)
+     {
+         QString font_name = font_families.at(i);
 
-        // Return true to keep the font, false to hide it seamlessly from the UI
-        return !MainWindow::hasEmbeddedBitmapTables(familyName);
-    }
-};
+         // enforces vector outlines and catches fonts wrapped in bitmap tables
+         if (font_database.isSmoothlyScalable(font_name))
+         {
+             // Cross-platform safety block: Catch explicit bitmap wrappers
+             if (font_name.contains("bitmap", Qt::CaseInsensitive) ||
+             font_name.contains("GB18030", Qt::CaseInsensitive))
+             {
+                 continue;
+             }
 
-// Helper to inspect raw binary font tables on macOS
-bool MainWindow::hasEmbeddedBitmapTables(const QString &familyName)
-{
-    CFStringRef cfFamilyName = familyName.toCFString();
-    CFStringRef keys[] = { kCTFontFamilyNameAttribute };
-    CFTypeRef values[] = { cfFamilyName };
+             font_combo_box->addItem(font_name);
+             int inserted_index = font_combo_box->count() - 1;
 
-    CFDictionaryRef attributes = CFDictionaryCreate(
-        kCFAllocatorDefault,
-        (const void**)keys,
-        (const void**)values,
-        1,
-        &kCTTypeDictionaryKeyCallBacks,
-        &kCTTypeDictionaryValueCallBacks
-    );
+             QFont font(font_name, 10);
+             font_combo_box->setItemData(inserted_index, font, Qt::FontRole);
+         }
+     }
 
-    CTFontDescriptorRef descriptor = CTFontDescriptorCreateWithAttributes(attributes);
-    CFRelease(attributes);
-    CFRelease(cfFamilyName);
+     //font_combo_box->setSizeAdjustPolicy(QComboBox::AdjustToContentsOnFirstShow);
+     font_combo_box->setFixedWidth(250);
+     font_combo_box->setEnabled(true);
 
-    // Guard 1: Exit early if the font descriptor failed to create
-    if (!descriptor)
-    {
-        return false;
-    }
+     int font_index = font_combo_box->findText(qApp->Seamly2DSettings()->getPointNameFont().family());
+     if (font_index >= 0)
+     {
+         font_combo_box->setCurrentIndex(font_index);
+         QFont initial_font = qApp->Seamly2DSettings()->getPointNameFont();
+         initial_font.setPointSize(10);
+         font_combo_box->setFont(initial_font);
+     }
 
-    CTFontRef font = CTFontCreateWithFontDescriptor(descriptor, 12.0, nullptr);
-    CFRelease(descriptor);
+     ui->pointName_ToolBar->insertWidget(ui->showPointNames_Action, font_combo_box);
 
-    // Exit early if the font could not be resolved
-    if (!font)
-    {
-        return false;
-    }
+     connect(font_combo_box, &QComboBox::currentTextChanged, this, [this](const QString &family)
+     {
+         QFont selected_font(family);
+         selected_font.setPointSize(10);
+         font_combo_box->setFont(selected_font);
+         qApp->Seamly2DSettings()->setPointNameFont(selected_font);
+         upDateScenes();
+     });
 
-    CFArrayRef tags = CTFontCopyAvailableTables(font, kCTFontTableOptionNoOptions);
-    CFRelease(font);
+     font_size_combo_box = new QComboBox;
+     ui->pointName_ToolBar->insertWidget(ui->showPointNames_Action, font_size_combo_box);
+     font_size_combo_box->setSizeAdjustPolicy(QComboBox::AdjustToContentsOnFirstShow);
 
-    // Exit early if the font has no available tables
-    if (!tags)
-    {
-        return false;
-    }
+     const QList<int> font_sizes = {
+         6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 20, 22, 24, 26, 28, 32, 36, 40, 44, 48, 54, 60, 66, 72, 80, 96
+     };
 
-    bool hasBitmaps = false;
-    CFIndex count = CFArrayGetCount(tags);
+     for (int size : font_sizes)
+     {
+         font_size_combo_box->addItem(QString::number(size), QVariant(size));
+     }
 
-    for (CFIndex i = 0; i < count; ++i)
-    {
-        uintptr_t value = (uintptr_t)CFArrayGetValueAtIndex(tags, i);
-        CTFontTableTag tag = (CTFontTableTag)value;
+     int size_index = font_size_combo_box->findData(qApp->Seamly2DSettings()->getPointNameSize());
+     if (size_index < 0 || size_index > 28)
+     {
+         size_index = 18;
+     }
+     font_size_combo_box->setCurrentIndex(size_index);
 
-        // 'sbix' = 0x73626978 | 'CBDT' = 0x43424454
-        // 'EBLC' = 0x45424C43 | 'EBDT' = 0x45424454
-        if (tag == 0x73626978 || tag == 0x43424454 || tag == 0x45424C43 || tag == 0x45424454)
-        {
-            hasBitmaps = true;
-            break;
-        }
-    }
+     connect(font_size_combo_box, &QComboBox::currentTextChanged, this, [this](QString text)
+     {
+         qApp->Seamly2DSettings()->setPointNameSize(text.toInt());
+         upDateScenes();
+     });
 
-    CFRelease(tags);
-    return hasBitmaps;
-}
-#endif
+     font_size_combo_box->setEnabled(true);
+
+     base_point_combo_box = new QComboBox;
+     ui->pointName_ToolBar->addWidget(base_point_combo_box);
+     initBasePointComboBox();
+     base_point_combo_box->setEnabled(true);
+
+     font_combo_box->ensurePolished();
+     font_size_combo_box->ensurePolished();
+
+     // Lock the font box height to perfectly match the size box height
+     int locked_height = font_size_combo_box->sizeHint().height();
+     font_combo_box->setFixedHeight(locked_height);
+
+     connect(base_point_combo_box, &QComboBox::currentTextChanged, this, &MainWindow::basePointChanged);
+ }
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief initializePointNameToolBar enable Point Name toolbar.
- */
-void MainWindow::initializePointNameToolBar()
-{
-    fontComboBox = new QFontComboBox ;
-    fontComboBox->setFontFilters(QFontComboBox::ScalableFonts);
-
-    // Intercept fonts containing a bitmap wrapper using the proxy filter on macOS
-#ifdef Q_OS_MAC
-    QAbstractItemModel *fontModel = fontComboBox->model();
-
-    if (fontModel)
-    {
-        MacBitmapFontFilterProxy *proxy = new MacBitmapFontFilterProxy(fontComboBox);
-        proxy->setSourceModel(fontModel);
-        fontComboBox->setModel(proxy);
-    }
-#endif
-
-    fontComboBox->setCurrentFont(qApp->Seamly2DSettings()->getPointNameFont());
-    ui->pointName_ToolBar->insertWidget(ui->showPointNames_Action,fontComboBox);
-    fontComboBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);
-    fontComboBox->setEnabled(true);
-
-    connect(fontComboBox, static_cast<void (QFontComboBox::*)(const QFont &)>(&QFontComboBox::currentFontChanged),
-            this, [this](QFont font)
-            {
-                qApp->Seamly2DSettings()->setPointNameFont(font);
-                upDateScenes();
-            });
-
-    fontSizeComboBox = new QComboBox ;
-    ui->pointName_ToolBar->insertWidget(ui->showPointNames_Action,fontSizeComboBox);
-    fontSizeComboBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);
-    fontSizeComboBox->addItem("6", QVariant(static_cast<int>(6)));
-    fontSizeComboBox->addItem("7", QVariant(static_cast<int>(7)));
-    fontSizeComboBox->addItem("8", QVariant(static_cast<int>(8)));
-    fontSizeComboBox->addItem("9", QVariant(static_cast<int>(9)));
-    fontSizeComboBox->addItem("10", QVariant(static_cast<int>(10)));
-    fontSizeComboBox->addItem("11", QVariant(static_cast<int>(11)));
-    fontSizeComboBox->addItem("12", QVariant(static_cast<int>(12)));
-    fontSizeComboBox->addItem("13", QVariant(static_cast<int>(13)));
-    fontSizeComboBox->addItem("14", QVariant(static_cast<int>(14)));
-    fontSizeComboBox->addItem("15", QVariant(static_cast<int>(15)));
-    fontSizeComboBox->addItem("16", QVariant(static_cast<int>(16)));
-    fontSizeComboBox->addItem("18", QVariant(static_cast<int>(18)));
-    fontSizeComboBox->addItem("20", QVariant(static_cast<int>(20)));
-    fontSizeComboBox->addItem("22", QVariant(static_cast<int>(22)));
-    fontSizeComboBox->addItem("24", QVariant(static_cast<int>(24)));
-    fontSizeComboBox->addItem("26", QVariant(static_cast<int>(26)));
-    fontSizeComboBox->addItem("28", QVariant(static_cast<int>(28)));
-    fontSizeComboBox->addItem("32", QVariant(static_cast<int>(32)));
-    fontSizeComboBox->addItem("36", QVariant(static_cast<int>(36)));
-    fontSizeComboBox->addItem("40", QVariant(static_cast<int>(40)));
-    fontSizeComboBox->addItem("44", QVariant(static_cast<int>(44)));
-    fontSizeComboBox->addItem("48", QVariant(static_cast<int>(48)));
-    fontSizeComboBox->addItem("54", QVariant(static_cast<int>(54)));
-    fontSizeComboBox->addItem("60", QVariant(static_cast<int>(60)));
-    fontSizeComboBox->addItem("66", QVariant(static_cast<int>(66)));
-    fontSizeComboBox->addItem("72", QVariant(static_cast<int>(72)));
-    fontSizeComboBox->addItem("80", QVariant(static_cast<int>(80)));
-    fontSizeComboBox->addItem("96", QVariant(static_cast<int>(96)));
-
-    int index = fontSizeComboBox->findData(qApp->Seamly2DSettings()->getPointNameSize());
-    if (index < 0 || index > 28)
-    {
-        index = 18;
-    }
-    fontSizeComboBox->setCurrentIndex(index);
-
-    connect(fontSizeComboBox, &QComboBox::currentTextChanged, this, [this](QString text)
-            {
-                qApp->Seamly2DSettings()->setPointNameSize(text.toInt());
-                upDateScenes();
-            });
-    fontSizeComboBox->setEnabled(true);
-
-    basePointComboBox = new QComboBox ;
-    ui->pointName_ToolBar->addWidget(basePointComboBox);
-    initBasePointComboBox();
-    basePointComboBox->setEnabled(true);
-
-    connect(basePointComboBox, &QComboBox::currentTextChanged, this, &MainWindow::basePointChanged);
-}
-
-
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief initBasePointComboBox fills basePointComboBox.
+ * @brief initBasePointComboBox fills base_point_combo_box.
  */
 void MainWindow::initBasePointComboBox()
 {
-    basePointComboBox->clear();
-    basePointComboBox->addItem(tr("Default"));
-    basePointComboBox->addItems(doc->GetCurrentAlphabet()); // These items are based on the Point name language
-    basePointComboBox->setToolTip(tr("Base name used for new points.\nPress enter to temporarily add it to the list."));
-    basePointComboBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);
-    basePointComboBox->setCurrentIndex(0);
-    basePointComboBox->setEditable(true);
+    base_point_combo_box->clear();
+    base_point_combo_box->addItem(tr("Default"));
+    base_point_combo_box->addItems(doc->GetCurrentAlphabet()); // These items are based on the Point name language
+    base_point_combo_box->setToolTip(tr("Base name used for new points.\nPress enter to temporarily add it to the list."));
+    base_point_combo_box->setSizeAdjustPolicy(QComboBox::AdjustToContents);
+    base_point_combo_box->setCurrentIndex(0);
+    base_point_combo_box->setEditable(true);
+    base_point_combo_box->setInsertPolicy(QComboBox::InsertAtTop);
 
     // Force any child line edit to dynamically pull from the current app palette
-    basePointComboBox->setStyleSheet("QComboBox QLineEdit { color: palette(text); background: palette(base); }");
-
-
-    basePointComboBox->setInsertPolicy(QComboBox::InsertAtTop);
+    base_point_combo_box->setStyleSheet("QComboBox QLineEdit { color: palette(text); background: palette(base); }");
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -2848,17 +2774,17 @@ void MainWindow::penChanged(Pen pen)
 
 void MainWindow::basePointChanged()
 {
-    QString text = basePointComboBox->currentText();
+    QString text = base_point_combo_box->currentText();
     QString basePoint = QString();
 
     QRegularExpression rx(NameRegExp());
     if (rx.match(text).hasMatch() == false)
     {
-        basePointComboBox->setStyleSheet("QComboBox {color: red;}");
+        base_point_combo_box->setStyleSheet("QComboBox {color: red;}");
     }
     else
     {
-        basePointComboBox->setStyleSheet("QComboBox {color: black;}");
+        base_point_combo_box->setStyleSheet("QComboBox {color: black;}");
 
         if (!text.isEmpty() && text != tr("Default"))
         {
@@ -6036,17 +5962,17 @@ void MainWindow::createActions()
 
     connect(ui->increaseSize_Action, &QAction::triggered, this, [this]()
     {
-        int index = qMin(fontSizeComboBox->currentIndex() + 1, fontSizeComboBox->count()-1);
-        fontSizeComboBox->setCurrentIndex(index);
-        qApp->Seamly2DSettings()->setPointNameSize(fontSizeComboBox->currentText().toInt());
+        int index = qMin(font_size_combo_box->currentIndex() + 1, font_size_combo_box->count()-1);
+        font_size_combo_box->setCurrentIndex(index);
+        qApp->Seamly2DSettings()->setPointNameSize(font_size_combo_box->currentText().toInt());
         upDateScenes();
     });
 
     connect(ui->decreaseSize_Action, &QAction::triggered, this, [this]()
     {
-        const int index = qMax(fontSizeComboBox->currentIndex() - 1, 0);
-        fontSizeComboBox->setCurrentIndex(index);
-        qApp->Seamly2DSettings()->setPointNameSize(fontSizeComboBox->currentText().toInt());
+        const int index = qMax(font_size_combo_box->currentIndex() - 1, 0);
+        font_size_combo_box->setCurrentIndex(index);
+        qApp->Seamly2DSettings()->setPointNameSize(font_size_combo_box->currentText().toInt());
         upDateScenes();
     });
 
@@ -6943,10 +6869,6 @@ void MainWindow::initToolBarStyles()
     initToolBarStyle(ui->edit_Toolbar);
     initToolBarStyle(ui->zoom_ToolBar);
     initToolBarStyle(ui->file_ToolBar);
-
-    fontComboBox->setCurrentFont(qApp->Seamly2DSettings()->getPointNameFont());
-    int index = fontSizeComboBox->findData(qApp->Seamly2DSettings()->getPointNameSize());
-    fontSizeComboBox->setCurrentIndex(index);
 }
 
 void MainWindow::resetOrigins()

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -346,6 +346,11 @@ private:
     void                              initializeStatusToolBar();
     void                              initializeModesToolBar();
     void                              initializeDraftToolBar();
+
+#ifdef Q_OS_MAC
+    bool                              hasEmbeddedBitmapTables(const QString &familyName);
+#endif
+
     void                              initializePointNameToolBar();
     void                              initializeToolsToolBar();
     void                              initializeToolBarVisibility();

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -299,9 +299,9 @@ private:
     QSharedPointer<DialogTool>        dialogTool;
     QPointer<HistoryDialog>           historyDialog;
 
-    QFontComboBox                    *fontComboBox;
-    QComboBox                        *fontSizeComboBox;
-    QComboBox                        *basePointComboBox;
+    QComboBox                        *font_combo_box;
+    QComboBox                        *font_size_combo_box;
+    QComboBox                        *base_point_combo_box;
     QComboBox                        *draftBlockComboBox;  /// @brief draftBlockComboBox stores names of draft blocks.
     QLabel                           *draftBlockLabel;
     qint32                            currentBlockIndex;   /// @brief currentBlockIndex  current selected draft block.
@@ -346,11 +346,6 @@ private:
     void                              initializeStatusToolBar();
     void                              initializeModesToolBar();
     void                              initializeDraftToolBar();
-
-#ifdef Q_OS_MAC
-    bool                              hasEmbeddedBitmapTables(const QString &familyName);
-#endif
-
     void                              initializePointNameToolBar();
     void                              initializeToolsToolBar();
     void                              initializeToolBarVisibility();

--- a/src/app/seamly2d/seamly2d.pro
+++ b/src/app/seamly2d/seamly2d.pro
@@ -350,6 +350,8 @@ win32 {
     copyToDestdir($${PWD}/$$INSTALL_XERCES, $$shell_path($${OUT_PWD}/$$DESTDIR))
 }
 
+macx: LIBS += -framework CoreText
+
 macx{
     APPLE_SIGN_IDENTITY_UNQUOTED = $(APPLE_SIGN_IDENTITY)
     APPLE_SIGN_IDENTITY = $$shell_quote($(APPLE_SIGN_IDENTITY))

--- a/src/app/seamly2d/seamly2d.pro
+++ b/src/app/seamly2d/seamly2d.pro
@@ -350,8 +350,6 @@ win32 {
     copyToDestdir($${PWD}/$$INSTALL_XERCES, $$shell_path($${OUT_PWD}/$$DESTDIR))
 }
 
-macx: LIBS += -framework CoreText
-
 macx{
     APPLE_SIGN_IDENTITY_UNQUOTED = $(APPLE_SIGN_IDENTITY)
     APPLE_SIGN_IDENTITY = $$shell_quote($(APPLE_SIGN_IDENTITY))


### PR DESCRIPTION
This PR re-addresses issue #852 to filter bitmap fonts wrapped in a tff container on the MacOS. Rather than addressing the issue by catching and handling an exception  - which is just a bad practice - this PR filters any bitmap fonts so they do not appear in the combobox in the first place. 

- After countless tries it became apparent that the simplest way to address the offending macOS "GB18030 bitmap" font was to refactor the code to use a QComboBox and populate the box with a filtered item list instead of using the QFontComboBox which is locked down from any changes in the underlying model. 

 -  Note: The "GB18030" font is packaged with Mac's to be able to sell in China. It's the only bitmap font distributed by Apple this way in a ttf wrapper.

 -  The only thing we loose with the QComboBox is the TrueType icon. Since everything but ttf fonts are filtered out, the icon is redundant. 

     <img width="267" height="285" alt="image" src="https://github.com/user-attachments/assets/8c24d436-9ba8-416f-93eb-79db73f16422" />

     <img width="628" height="296" alt="image" src="https://github.com/user-attachments/assets/e3ce001b-7f92-4817-8218-ce3324c30de5" />


- Windows and MacOs versions tested fine. No ill effects with the Font Comboboxes  in either the Point name toolbar or in the Preferences were found. 

- Removes an unnecessary refresh of the Font Combobox in initBasePointComboBox()

- Refactors populating the font point size combobox. 
