### PR TITLE
fix: reject duplicate group names on inline rename #issue-1682

### DIFF
--- a/src/app/seamly2d/dialogs/groups_widget.cpp
+++ b/src/app/seamly2d/dialogs/groups_widget.cpp
@@ -220,7 +220,26 @@ void GroupsWidget::renameGroup(int row, int column)
     const bool locked = m_doc->getGroupLock(groupId);
     if (locked == false)
     {
-        m_doc->setGroupName(groupId, ui->groups_TableWidget->item(row, column)->text());
+        QTableWidgetItem *item = ui->groups_TableWidget->item(row, column);
+        const QString newGroupName = item->text();
+        const QString oldGroupName = m_doc->getGroupName(groupId);
+
+        if (newGroupName != oldGroupName && m_doc->groupNameExists(newGroupName))
+        {
+            QMessageBox messageBox;
+            messageBox.setWindowTitle(tr("Name Exists"));
+            messageBox.setIcon(QMessageBox::Warning);
+            messageBox.setStandardButtons(QMessageBox::Ok);
+            messageBox.setText(tr("The action can't be completed because the group name already exists."));
+            messageBox.exec();
+
+            ui->groups_TableWidget->blockSignals(true);
+            item->setText(oldGroupName);
+            ui->groups_TableWidget->blockSignals(false);
+            return;
+        }
+
+        m_doc->setGroupName(groupId, newGroupName);
         updateGroups();
     }
 }

--- a/src/app/seamly2d/dialogs/groups_widget.cpp
+++ b/src/app/seamly2d/dialogs/groups_widget.cpp
@@ -221,10 +221,10 @@ void GroupsWidget::renameGroup(int row, int column)
     if (locked == false)
     {
         QTableWidgetItem *item = ui->groups_TableWidget->item(row, column);
-        const QString newGroupName = item->text();
-        const QString oldGroupName = m_doc->getGroupName(groupId);
+        const QString new_group_name = item->text();
+        const QString old_group_name = m_doc->getGroupName(groupId);
 
-        if (newGroupName != oldGroupName && m_doc->groupNameExists(newGroupName))
+        if (new_group_name != old_group_name && m_doc->groupNameExists(new_group_name))
         {
             QMessageBox messageBox;
             messageBox.setWindowTitle(tr("Name Exists"));
@@ -234,12 +234,12 @@ void GroupsWidget::renameGroup(int row, int column)
             messageBox.exec();
 
             ui->groups_TableWidget->blockSignals(true);
-            item->setText(oldGroupName);
+            item->setText(old_group_name);
             ui->groups_TableWidget->blockSignals(false);
             return;
         }
 
-        m_doc->setGroupName(groupId, newGroupName);
+        m_doc->setGroupName(groupId, new_group_name);
         updateGroups();
     }
 }


### PR DESCRIPTION
Fixes #1682.

## Summary

`GroupsWidget::renameGroup()` (triggered by double-clicking a group's name cell in the Groups panel) wrote the new name straight through without checking for a collision, unlike the two other group create/rename paths (`addGroupToList`, `editGroup`), which both call `groupNameExists()` and reject the duplicate with a warning dialog.

Two groups ending up with the same name lets any later name-based group lookup (e.g. `getGroupIdByName`, used by "Add to Group") resolve to whichever one comes first in a linear scan - silently landing on the wrong group.

Now matches the other two paths: same `groupNameExists()` check, same "Name Exists" warning dialog, and the edit reverts to the old name on rejection.

## Test plan

- [x] Built and ran `ParserTest`, `TranslationsTest`, `Seamly2DTests` - all green
- [x] Manually verified in the running app: created "GroupA" and "GroupB", double-clicked "GroupB"'s name cell and typed "GroupA" - correctly rejected with the "Name Exists" warning, and the cell reverted to "GroupB" after dismissing it