### PR TITLE
fix: ignore more warnings from QtWaylandClient

### DIFF
--- a/src/app/seamly2d/core/application_2d.cpp
+++ b/src/app/seamly2d/core/application_2d.cpp
@@ -96,8 +96,8 @@ inline void noisyFailureMsgHandler(QtMsgType type, const QMessageLogContext &con
     // Qt's Wayland plugin warns on every focus change when the compositor sends a text input leave
     // event for a surface it isn't tracking. The plugin carries on as normal after logging it, so
     // it is noise. Drop it instead of logging it and popping up a dialog on every interaction.
-    if ((type == QtWarningMsg) && msg.contains(QStringLiteral("zwp_text_input_v3_leave"))
-            && msg.contains(QStringLiteral("Got leave event for surface")))
+    if ((type == QtWarningMsg) && msg.contains(QStringLiteral("QWaylandTextInputv3"))
+            && msg.contains(QStringLiteral("surface 0x0")))
     {
         return;
     }

--- a/src/app/seamlyme/application_me.cpp
+++ b/src/app/seamlyme/application_me.cpp
@@ -98,8 +98,8 @@ inline void noisyFailureMsgHandler(QtMsgType type, const QMessageLogContext &con
     // Qt's Wayland plugin warns on every focus change when the compositor sends a text input leave
     // event for a surface it isn't tracking. The plugin carries on as normal after logging it, so
     // it is noise. Drop it instead of logging it and popping up a dialog on every interaction.
-    if ((type == QtWarningMsg) && msg.contains(QStringLiteral("zwp_text_input_v3_leave"))
-            && msg.contains(QStringLiteral("Got leave event for surface")))
+    if ((type == QtWarningMsg) && msg.contains(QStringLiteral("QWaylandTextInputv3"))
+            && msg.contains(QStringLiteral("surface 0x0")))
     {
         return;
     }


### PR DESCRIPTION
Follow up on 464bcec, as I was still seeing some warning. We now also filter out warnings like this one:

virtual void QtWaylandClient::QWaylandTextInputv3::disableSurface(wl_surface*)
Try to disable surface 0x0 with focusing surface 0x5a674e2a15e0

---

For reference, the warning fixed by the previous commit was:
virtual void
QtWaylandClient::QWaylandTextInputv3::zwp_text_input_v3_leave(wl_surface*)
Got leave event for surface 0x0 with focusing surface 0x5e1ecf07ad20