### PR TITLE
fix(#1687): formula editor expansion in spline path dialog

### DIFF
--- a/src/libs/vtools/dialogs/tools/dialogsplinepath.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogsplinepath.cpp
@@ -1077,14 +1077,6 @@ void DialogSplinePath::collapseFormula(QPlainTextEdit *textEdit, QPushButton *pu
     SCASSERT(textEdit != nullptr)
     SCASSERT(pushButton != nullptr)
 
-    const QTextCursor cursor = textEdit->textCursor();
-
-    setMaximumWidth(260);
     textEdit->setFixedHeight(height);
     pushButton->setIcon(QIcon::fromTheme("go-down", QIcon(":/icons/win.icon.theme/16x16/actions/go-down.png")));
-    setUpdatesEnabled(false);
-    repaint();
-    setUpdatesEnabled(true);
-    textEdit->setFocus();
-    textEdit->setTextCursor(cursor);
 }

--- a/src/libs/vtools/dialogs/tools/dialogtool.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogtool.cpp
@@ -84,12 +84,11 @@
 #include <QtDebug>
 #include <QtMath>
 #include <algorithm>
-#include <new>
 #include <QBuffer>
 #include <QFont>
+#include <QBoxLayout>
 
 #include "../ifc/xml/vabstractpattern.h"
-#include "../ifc/xml/vdomdocument.h"
 #include "../qmuparser/qmudef.h"
 #include "../qmuparser/qmuparsererror.h"
 #include "../vgeometry/vpointf.h"
@@ -109,7 +108,6 @@ template <class T> class QSharedPointer;
 Q_LOGGING_CATEGORY(vDialog, "v.dialog")
 
 #define DIALOG_MAX_FORMULA_HEIGHT 64
-#define DIALOG_MIN_WIDTH 260
 
 namespace
 {
@@ -141,6 +139,7 @@ DialogTool:: DialogTool(const VContainer *data, const quint32 &toolId, QWidget *
     : QDialog(parent)
     , data(data)
     , isInitialized(false)
+    , initial_dialog_height_(0)
     , flagName(true)
     , flagFormula(true)
     , flagError(true)
@@ -229,6 +228,7 @@ void DialogTool::showEvent(QShowEvent *event)
     }
     // do your init stuff here
 
+    initial_dialog_height_ = height();
     setMaximumSize(size());
     setMinimumSize(size());
 
@@ -1005,10 +1005,10 @@ void DialogTool::DeployFormula(QPlainTextEdit *formula, QPushButton *buttonGrowL
     SCASSERT(buttonGrowLength != nullptr)
 
     const QTextCursor cursor = formula->textCursor();
+    const bool expanded = formula->height() < DIALOG_MAX_FORMULA_HEIGHT;
 
-    if (formula->height() < DIALOG_MAX_FORMULA_HEIGHT)
+    if (expanded)
     {
-        setMaximumWidth(QWIDGETSIZE_MAX);
         formula->setFixedHeight(DIALOG_MAX_FORMULA_HEIGHT);
         //Set icon from theme (internal for Windows system)
         buttonGrowLength->setIcon(QIcon::fromTheme("go-up",
@@ -1016,21 +1016,34 @@ void DialogTool::DeployFormula(QPlainTextEdit *formula, QPushButton *buttonGrowL
     }
     else
     {
-        setMaximumWidth(DIALOG_MIN_WIDTH);
         formula->setFixedHeight(formulaBaseHeight);
         //Set icon from theme (internal for Windows system)
         buttonGrowLength->setIcon(QIcon::fromTheme("go-down",
                                                    QIcon(":/icons/win.icon.theme/16x16/actions/go-down.png")));
     }
 
-    // I found that after change size of formula field, it was filed for angle formula, field for formula became black.
-    // This code prevent this.
-    setUpdatesEnabled(false);
-    repaint();
-    setUpdatesEnabled(true);
+    formula->updateGeometry();
+    QTimer::singleShot(0, this, [this, expanded]() { UpdateFormulaLayout(expanded); });
 
     formula->setFocus();
     formula->setTextCursor(cursor);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void DialogTool::UpdateFormulaLayout(bool expanded)
+{
+    QLayout *dialogLayout = layout();
+    SCASSERT(dialogLayout != nullptr)
+
+    dialogLayout->invalidate();
+    dialogLayout->activate();
+
+    setMinimumHeight(0);
+    setMaximumHeight(QWIDGETSIZE_MAX);
+    resize(width(), expanded ? qMax(initial_dialog_height_, sizeHint().height()) : initial_dialog_height_);
+    setMinimumHeight(height());
+    setMaximumHeight(height());
+    update();
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogtool.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogtool.cpp
@@ -139,7 +139,7 @@ DialogTool:: DialogTool(const VContainer *data, const quint32 &toolId, QWidget *
     : QDialog(parent)
     , data(data)
     , isInitialized(false)
-    , initial_dialog_height_(0)
+    , initialDialogHeight(0)
     , flagName(true)
     , flagFormula(true)
     , flagError(true)
@@ -228,7 +228,7 @@ void DialogTool::showEvent(QShowEvent *event)
     }
     // do your init stuff here
 
-    initial_dialog_height_ = height();
+    initialDialogHeight = height();
     setMaximumSize(size());
     setMinimumSize(size());
 
@@ -1040,7 +1040,7 @@ void DialogTool::UpdateFormulaLayout(bool expanded)
 
     setMinimumHeight(0);
     setMaximumHeight(QWIDGETSIZE_MAX);
-    resize(width(), expanded ? qMax(initial_dialog_height_, sizeHint().height()) : initial_dialog_height_);
+    resize(width(), expanded ? qMax(initialDialogHeight, sizeHint().height()) : initialDialogHeight);
     setMinimumHeight(height());
     setMaximumHeight(height());
     update();

--- a/src/libs/vtools/dialogs/tools/dialogtool.h
+++ b/src/libs/vtools/dialogs/tools/dialogtool.h
@@ -180,7 +180,7 @@ protected:
     /** @brief isInitialized true if window is initialized */
     bool             isInitialized;
 
-    int              initial_dialog_height_;
+    int              initialDialogHeight;
 
     /** @brief flagName true if name is correct */
     bool             flagName;

--- a/src/libs/vtools/dialogs/tools/dialogtool.h
+++ b/src/libs/vtools/dialogs/tools/dialogtool.h
@@ -180,6 +180,8 @@ protected:
     /** @brief isInitialized true if window is initialized */
     bool             isInitialized;
 
+    int              initial_dialog_height_;
+
     /** @brief flagName true if name is correct */
     bool             flagName;
 
@@ -281,6 +283,7 @@ protected:
 
     bool             SetObject(const quint32 &id, QComboBox *box, const QString &toolTip);
     void             DeployFormula(QPlainTextEdit *formula, QPushButton *buttonGrowLength, int formulaBaseHeight);
+    void             UpdateFormulaLayout(bool expanded);
 
     template <typename T>
     void             initializeOkCancelApply(T *ui);


### PR DESCRIPTION
## Summary

Fixes an issue where expanding a formula editor in the Interactive Spline dialog could cause the editor to overlap adjacent controls.

The dialog is initially locked to its displayed size in `DialogTool::showEvent()`. When a formula editor expands from its normal height to the maximum formula height, the fixed dialog could not grow to accommodate the updated layout.

This change:

- Recalculates the dialog layout after a formula editor changes height.
- Temporarily releases the dialog height constraint and resizes the dialog to fit the expanded editor.
- Restores the exact initial dialog height when the editor is collapsed.
- Removes unnecessary repaint, focus, and window-width changes from `DialogSplinePath::collapseFormula()`.

## Root Cause

`DialogTool::showEvent()` sets both the minimum and maximum dialog size to the initial size. This prevents the dialog from growing after `DeployFormula()` increases a `QPlainTextEdit` height.

The previous implementation also forced repaint operations while changing widget geometry. Repainting does not guarantee that the layout has completed recalculation and can leave the UI in an inconsistent visual state.

## Testing

- Opened the Interactive Spline dialog.
- Expanded each formula editor using its arrow button.
- Verified that the dialog grows to fit the expanded editor.
- Collapsed each formula editor.
- Verified that the dialog returns to its original height and layout.