### PR TITLE
fix: write corrected formula/radius to the right attribute in vpattern.cpp #issue-1679

### DIFF
--- a/src/app/seamly2d/xml/vpattern.cpp
+++ b/src/app/seamly2d/xml/vpattern.cpp
@@ -2215,8 +2215,8 @@ void VPattern::ParseToolPointOfIntersectionCircles(VMainGraphicsScene *scene, QD
         //Rewrite attribute formula. Need for situation when we have wrong formula.
         if (c1R != c1Radius || c2R != c2Radius)
         {
-            SetAttribute(domElement, AttrC1Center, c1R);
-            SetAttribute(domElement, AttrC2Center, c2R);
+            SetAttribute(domElement, AttrC1Radius, c1R);
+            SetAttribute(domElement, AttrC2Radius, c2R);
             modified = true;
             haveLiteChange();
         }
@@ -2290,7 +2290,7 @@ void VPattern::ParseToolPointFromCircleAndTangent(VMainGraphicsScene *scene, QDo
         //Rewrite attribute formula. Need for situation when we have wrong formula.
         if (cR != cRadius)
         {
-            SetAttribute(domElement, AttrCCenter, cR);
+            SetAttribute(domElement, AttrCRadius, cR);
             modified = true;
             haveLiteChange();
         }
@@ -3203,9 +3203,9 @@ void VPattern::ParseToolMove(VMainGraphicsScene *scene, QDomElement &domElement,
         //Rewrite attribute formula. Need for situation when we have wrong formula.
         if (a != angle || len != length || rot != rotation)
         {
-            SetAttribute(domElement, AttrAngle, angle);
-            SetAttribute(domElement, AttrLength, length);
-            SetAttribute(domElement, AttrRotationAngle, rotation);
+            SetAttribute(domElement, AttrAngle, a);
+            SetAttribute(domElement, AttrLength, len);
+            SetAttribute(domElement, AttrRotationAngle, rot);
             modified = true;
             haveLiteChange();
         }


### PR DESCRIPTION
Closes #1679.

Three pre-existing bugs in the "formula was auto-corrected on load, write it back" path of `src/app/seamly2d/xml/vpattern.cpp`, found incidentally while working on #1678. Each one wrote the wrong attribute or the wrong (uncorrected) value:

- `ParseToolPointOfIntersectionCircles`: wrote the corrected radius formulas into `AttrC1Center`/`AttrC2Center` (point-id attributes) instead of `AttrC1Radius`/`AttrC2Radius`.
- `ParseToolPointFromCircleAndTangent`: wrote the corrected radius formula into `AttrCCenter` instead of `AttrCRadius`.
- `ParseToolMove`: wrote back the original, still-broken `angle`/`length`/`rotation` strings instead of the actually-corrected `a`/`len`/`rot` values, so the auto-fix never persisted.

## Test plan
- [x] `seamly2d.exe` builds clean (Qt 6.11.1 / MinGW, Debug)
- [x] `ParserTest.exe` passes
- [x] `TranslationsTest.exe` passes
- [x] `Seamly2DTests.exe` passes