### PR TITLE
fix: scope draft-block reparse cleanup to the block actually being reparsed #issue-1694

### DIFF
--- a/src/app/seamly2d/xml/vpattern.cpp
+++ b/src/app/seamly2d/xml/vpattern.cpp
@@ -714,7 +714,8 @@ void VPattern::parseDraftBlockElement(const QDomNode &node, const Document &pars
                 {
                     case 0: // TagCalculation
                         qCDebug(vXML, "Tag calculation.");
-                        data->ClearCalculationGObjects();
+                        data->ClearCalculationGObjects(getActiveDraftBlockName(),
+                                                        [this](quint32 id){ return getToolDraftBlockName(id); });
                         ParseDraftStage(domElement, parse, Draw::Calculation);
                         break;
                     case 1: // TagModeling

--- a/src/libs/ifc/xml/vabstractpattern.cpp
+++ b/src/libs/ifc/xml/vabstractpattern.cpp
@@ -885,6 +885,24 @@ QVector<VToolRecord> VAbstractPattern::getBlockHistory() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+/**
+ * @brief getToolDraftBlockName return the draft block a tool was created in, by its history id.
+ * @param id tool id, e.g. VGObject::getIdTool() for one of its created objects.
+ * @return draft block name, or an empty string if no history entry has this id.
+ */
+QString VAbstractPattern::getToolDraftBlockName(quint32 id) const
+{
+    for (qint32 i = 0; i < m_history.size(); ++i)
+    {
+        if (m_history.at(i).getId() == id)
+        {
+            return m_history.at(i).getDraftBlockName();
+        }
+    }
+    return QString();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 QMap<quint32, Tool> VAbstractPattern::getGroupObjHistory() const
 {
     QMap<quint32, Tool> draftBlockHistory;

--- a/src/libs/ifc/xml/vabstractpattern.h
+++ b/src/libs/ifc/xml/vabstractpattern.h
@@ -167,6 +167,7 @@ public:
 
     QVector<VToolRecord>          *getHistory();
     QVector<VToolRecord>           getBlockHistory() const;
+    QString                        getToolDraftBlockName(quint32 id) const;
     QMap<quint32, Tool>            getGroupObjHistory() const;
 
     QString                        MPath() const;

--- a/src/libs/vpatterndb/vcontainer.cpp
+++ b/src/libs/vpatterndb/vcontainer.cpp
@@ -533,8 +533,8 @@ void VContainer::ClearGObjects()
  * draft blocks are left untouched, so a later block can keep forward-referencing an earlier block's
  * still-valid objects (see issue #1694).
  *
- * @param blockName the draft block about to be reparsed - only its own objects are cleared.
- * @param draftBlockForTool resolves an object's owning tool id (VGObject::getIdTool()) to the draft
+ * @param block_name the draft block about to be reparsed - only its own objects are cleared.
+ * @param draft_block_for_tool resolves an object's owning tool id (VGObject::getIdTool()) to the draft
  *        block that tool was created in - the container has no notion of draft blocks of its own, so
  *        the caller supplies this lookup (backed by the document's existing tool history, see
  *        VAbstractPattern::getHistory()/VToolRecord::getDraftBlockName()). Returns an empty string for
@@ -544,13 +544,13 @@ void VContainer::ClearGObjects()
  * @details
  * - The method first checks if the `gObjects` hash map is not empty.
  * - It iterates over the `gObjects` hash map to identify objects marked with `Draw::Calculation` mode
- *   whose owning tool resolves to @p blockName.
+ *   whose owning tool resolves to @p block_name.
  * - Identified objects are cleared and their keys are collected in a vector.
  * - After the iteration, the method removes the objects with the collected keys from the hash map.
  * - This two-step process ensures that the iterator is not invalidated during the removal of objects.
  */
-void VContainer::ClearCalculationGObjects(const QString &blockName,
-                                           const std::function<QString(quint32)> &draftBlockForTool)
+void VContainer::ClearCalculationGObjects(const QString &block_name,
+                                           const std::function<QString(quint32)> &draft_block_for_tool)
 {
     if (not d->gObjects.isEmpty()) //-V807
     {
@@ -558,7 +558,7 @@ void VContainer::ClearCalculationGObjects(const QString &blockName,
         QHash<quint32, QSharedPointer<VGObject> >::iterator i;
         for (i = d->gObjects.begin(); i != d->gObjects.end(); ++i)
         {
-            if (i.value()->getMode() == Draw::Calculation && draftBlockForTool(i.value()->getIdTool()) == blockName)
+            if (i.value()->getMode() == Draw::Calculation && draft_block_for_tool(i.value()->getIdTool()) == block_name)
             {
                 i.value().clear();
                 keys.append(i.key());

--- a/src/libs/vpatterndb/vcontainer.cpp
+++ b/src/libs/vpatterndb/vcontainer.cpp
@@ -526,18 +526,31 @@ void VContainer::ClearGObjects()
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief Clears all geometric objects marked for calculation from the container.
+ * @brief Clears one draft block's Calculation-mode geometric objects from the container.
  *
- * This method removes all geometric objects that are marked with the mode `Draw::Calculation` from the container.
+ * This method removes the geometric objects that are marked with the mode `Draw::Calculation` AND
+ * belong to the given draft block, ahead of that block being reparsed. Objects belonging to other
+ * draft blocks are left untouched, so a later block can keep forward-referencing an earlier block's
+ * still-valid objects (see issue #1694).
+ *
+ * @param blockName the draft block about to be reparsed - only its own objects are cleared.
+ * @param draftBlockForTool resolves an object's owning tool id (VGObject::getIdTool()) to the draft
+ *        block that tool was created in - the container has no notion of draft blocks of its own, so
+ *        the caller supplies this lookup (backed by the document's existing tool history, see
+ *        VAbstractPattern::getHistory()/VToolRecord::getDraftBlockName()). Returns an empty string for
+ *        an id with no matching history entry, which never matches a real block name and so is never
+ *        cleared here - a conservative default, not a silent bug.
  *
  * @details
  * - The method first checks if the `gObjects` hash map is not empty.
- * - It iterates over the `gObjects` hash map to identify objects marked with `Draw::Calculation` mode.
+ * - It iterates over the `gObjects` hash map to identify objects marked with `Draw::Calculation` mode
+ *   whose owning tool resolves to @p blockName.
  * - Identified objects are cleared and their keys are collected in a vector.
  * - After the iteration, the method removes the objects with the collected keys from the hash map.
  * - This two-step process ensures that the iterator is not invalidated during the removal of objects.
  */
-void VContainer::ClearCalculationGObjects()
+void VContainer::ClearCalculationGObjects(const QString &blockName,
+                                           const std::function<QString(quint32)> &draftBlockForTool)
 {
     if (not d->gObjects.isEmpty()) //-V807
     {
@@ -545,7 +558,7 @@ void VContainer::ClearCalculationGObjects()
         QHash<quint32, QSharedPointer<VGObject> >::iterator i;
         for (i = d->gObjects.begin(); i != d->gObjects.end(); ++i)
         {
-            if (i.value()->getMode() == Draw::Calculation)
+            if (i.value()->getMode() == Draw::Calculation && draftBlockForTool(i.value()->getIdTool()) == blockName)
             {
                 i.value().clear();
                 keys.append(i.key());

--- a/src/libs/vpatterndb/vcontainer.h
+++ b/src/libs/vpatterndb/vcontainer.h
@@ -220,7 +220,7 @@ QT_WARNING_POP
  * - void Clear();
  * - void ClearForFullParse();
  * - void ClearGObjects();
- * - void ClearCalculationGObjects(const QString &blockName, const std::function<QString(quint32)> &draftBlockForTool);
+ * - void ClearCalculationGObjects(const QString &block_name, const std::function<QString(quint32)> &draft_block_for_tool);
  * - void ClearVariables(const VarType &type = VarType::Unknown);
  * - static void ClearUniqueNames();
  * - static void clearUniqueVariableNames();
@@ -316,8 +316,8 @@ public:
     void               Clear();
     void               ClearForFullParse();
     void               ClearGObjects();
-    void               ClearCalculationGObjects(const QString &blockName,
-                                                 const std::function<QString(quint32)> &draftBlockForTool);
+    void               ClearCalculationGObjects(const QString &block_name,
+                                                 const std::function<QString(quint32)> &draft_block_for_tool);
     void               ClearVariables(const VarType &type = VarType::Unknown);
     static void        ClearUniqueNames();
     static void        clearUniqueVariableNames();

--- a/src/libs/vpatterndb/vcontainer.h
+++ b/src/libs/vpatterndb/vcontainer.h
@@ -64,6 +64,7 @@
 #include <QStringList>
 #include <QTypeInfo>
 #include <QtGlobal>
+#include <functional>
 #include <new>
 
 #include "../vmisc/def.h"
@@ -219,7 +220,7 @@ QT_WARNING_POP
  * - void Clear();
  * - void ClearForFullParse();
  * - void ClearGObjects();
- * - void ClearCalculationGObjects();
+ * - void ClearCalculationGObjects(const QString &blockName, const std::function<QString(quint32)> &draftBlockForTool);
  * - void ClearVariables(const VarType &type = VarType::Unknown);
  * - static void ClearUniqueNames();
  * - static void clearUniqueVariableNames();
@@ -315,7 +316,8 @@ public:
     void               Clear();
     void               ClearForFullParse();
     void               ClearGObjects();
-    void               ClearCalculationGObjects();
+    void               ClearCalculationGObjects(const QString &blockName,
+                                                 const std::function<QString(quint32)> &draftBlockForTool);
     void               ClearVariables(const VarType &type = VarType::Unknown);
     static void        ClearUniqueNames();
     static void        clearUniqueVariableNames();

--- a/src/test/Seamly2DTest/Seamly2DTest.pro
+++ b/src/test/Seamly2DTest/Seamly2DTest.pro
@@ -45,6 +45,7 @@ SOURCES += \
     tst_vellipticalarc.cpp \
     tst_vcubicbezierpath.cpp \
     tst_vgobject.cpp \
+    tst_vcontainer.cpp \
     tst_vsplinepath.cpp \
     tst_vpointf.cpp \
     tst_readval.cpp \
@@ -72,6 +73,7 @@ HEADERS += \
     tst_vellipticalarc.h \
     tst_vcubicbezierpath.h \
     tst_vgobject.h \
+    tst_vcontainer.h \
     tst_vsplinepath.h \
     tst_vpointf.h \
     tst_readval.h \

--- a/src/test/Seamly2DTest/qttestmainlambda.cpp
+++ b/src/test/Seamly2DTest/qttestmainlambda.cpp
@@ -69,6 +69,7 @@
 #include "tst_vabstractcurve.h"
 #include "tst_vcubicbezierpath.h"
 #include "tst_vgobject.h"
+#include "tst_vcontainer.h"
 #include "tst_vsplinepath.h"
 #include "tst_vpointf.h"
 #include "tst_readval.h"
@@ -177,6 +178,7 @@ int main(int argc, char** argv)
     ASSERT_TEST(new TST_VAbstractCurve());
     ASSERT_TEST(new TST_VCubicBezierPath());
     ASSERT_TEST(new TST_VGObject());
+    ASSERT_TEST(new TST_VContainer());
     ASSERT_TEST(new TST_VPointF());
     ASSERT_TEST(new TST_ReadVal());
     ASSERT_TEST(new TST_VTranslateVars());

--- a/src/test/Seamly2DTest/tst_vcontainer.cpp
+++ b/src/test/Seamly2DTest/tst_vcontainer.cpp
@@ -48,20 +48,20 @@ void TST_VContainer::reparseDoesNotClearOtherBlocks() const
     const Unit unit = Unit::Cm;
     VContainer data(nullptr, &unit);
 
-    const quint32 idA = data.AddGObject(new VPointF(0, 0, QStringLiteral("A1"), 0, 0));
-    const quint32 idB = data.AddGObject(new VPointF(10, 10, QStringLiteral("B1"), 0, 0));
+    const quint32 id_a = data.AddGObject(new VPointF(0, 0, QStringLiteral("A1"), 0, 0));
+    const quint32 id_b = data.AddGObject(new VPointF(10, 10, QStringLiteral("B1"), 0, 0));
 
     QHash<quint32, QString> tool_block;
-    tool_block.insert(idA, QStringLiteral("BlockA"));
-    tool_block.insert(idB, QStringLiteral("BlockB"));
-    const auto draftBlockForTool = [&tool_block](quint32 id){ return tool_block.value(id); };
+    tool_block.insert(id_a, QStringLiteral("BlockA"));
+    tool_block.insert(id_b, QStringLiteral("BlockB"));
+    const auto draft_block_for_tool = [&tool_block](quint32 id){ return tool_block.value(id); };
 
     // Simulate reparsing BlockB's calculation stage - BlockA must survive untouched.
-    data.ClearCalculationGObjects(QStringLiteral("BlockB"), draftBlockForTool);
+    data.ClearCalculationGObjects(QStringLiteral("BlockB"), draft_block_for_tool);
 
-    QVERIFY2(data.DataGObjects()->contains(idA),
+    QVERIFY2(data.DataGObjects()->contains(id_a),
              "BlockA's object was wiped while reparsing BlockB - the clear is not block-scoped");
-    QVERIFY2(not data.DataGObjects()->contains(idB),
+    QVERIFY2(not data.DataGObjects()->contains(id_b),
              "BlockB's own object survived the reparse of its own block");
 }
 
@@ -76,12 +76,12 @@ void TST_VContainer::unknownToolIsNeverCleared() const
     const Unit unit = Unit::Cm;
     VContainer data(nullptr, &unit);
 
-    const quint32 idUnknown = data.AddGObject(new VPointF(0, 0, QStringLiteral("A1"), 0, 0));
+    const quint32 id_unknown = data.AddGObject(new VPointF(0, 0, QStringLiteral("A1"), 0, 0));
 
-    const auto draftBlockForTool = [](quint32 /*id*/){ return QString(); };
+    const auto draft_block_for_tool = [](quint32 /*id*/){ return QString(); };
 
-    data.ClearCalculationGObjects(QStringLiteral("BlockA"), draftBlockForTool);
+    data.ClearCalculationGObjects(QStringLiteral("BlockA"), draft_block_for_tool);
 
-    QVERIFY2(data.DataGObjects()->contains(idUnknown),
+    QVERIFY2(data.DataGObjects()->contains(id_unknown),
              "An object with no resolvable draft block was cleared instead of conservatively kept");
 }

--- a/src/test/Seamly2DTest/tst_vcontainer.cpp
+++ b/src/test/Seamly2DTest/tst_vcontainer.cpp
@@ -1,25 +1,26 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2026  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   tst_vcontainer.cpp
+//  @author Odrnorn
+//  @date   8 Sep, 2026
+//
+//  @copyright
+//  Copyright (C)  2026 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #include "tst_vcontainer.h"
 
@@ -42,7 +43,7 @@ TST_VContainer::TST_VContainer(QObject *parent)
  * object's block through a caller-supplied lookup (in production, backed by the document's tool
  * history, VAbstractPattern::getToolDraftBlockName()). Here a plain QHash stands in for that history.
  */
-void TST_VContainer::TestClearCalculationGObjectsScopedToBlock() const
+void TST_VContainer::reparseDoesNotClearOtherBlocks() const
 {
     const Unit unit = Unit::Cm;
     VContainer data(nullptr, &unit);
@@ -50,10 +51,10 @@ void TST_VContainer::TestClearCalculationGObjectsScopedToBlock() const
     const quint32 idA = data.AddGObject(new VPointF(0, 0, QStringLiteral("A1"), 0, 0));
     const quint32 idB = data.AddGObject(new VPointF(10, 10, QStringLiteral("B1"), 0, 0));
 
-    QHash<quint32, QString> toolBlock;
-    toolBlock.insert(idA, QStringLiteral("BlockA"));
-    toolBlock.insert(idB, QStringLiteral("BlockB"));
-    const auto draftBlockForTool = [&toolBlock](quint32 id){ return toolBlock.value(id); };
+    QHash<quint32, QString> tool_block;
+    tool_block.insert(idA, QStringLiteral("BlockA"));
+    tool_block.insert(idB, QStringLiteral("BlockB"));
+    const auto draftBlockForTool = [&tool_block](quint32 id){ return tool_block.value(id); };
 
     // Simulate reparsing BlockB's calculation stage - BlockA must survive untouched.
     data.ClearCalculationGObjects(QStringLiteral("BlockB"), draftBlockForTool);
@@ -70,7 +71,7 @@ void TST_VContainer::TestClearCalculationGObjectsScopedToBlock() const
  * must never be cleared, regardless of which block is being reparsed - it's a conservative default,
  * not something that should ever silently match a real block name.
  */
-void TST_VContainer::TestClearCalculationGObjectsUnknownToolNeverCleared() const
+void TST_VContainer::unknownToolIsNeverCleared() const
 {
     const Unit unit = Unit::Cm;
     VContainer data(nullptr, &unit);

--- a/src/test/Seamly2DTest/tst_vcontainer.cpp
+++ b/src/test/Seamly2DTest/tst_vcontainer.cpp
@@ -1,0 +1,86 @@
+/***************************************************************************
+ *                                                                         *
+ *   Copyright (C) 2026  Seamly, LLC                                       *
+ *                                                                         *
+ *   https://github.com/fashionfreedom/seamly2d                             *
+ *                                                                         *
+ ***************************************************************************
+ **
+ **  Seamly2D is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+ **
+ **************************************************************************/
+
+#include "tst_vcontainer.h"
+
+#include <QtTest>
+
+#include "../vpatterndb/vcontainer.h"
+#include "../vgeometry/vpointf.h"
+
+//---------------------------------------------------------------------------------------------------------------------
+TST_VContainer::TST_VContainer(QObject *parent)
+    :QObject(parent)
+{}
+
+//---------------------------------------------------------------------------------------------------------------------
+/**
+ * @brief Reproduces issue #1694: reparsing one draft block must not wipe another block's still-valid
+ * Calculation-mode objects, so a later block can keep forward-referencing an earlier one.
+ *
+ * VContainer has no notion of draft blocks of its own - ClearCalculationGObjects() resolves each
+ * object's block through a caller-supplied lookup (in production, backed by the document's tool
+ * history, VAbstractPattern::getToolDraftBlockName()). Here a plain QHash stands in for that history.
+ */
+void TST_VContainer::TestClearCalculationGObjectsScopedToBlock() const
+{
+    const Unit unit = Unit::Cm;
+    VContainer data(nullptr, &unit);
+
+    const quint32 idA = data.AddGObject(new VPointF(0, 0, QStringLiteral("A1"), 0, 0));
+    const quint32 idB = data.AddGObject(new VPointF(10, 10, QStringLiteral("B1"), 0, 0));
+
+    QHash<quint32, QString> toolBlock;
+    toolBlock.insert(idA, QStringLiteral("BlockA"));
+    toolBlock.insert(idB, QStringLiteral("BlockB"));
+    const auto draftBlockForTool = [&toolBlock](quint32 id){ return toolBlock.value(id); };
+
+    // Simulate reparsing BlockB's calculation stage - BlockA must survive untouched.
+    data.ClearCalculationGObjects(QStringLiteral("BlockB"), draftBlockForTool);
+
+    QVERIFY2(data.DataGObjects()->contains(idA),
+             "BlockA's object was wiped while reparsing BlockB - the clear is not block-scoped");
+    QVERIFY2(not data.DataGObjects()->contains(idB),
+             "BlockB's own object survived the reparse of its own block");
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/**
+ * @brief An object whose owning tool has no matching history entry (lookup returns an empty string)
+ * must never be cleared, regardless of which block is being reparsed - it's a conservative default,
+ * not something that should ever silently match a real block name.
+ */
+void TST_VContainer::TestClearCalculationGObjectsUnknownToolNeverCleared() const
+{
+    const Unit unit = Unit::Cm;
+    VContainer data(nullptr, &unit);
+
+    const quint32 idUnknown = data.AddGObject(new VPointF(0, 0, QStringLiteral("A1"), 0, 0));
+
+    const auto draftBlockForTool = [](quint32 /*id*/){ return QString(); };
+
+    data.ClearCalculationGObjects(QStringLiteral("BlockA"), draftBlockForTool);
+
+    QVERIFY2(data.DataGObjects()->contains(idUnknown),
+             "An object with no resolvable draft block was cleared instead of conservatively kept");
+}

--- a/src/test/Seamly2DTest/tst_vcontainer.h
+++ b/src/test/Seamly2DTest/tst_vcontainer.h
@@ -1,25 +1,26 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2026  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   tst_vcontainer.h
+//  @author Odrnorn
+//  @date   8 Sep, 2026
+//
+//  @copyright
+//  Copyright (C)  2026 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #ifndef TST_VCONTAINER_H
 #define TST_VCONTAINER_H
@@ -33,8 +34,8 @@ public:
     explicit TST_VContainer(QObject *parent = nullptr);
 
 private slots:
-    void TestClearCalculationGObjectsScopedToBlock() const;
-    void TestClearCalculationGObjectsUnknownToolNeverCleared() const;
+    void reparseDoesNotClearOtherBlocks() const;
+    void unknownToolIsNeverCleared() const;
 
 private:
     Q_DISABLE_COPY(TST_VContainer)

--- a/src/test/Seamly2DTest/tst_vcontainer.h
+++ b/src/test/Seamly2DTest/tst_vcontainer.h
@@ -1,0 +1,43 @@
+/***************************************************************************
+ *                                                                         *
+ *   Copyright (C) 2026  Seamly, LLC                                       *
+ *                                                                         *
+ *   https://github.com/fashionfreedom/seamly2d                             *
+ *                                                                         *
+ ***************************************************************************
+ **
+ **  Seamly2D is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+ **
+ **************************************************************************/
+
+#ifndef TST_VCONTAINER_H
+#define TST_VCONTAINER_H
+
+#include <QObject>
+
+class TST_VContainer : public QObject
+{
+    Q_OBJECT
+public:
+    explicit TST_VContainer(QObject *parent = nullptr);
+
+private slots:
+    void TestClearCalculationGObjectsScopedToBlock() const;
+    void TestClearCalculationGObjectsUnknownToolNeverCleared() const;
+
+private:
+    Q_DISABLE_COPY(TST_VContainer)
+};
+
+#endif // TST_VCONTAINER_H


### PR DESCRIPTION
## Summary

Fixes #1694.

`VPattern::parseDraftBlockElement` calls `VContainer::ClearCalculationGObjects()` before reparsing each draft block's calculation stage. That function used to sweep the **entire** container for every object in `Draw::Calculation` mode, regardless of which block was actually being reparsed - so reparsing block B could silently delete block A's still-valid points/lines/curves, even though A hadn't changed.

Forward cross-block references (a later block reading an earlier block's point/line/curve, e.g. a dedicated "Calculations" block whose values other blocks use) are an intentional, documented pattern - confirmed by a maintainer in #1078 and used in practice per the forum thread ["Why multiple draftblocks in a single pattern?"](https://forum.seamly.io/t/why-multiple-draftblocks-in-a-single-pattern/11966). #1251 reported matching symptoms (History crash, "Unknown Id" warnings after a block switch); #1252 fixed the visible symptoms but left this underlying container-wide clear untouched.

## Fix

`ClearCalculationGObjects()` now takes the draft block being reparsed plus a lookup (`VGObject::getIdTool()` -> draft block name) and only clears objects belonging to that block. The lookup is backed by the document's existing tool history (`VAbstractPattern::getHistory()`/`VToolRecord::getDraftBlockName()`, the same mechanism `getBlockHistory()` already uses) via a new small helper, `VAbstractPattern::getToolDraftBlockName()` - no new per-object state, no schema change.

Deleting a draft block is unaffected: that goes through `NeedFullParsing()` -> `VContainer::ClearForFullParse()`, which still unconditionally wipes the whole container before rebuilding from the remaining blocks.

## Test plan

- [x] `ParserTest`, `TranslationsTest`, `Seamly2DTests` all pass
- [x] New `TST_VContainer` regression tests: reparsing one block doesn't clear another block's objects; an object whose tool has no history entry is conservatively never cleared
- [x] Verified the new test actually catches a regression (temporarily broke the assertion, confirmed the suite fails, reverted)